### PR TITLE
Remove duplicate adrenotools submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "app/app/src/main/cpp/adrenotools"]
-	path = app/app/src/main/cpp/adrenotools
-	url = https://github.com/Pipetto-crypto/libadrenotools.git
 [submodule "app/src/main/cpp/adrenotools"]
 	path = app/src/main/cpp/adrenotools
 	url = https://github.com/Pipetto-crypto/libadrenotools.git


### PR DESCRIPTION
## Summary
- Removes a stale/duplicate `.gitmodules` entry at `app/app/src/main/cpp/adrenotools` (doubled `app/` prefix)
- The path didn't exist on disk — only the correct entry at `app/src/main/cpp/adrenotools` is used by the build

## Test plan
- [x] Debug build passes with no issues