### PR TITLE
Fix container launch without opening container first

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -503,6 +503,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
         imageFs = ImageFs.find(this);
         GuestProgramLauncherComponent.ensureImageFsNativeLibrary(this, imageFs, "libfakeinput.so");
+        GuestProgramLauncherComponent.ensureImageFsNativeLibrary(this, imageFs, "libandroid-sysvshm.so");
         File devInputDir = new File(imageFs.getRootDir(), "dev/input");
         if (devInputDir.exists() || devInputDir.mkdirs()) {
             for (int i = 0; i < 4; i++) {
@@ -1589,6 +1590,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
     private void setupWineSystemFiles() {
         ensureWinePrefixReady();
+        ensureWinePrefixEssentialFiles();
 
         String appVersion = String.valueOf(AppUtils.getVersionCode(this));
         String imgVersion = String.valueOf(imageFs.getVersion());
@@ -1617,16 +1619,16 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     preNormalizedDxwrapperConfig + "' after='" + dxwrapperConfig + "' wrapper='" + dxwrapper + "'");
         }
 
-        if (!dxwrapper.equals(container.getExtra("dxwrapper"))) {
-            extractDXWrapperFiles(dxwrapper);
-            container.putExtra("dxwrapper", dxwrapper);
-            containerDataChanged = true;
-        }
-
         String wincomponents = shortcut != null ? getShortcutSetting("wincomponents", container.getWinComponents()) : container.getWinComponents();
         if (!wincomponents.equals(container.getExtra("wincomponents")) || firstTimeBoot) {
             extractWinComponentFiles();
             container.putExtra("wincomponents", wincomponents);
+            containerDataChanged = true;
+        }
+
+        if (!dxwrapper.equals(container.getExtra("dxwrapper")) || firstTimeBoot) {
+            extractDXWrapperFiles(dxwrapper);
+            container.putExtra("dxwrapper", dxwrapper);
             containerDataChanged = true;
         }
 
@@ -2291,6 +2293,58 @@ public class XServerDisplayActivity extends AppCompatActivity {
             Log.i("XServerDisplayActivity", "Wine prefix repaired successfully for container " + container.id);
         } else {
             Log.e("XServerDisplayActivity", "Wine prefix repair failed for container " + container.id);
+        }
+    }
+
+    private void ensureWinePrefixEssentialFiles() {
+        if (container == null) return;
+        File containerWindowsDir = new File(container.getRootDir(), ".wine/drive_c/windows");
+        String[] essentialFiles = {"winhandler.exe", "wfm.exe"};
+
+        boolean anyMissing = false;
+        for (String filename : essentialFiles) {
+            if (!new File(containerWindowsDir, filename).exists()) {
+                anyMissing = true;
+                break;
+            }
+        }
+
+        if (anyMissing) {
+            // Try to find the files from another container that has them
+            File homeDir = new File(imageFs.getRootDir(), "home");
+            File[] homeDirs = homeDir.listFiles();
+            File sourceWindowsDir = null;
+            if (homeDirs != null) {
+                for (File dir : homeDirs) {
+                    if (!dir.isDirectory() || FileUtils.isSymlink(dir)) continue;
+                    File candidate = new File(dir, ".wine/drive_c/windows");
+                    if (new File(candidate, "winhandler.exe").exists()) {
+                        sourceWindowsDir = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (sourceWindowsDir != null) {
+                for (String filename : essentialFiles) {
+                    File dest = new File(containerWindowsDir, filename);
+                    if (!dest.exists()) {
+                        File source = new File(sourceWindowsDir, filename);
+                        if (source.exists()) {
+                            Log.d("XServerDisplayActivity", "Copying missing " + filename + " from " + sourceWindowsDir.getParent() + " to container");
+                            FileUtils.copy(source, dest);
+                        }
+                    }
+                }
+            } else {
+                // No source found — re-extract from imagefs to get the files
+                Log.w("XServerDisplayActivity", "Essential wine prefix files missing and no source container found, re-extracting container pattern");
+                TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this,
+                        "container_pattern.tzst", container.getRootDir(), onExtractFileListener);
+                for (String filename : essentialFiles) {
+                    Log.d("XServerDisplayActivity", filename + " exists after re-extraction: " + new File(containerWindowsDir, filename).exists());
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/winlator/cmod/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/cmod/container/ContainerManager.java
@@ -93,10 +93,36 @@ public class ContainerManager {
 
 
     public void activateContainer(Container container) {
-        container.setRootDir(new File(homeDir, ImageFs.USER+"-"+container.id));
+        File containerDir = new File(homeDir, ImageFs.USER+"-"+container.id);
+        container.setRootDir(containerDir);
         File file = new File(homeDir, ImageFs.USER);
-        file.delete();
+        // Replace the real "xuser" dir (from imagefs.txz) with a symlink to the active
+        // container. Migrate winhandler.exe/wfm.exe first since they aren't in container
+        // pattern archives. Only runs once — after that xuser is already a symlink.
+        if (file.exists() && !FileUtils.isSymlink(file)) {
+            Log.w("ContainerManager", "activateContainer: migrating essential files from " + file.getPath() + " to container " + container.id);
+            migrateEssentialFiles(file, containerDir);
+            FileUtils.delete(file);
+        } else {
+            file.delete();
+        }
         FileUtils.symlink("./"+ImageFs.USER+"-"+container.id, file.getPath());
+    }
+
+    private void migrateEssentialFiles(File sourceDir, File destDir) {
+        String[] essentialPaths = {
+            ".wine/drive_c/windows/winhandler.exe",
+            ".wine/drive_c/windows/wfm.exe"
+        };
+        for (String path : essentialPaths) {
+            File source = new File(sourceDir, path);
+            File dest = new File(destDir, path);
+            if (source.exists() && !dest.exists()) {
+                dest.getParentFile().mkdirs();
+                FileUtils.copy(source, dest);
+                Log.d("ContainerManager", "Migrated " + path + " to container");
+            }
+        }
     }
 
     public void createContainerAsync(final JSONObject data, ContentsManager contentsManager, Callback<Container> callback) {

--- a/app/src/main/java/com/winlator/cmod/steam/service/SteamAutoCloud.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/service/SteamAutoCloud.kt
@@ -629,15 +629,8 @@ object SteamAutoCloud {
             val localAppChangeNumber = overrideLocalChangeNumber ?: steamInstance.changeNumbersDao.getByAppId(appInfo.id)?.changeNumber ?: -1
 
             val changeNumber = if (localAppChangeNumber >= 0) localAppChangeNumber else 0
-            val appFileListChange = steamCloud.getAppFileListChange(appInfo.id, changeNumber).await()
 
-            val cloudAppChangeNumber = appFileListChange.currentChangeNumber
-
-            Timber.i("AppChangeNumber: $localAppChangeNumber -> $cloudAppChangeNumber")
-
-            appFileListChange.printFileChangeList(appInfo)
-
-            // retrieve existing user files from local storage
+            // retrieve existing user files from local storage first so we can detect missing saves
             val localUserFilesMap: Map<String, List<UserFileInfo>>
             val allLocalUserFiles: List<UserFileInfo>
 
@@ -645,6 +638,23 @@ object SteamAutoCloud {
                 localUserFilesMap = getLocalUserFilesAsPrefixMap()
                 allLocalUserFiles = localUserFilesMap.map { it.value }.flatten()
             }.inWholeMicroseconds
+
+            // If local saves are missing but we have a stored change number, request full file list
+            // (change number 0) instead of a delta, so the cloud returns all files for download
+            val effectiveChangeNumber = if (allLocalUserFiles.isEmpty() && changeNumber > 0) {
+                Timber.w("No local saves found but stored changeNumber=$changeNumber; requesting full file list from cloud")
+                0
+            } else {
+                changeNumber
+            }
+
+            val appFileListChange = steamCloud.getAppFileListChange(appInfo.id, effectiveChangeNumber).await()
+
+            val cloudAppChangeNumber = appFileListChange.currentChangeNumber
+
+            Timber.i("AppChangeNumber: $localAppChangeNumber -> $cloudAppChangeNumber (requested with changeNumber=$effectiveChangeNumber)")
+
+            appFileListChange.printFileChangeList(appInfo)
 
             val downloadUserFiles: (CoroutineScope) -> Deferred<PostSyncInfo?> = { parentScope ->
                 parentScope.async {

--- a/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
@@ -67,12 +67,15 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         File sourceFile = new File(nativeLibDir, libraryName);
 
         if (sourceFile.exists() && (!destFile.exists() || destFile.length() != sourceFile.length())) {
+            Log.d("GuestLauncher", "Copying " + libraryName + " from nativeLibDir to imagefs (dest exists=" + destFile.exists() + ")");
             try {
                 FileUtils.copy(sourceFile, destFile);
+                Log.d("GuestLauncher", "Successfully copied " + libraryName + " to " + destFile.getAbsolutePath());
             } catch (Exception e) {
                 Log.e("GuestLauncher", "Failed to copy " + libraryName, e);
             }
         } else if (!destFile.exists()) {
+            Log.d("GuestLauncher", "Extracting " + libraryName + " from APK (not found in nativeLibDir or imagefs)");
             try (java.util.zip.ZipFile apk = new java.util.zip.ZipFile(context.getApplicationInfo().sourceDir)) {
                 String abi = android.os.Build.SUPPORTED_ABIS[0];
                 String entryName = "lib/" + abi + "/" + libraryName;
@@ -87,13 +90,22 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
                         }
                     }
                     destFile.setExecutable(true, false);
+                    Log.d("GuestLauncher", "Successfully extracted " + libraryName + " from APK to " + destFile.getAbsolutePath());
+                } else {
+                    Log.w("GuestLauncher", libraryName + " not found in APK at " + entryName);
                 }
             } catch (Exception e) {
                 Log.e("GuestLauncher", "Failed to extract " + libraryName, e);
             }
+        } else {
+            Log.d("GuestLauncher", libraryName + " already exists at " + destFile.getAbsolutePath() + " (size=" + destFile.length() + ")");
         }
 
-        return destFile.exists() ? destFile : null;
+        boolean result = destFile.exists();
+        if (!result) {
+            Log.e("GuestLauncher", libraryName + " is NOT available after ensure - this will cause issues!");
+        }
+        return result ? destFile : null;
     }
 
     public void setWorkingDir(File workingDir) {
@@ -157,16 +169,18 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         envVars.put("FONTCONFIG_PATH", imageFs.getRootDir().getPath() + "/usr/etc/fonts");
 
         File libDir = imageFs.getLibDir();
-        File sysvshm64 = new File(libDir, "libandroid-sysvshm.so");
+        File sysvshm64 = ensureImageFsNativeLibrary(context, imageFs, "libandroid-sysvshm.so");
         File libredirect64 = new File(libDir, "libredirect.so");
-        if (sysvshm64.exists() || libredirect64.exists()) {
+        Log.d("GuestLauncher", "execShellCommand LD_PRELOAD setup: sysvshm=" + (sysvshm64 != null) + " libredirect=" + libredirect64.exists());
+        if ((sysvshm64 != null && sysvshm64.exists()) || libredirect64.exists()) {
             StringBuilder ldPreload = new StringBuilder();
             if (libredirect64.exists()) ldPreload.append(libredirect64.getPath());
-            if (sysvshm64.exists()) {
+            if (sysvshm64 != null && sysvshm64.exists()) {
                 if (ldPreload.length() > 0) ldPreload.append(" ");
                 ldPreload.append(sysvshm64.getPath());
             }
             envVars.put("LD_PRELOAD", ldPreload.toString());
+            Log.d("GuestLauncher", "execShellCommand LD_PRELOAD=" + ldPreload.toString());
         }
         envVars.put("WINEESYNC_WINLATOR", "1");
         mergeExternalEnvVars(envVars, envVars.get("LD_PRELOAD"), envVars.get("FAKE_EVDEV_DIR"));
@@ -590,10 +604,13 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         envVars.put("WINE_NEW_NDIS", "1");
         
         String ld_preload = "";
-        
-        // Check for specific shared memory libraries
-        if ((new File(imageFs.getLibDir(), "libandroid-sysvshm.so")).exists()){
-            ld_preload = imageFs.getLibDir() + "/libandroid-sysvshm.so";
+
+        // Ensure shared memory library is extracted and available
+        File sysvshmDest = ensureImageFsNativeLibrary(context, imageFs, "libandroid-sysvshm.so");
+        if (sysvshmDest != null && sysvshmDest.exists()){
+            ld_preload = sysvshmDest.getAbsolutePath();
+        } else {
+            Log.w("GuestProgramLauncher", "libandroid-sysvshm.so not available for LD_PRELOAD - shared memory may fail!");
         }
 
         File fakeinputDest = ensureImageFsNativeLibrary(context, imageFs, "libfakeinput.so");
@@ -603,7 +620,10 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
                 ld_preload += ":";
             }
             ld_preload += fakeinputDest.getAbsolutePath();
+        } else {
+            Log.w("GuestProgramLauncher", "libfakeinput.so not available for LD_PRELOAD");
         }
+        Log.d("GuestProgramLauncher", "execGuestProgram LD_PRELOAD=" + ld_preload);
 
         File devInputDir = new File(imageFs.getRootDir(), "dev/input");
         devInputDir.mkdirs();


### PR DESCRIPTION
- Fix `activateContainer()` to properly replace the real `xuser` directory with a symlink to the active container, migrating `winhandler.exe`/`wfm.exe` first since they aren't in container pattern archives
- Ensure `libandroid-sysvshm.so` is extracted from APK via `ensureImageFsNativeLibrary()` instead of only checking existence
- Reorder DLL extraction so WinComponents extract before DXVK, preventing Wine built-in d3d DLLs from overwriting DXVK on first boot
- Add `ensureWinePrefixEssentialFiles()` fallback for missing `winhandler.exe`/`wfm.exe`
- Fix Steam cloud save recovery when local files are missing but stored change number matches cloud (request full file list instead of empty delta)