### PR TITLE
Add per-game exec arguments to container config

### DIFF
--- a/app/src/main/java/com/winlator/cmod/ContainerDetailFragment.java
+++ b/app/src/main/java/com/winlator/cmod/ContainerDetailFragment.java
@@ -101,7 +101,8 @@ public class ContainerDetailFragment extends Fragment {
             "startupSelection", "box64Version", "box64Preset", "fexcoreVersion", "fexcorePreset",
             "desktopTheme", "midiSoundFont", "lc_all",
             "launchRealSteam", "useLegacyDRM", "useSteamInput",
-            "steamType", "forceDlc", "steamOfflineMode", "unpackFiles"
+            "steamType", "forceDlc", "steamOfflineMode", "unpackFiles",
+            "execArgs"
     };
 
     private ContainerManager manager;
@@ -586,6 +587,7 @@ public class ContainerDetailFragment extends Fragment {
         if (valuesDiffer(snapshot.get("desktopTheme"), targetContainer.getDesktopTheme())) return false;
         if (valuesDiffer(snapshot.get("midiSoundFont"), targetContainer.getMIDISoundFont())) return false;
         if (valuesDiffer(snapshot.get("lc_all"), targetContainer.getLC_ALL())) return false;
+        if (valuesDiffer(snapshot.get("execArgs"), targetContainer.getExecArgs())) return false;
         if ("STEAM".equals(gameSource)) {
             if (valuesDiffer(snapshot.get("useLegacyDRM"), targetContainer.isUseLegacyDRM())) return false;
             if (valuesDiffer(snapshot.get("launchRealSteam"), targetContainer.isLaunchRealSteam())) return false;
@@ -754,6 +756,8 @@ public class ContainerDetailFragment extends Fragment {
         snapshot.put("steamOfflineMode", cbSteamOfflineMode != null && cbSteamOfflineMode.isChecked() ? "1" : "0");
         CompoundButton cbUnpackFiles = view.findViewById(R.id.CBUnpackFiles);
         snapshot.put("unpackFiles", cbUnpackFiles != null && cbUnpackFiles.isChecked() ? "1" : "0");
+        EditText etExecArgs = view.findViewById(R.id.ETExecArgs);
+        snapshot.put("execArgs", etExecArgs != null ? etExecArgs.getText().toString() : "");
         return snapshot;
     }
 
@@ -1183,6 +1187,78 @@ public class ContainerDetailFragment extends Fragment {
                     : (settingsContainer != null ? settingsContainer.getCPUListWoW64(true) : Container.getFallbackCPUListWoW64()))
                 : (isEditMode() && container != null ? container.getCPUListWoW64(true) : Container.getFallbackCPUListWoW64()));
 
+        // Exec arguments
+        final EditText etExecArgs = view.findViewById(R.id.ETExecArgs);
+        etExecArgs.setText(isPerGameSettingsMode()
+                ? (isShortcutMode()
+                    ? getShortcutSettingValue("execArgs", settingsContainer != null ? settingsContainer.getExecArgs() : "")
+                    : (settingsContainer != null ? settingsContainer.getExecArgs() : ""))
+                : (isEditMode() && container != null ? container.getExecArgs() : ""));
+        etExecArgs.setOnEditorActionListener((v, actionId, event) -> {
+            etExecArgs.clearFocus();
+            android.view.inputmethod.InputMethodManager imm = (android.view.inputmethod.InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null) imm.hideSoftInputFromWindow(etExecArgs.getWindowToken(), 0);
+            return true;
+        });
+
+        // Dismiss keyboard and clear focus when tapping outside the EditText
+        View scrollView = view.findViewById(R.id.SVContainerDetail);
+        if (scrollView != null) {
+            scrollView.setOnTouchListener((v, event) -> {
+                if (event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+                    View focused = v.findFocus();
+                    if (focused instanceof EditText) {
+                        android.graphics.Rect outRect = new android.graphics.Rect();
+                        focused.getGlobalVisibleRect(outRect);
+                        if (!outRect.contains((int) event.getRawX(), (int) event.getRawY())) {
+                            focused.clearFocus();
+                            android.view.inputmethod.InputMethodManager imm = (android.view.inputmethod.InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                            if (imm != null) imm.hideSoftInputFromWindow(focused.getWindowToken(), 0);
+                        }
+                    }
+                }
+                return false;
+            });
+        }
+
+        final View btExtraArgsMenu = view.findViewById(R.id.BTExtraArgsMenu);
+        btExtraArgsMenu.setOnClickListener(v -> {
+            // Dismiss keyboard if open
+            etExecArgs.clearFocus();
+            android.view.inputmethod.InputMethodManager imm = (android.view.inputmethod.InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null) imm.hideSoftInputFromWindow(etExecArgs.getWindowToken(), 0);
+            Context themedContext = new android.view.ContextThemeWrapper(context, R.style.ThemeOverlay_ContentPopupMenu);
+            PopupMenu popupMenu = new PopupMenu(themedContext, v);
+            popupMenu.getMenuInflater().inflate(R.menu.extra_args_popup_menu, popupMenu.getMenu());
+
+            // Bold the section header items
+            Menu menu = popupMenu.getMenu();
+            for (int i = 0; i < menu.size(); i++) {
+                android.view.MenuItem mi = menu.getItem(i);
+                String title = mi.getTitle().toString();
+                if (title.startsWith("──")) {
+                    android.text.SpannableString styled = new android.text.SpannableString(title);
+                    styled.setSpan(new android.text.style.StyleSpan(android.graphics.Typeface.BOLD), 0, title.length(), 0);
+                    styled.setSpan(new android.text.style.ForegroundColorSpan(0xFFFFFFFF), 0, title.length(), 0);
+                    mi.setTitle(styled);
+                }
+            }
+
+            popupMenu.setOnMenuItemClickListener(item -> {
+                String value = item.getTitle().toString();
+                if (value.startsWith("──")) return false;
+                String current = etExecArgs.getText().toString();
+                if (!current.contains(value)) {
+                    String newText = !current.isEmpty() ? current + " " + value : value;
+                    etExecArgs.setText(newText);
+                    etExecArgs.setSelection(newText.length());
+                }
+                item.setChecked(!item.isChecked());
+                return false;
+            });
+            popupMenu.show();
+        });
+
         createWineConfigurationTab(view);
         final EnvVarsView envVarsView = createEnvVarsTab(view);
         createWinComponentsTab(view, isPerGameSettingsMode()
@@ -1314,6 +1390,7 @@ public class ContainerDetailFragment extends Fragment {
                 boolean forceDlc = cbForceDlc.isChecked();
                 boolean steamOfflineMode = cbSteamOfflineMode.isChecked();
                 boolean unpackFiles = cbUnpackFiles.isChecked();
+                String execArgs = etExecArgs.getText().toString();
 
                 // Define final input type
                 int finalInputType = 0;
@@ -1437,6 +1514,7 @@ public class ContainerDetailFragment extends Fragment {
                             shortcut.putExtra("steamOfflineMode", null);
                             shortcut.putExtra("unpackFiles", null);
                         }
+                        shortcut.putExtra("execArgs", !execArgs.isEmpty() ? execArgs : null);
                         shortcut.putExtra(EXTRA_USE_CONTAINER_DEFAULTS, "0");
                     }
                     
@@ -1498,6 +1576,7 @@ public class ContainerDetailFragment extends Fragment {
                     container.setForceDlc(forceDlc);
                     container.setSteamOfflineMode(steamOfflineMode);
                     container.setUnpackFiles(unpackFiles);
+                    container.setExecArgs(execArgs);
                     Log.d(TAG, "Persist container.saveData containerId=" + container.id +
                             " finalDxwrapperConfig='" + container.getDXWrapperConfig() + "'");
                     container.saveData();
@@ -1531,6 +1610,7 @@ public class ContainerDetailFragment extends Fragment {
                     data.put("fexcoreVersion", fexcoreVersion);
                     data.put("fexcorePreset", fexcorePreset);
                     data.put("desktopTheme", desktopTheme);
+                    if (!execArgs.isEmpty()) data.put("execArgs", execArgs);
                     if ("STEAM".equals(createShortcutForSource)) {
                         data.put("useLegacyDRM", useLegacyDRM ? "1" : "0");
                         data.put("launchRealSteam", launchRealSteam ? "1" : "0");
@@ -2510,6 +2590,9 @@ public class ContainerDetailFragment extends Fragment {
         CPUListView cpuListViewWoW64 = view.findViewById(R.id.CPUListViewWoW64);
         if (cpuListViewWoW64 != null) cpuListViewWoW64.setCheckedCPUList(c.getCPUListWoW64(true));
 
+        EditText etExecArgs = view.findViewById(R.id.ETExecArgs);
+        if (etExecArgs != null) etExecArgs.setText(c.getExecArgs());
+
         applyInputTypeToUi(view, c.getInputType(), false);
         EnvVarsView envVarsView = view.findViewById(R.id.EnvVarsView);
         if (envVarsView != null) {
@@ -2812,6 +2895,12 @@ public class ContainerDetailFragment extends Fragment {
         markIfChanged(findLabelForView(contentView.findViewById(R.id.CPUListViewWoW64), llContent),
                 ((CPUListView) contentView.findViewById(R.id.CPUListViewWoW64)).getCheckedCPUListAsString(),
                 comparisonContainer.getCPUListWoW64(true));
+        EditText etExecArgsIndicator = contentView.findViewById(R.id.ETExecArgs);
+        if (etExecArgsIndicator != null) {
+            markIfChanged(findLabelForView(etExecArgsIndicator, llContent),
+                    etExecArgsIndicator.getText().toString(),
+                    comparisonContainer.getExecArgs());
+        }
         markIfChanged(findLabelForView(contentView.findViewById(R.id.SDesktopTheme), llContent),
                 getDesktopTheme(contentView),
                 comparisonContainer.getDesktopTheme());

--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -2886,6 +2886,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
             if (gameSource.equals("STEAM")) {
                 int appId = Integer.parseInt(shortcut.getExtra("app_id"));
+                String steamExtraArgs = shortcut.getSettingExtra("execArgs", container.getExecArgs());
+                steamExtraArgs = (steamExtraArgs != null && !steamExtraArgs.isEmpty()) ? " " + steamExtraArgs : "";
 
                 if (!container.isUseLegacyDRM()) {
                     // ColdClient mode: ALWAYS launch through steamclient_loader_x64.exe
@@ -2902,27 +2904,30 @@ public class XServerDisplayActivity extends AppCompatActivity {
                             String dir = gameExeWinPath.substring(0, lastBackslash);
                             if (dir.endsWith(":")) dir += "\\";
                             String file = gameExeWinPath.substring(lastBackslash + 1);
-                            
+
                             File nativeDir = com.winlator.cmod.core.WineUtils.getNativePath(imageFs, dir);
                             if (nativeDir != null && nativeDir.exists()) {
                                 launcherComponent.setWorkingDir(nativeDir);
                                 Log.d("XServerDisplayActivity", "Set native working dir for Steam process: " + nativeDir.getPath());
                             }
-                            
+
                             if (wineInfo != null && wineInfo.isArm64EC()) {
-                                args = "\"" + gameExeWinPath + "\"";
+                                args = "\"" + gameExeWinPath + "\"" + steamExtraArgs;
                             } else {
-                                args = "/dir " + StringUtils.escapeDOSPath(dir) + " \"" + file + "\"";
+                                args = "/dir " + StringUtils.escapeDOSPath(dir) + " \"" + file + "\"" + steamExtraArgs;
                             }
                         } else {
-                            args = "\"" + gameExeWinPath + "\"";
+                            args = "\"" + gameExeWinPath + "\"" + steamExtraArgs;
                         }
                     } else {
                         args = "\"wfm.exe\"";
                     }
                 }
             } else if (gameSource.equals("EPIC") || gameSource.equals("GOG")) {
-                String extraArgs = getIntent().getStringExtra("extra_exec_args");
+                String extraArgs = shortcut.getSettingExtra("execArgs", container.getExecArgs());
+                if (extraArgs == null || extraArgs.isEmpty()) {
+                    extraArgs = getIntent().getStringExtra("extra_exec_args");
+                }
                 extraArgs = (extraArgs != null && !extraArgs.isEmpty()) ? " " + extraArgs : "";
 
                 boolean needsAutoDetect = path == null || path.isEmpty() || "A:\\".equals(path) || "A:\\\\".equals(path);
@@ -3000,7 +3005,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 Log.d("XServerDisplayActivity", gameSource + " game launch: " + args);
             } else {
                 // Custom shortcut
-                String extraArgs = shortcut.getExtra("execArgs");
+                String extraArgs = shortcut.getSettingExtra("execArgs", container.getExecArgs());
                 extraArgs = (extraArgs != null && !extraArgs.isEmpty()) ? " " + extraArgs : "";
 
                 if (path != null && (path.startsWith("explorer") || path.contains(" /desktop"))) {
@@ -3208,7 +3213,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
             exePath = "";
         }
 
-        String exeCommandLine = container.getExecArgs() != null ? container.getExecArgs() : "";
+        String perGameExecArgs = shortcut != null ? shortcut.getSettingExtra("execArgs", container.getExecArgs()) : container.getExecArgs();
+        String exeCommandLine = perGameExecArgs != null ? perGameExecArgs : "";
 
         String injectionSection = container.isUnpackFiles()
                 ? "[Injection]\nIgnoreLoaderArchDifference=1\nDllsToInjectFolder=extra_dlls\n"

--- a/app/src/main/res/drawable/ic_terminal.xml
+++ b/app/src/main/res/drawable/ic_terminal.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material 3 terminal/code prompt icon -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- > chevron -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M5,8 L10,13 L5,18"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <!-- _ underscore -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M13,18 L19,18"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+</vector>

--- a/app/src/main/res/layout/container_detail_fragment.xml
+++ b/app/src/main/res/layout/container_detail_fragment.xml
@@ -1443,7 +1443,48 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:visibility="gone">
+                android:visibility="gone"
+                android:focusable="true"
+                android:focusableInTouchMode="true">
+
+            <!-- Exec Arguments -->
+            <TextView
+                style="@style/OtherSettingsSectionLabel"
+                android:text="@string/shortcuts_properties_exec_arguments" />
+
+            <LinearLayout
+                style="@style/OtherSettingsCard"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="6dp">
+
+                    <EditText
+                        android:id="@+id/ETExecArgs"
+                        style="@style/OtherSettingsEditText"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:hint="@string/shortcuts_properties_exec_arguments"
+                        android:inputType="text"
+                        android:imeOptions="actionDone|flagNoExtractUi|flagNoFullscreen"
+                        android:singleLine="true" />
+
+                    <ImageButton
+                        android:id="@+id/BTExtraArgsMenu"
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:layout_marginStart="8dp"
+                        android:background="@drawable/content_icon_surface"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_terminal"
+                        android:contentDescription="@string/common_ui_options" />
+                </LinearLayout>
+            </LinearLayout>
 
             <TextView
                 style="@style/OtherSettingsSectionLabel"

--- a/app/src/main/res/menu/extra_args_popup_menu.xml
+++ b/app/src/main/res/menu/extra_args_popup_menu.xml
@@ -1,14 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:title="-force-gfx-direct" />
-    <item android:title="-force-d3d11-singlethreaded" />
-    <item android:title="-force-dx9" />
+    <!-- Unity Engine -->
+    <item android:title="── Unity ──" android:enabled="false" />
     <item android:title="-force-d3d9" />
     <item android:title="-force-d3d11" />
-    <item android:title="--force-gfx-direct" />
-    <item android:title="--force-d3d11-singlethreaded" />
-    <item android:title="--force-dx9" />
-    <item android:title="--force-d3d9" />
-    <item android:title="--force-d3d11" />
+    <item android:title="-force-d3d12" />
+    <item android:title="-force-vulkan" />
+    <item android:title="-force-glcore" />
+    <item android:title="-force-gfx-direct" />
+    <item android:title="-force-d3d11-singlethreaded" />
+    <item android:title="-screen-fullscreen 0" />
+    <item android:title="-screen-fullscreen 1" />
+    <item android:title="-popupwindow" />
+    <item android:title="-nolog" />
+
+    <!-- Unreal Engine -->
+    <item android:title="── Unreal ──" android:enabled="false" />
+    <item android:title="-WINDOWED" />
+    <item android:title="-FULLSCREEN" />
+    <item android:title="-dx11" />
+    <item android:title="-dx12" />
+    <item android:title="-vulkan" />
+    <item android:title="-NOSPLASH" />
+    <item android:title="-NOSOUND" />
+
+    <!-- Source Engine -->
+    <item android:title="── Source ──" android:enabled="false" />
+    <item android:title="-sw" />
+    <item android:title="-novid" />
+    <item android:title="-nojoy" />
+    <item android:title="-console" />
+    <item android:title="-nosound" />
+
+    <!-- General -->
+    <item android:title="── General ──" android:enabled="false" />
+    <item android:title="-windowed" />
+    <item android:title="-fullscreen" />
+    <item android:title="-nointro" />
+    <item android:title="-skipvideos" />
+    <item android:title="-novsync" />
     <item android:title="/d3d9" />
 </menu>


### PR DESCRIPTION
- Add exec args input field with terminal icon button under the Config section in per-game settings
- Per-game exec args override container defaults via the existing shortcut settings system
- Wire exec args into all launch paths: Steam (ColdClient + legacy DRM), Epic/GOG, and Custom games
- Expand popup menu with engine-specific presets organized by Unity, Unreal, Source, and General categories
- Bold section headers in popup menu, menu stays open for multi-select
- Keyboard dismisses on tap-outside, Done key, or when opening the popup menu
- Add ic_terminal drawable for the popup button