### PR TITLE
Revert problematic C: drive permission and dosdevices changes

### DIFF
--- a/app/src/main/java/com/winlator/cmod/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/cmod/container/ContainerManager.java
@@ -96,11 +96,6 @@ public class ContainerManager {
         File containerDir = new File(homeDir, ImageFs.USER+"-"+container.id);
         container.setRootDir(containerDir);
         File file = new File(homeDir, ImageFs.USER);
-        
-        // Make C: Drive read and writable for all users (for game modding, etc.)
-        try {
-            Runtime.getRuntime().exec(new String[]{"chmod", "-R", "0777", new File(containerDir, ".wine/drive_c").getAbsolutePath()});
-        } catch (Exception e) {}
 
         // Replace the real "xuser" dir (from imagefs.txz) with a symlink to the active
         // container. Migrate winhandler.exe/wfm.exe first since they aren't in container

--- a/app/src/main/java/com/winlator/cmod/core/TarCompressorUtils.java
+++ b/app/src/main/java/com/winlator/cmod/core/TarCompressorUtils.java
@@ -183,7 +183,7 @@ public abstract class TarCompressorUtils {
                     }
                 }
 
-                FileUtils.chmod(file, 0777);
+                FileUtils.chmod(file, 0771);
             }
             return true;
         }
@@ -283,7 +283,7 @@ public abstract class TarCompressorUtils {
                     }
                 }
 
-                FileUtils.chmod(file, 0777);
+                FileUtils.chmod(file, 0771);
             }
             return true;
         } catch (IOException e) {

--- a/app/src/main/java/com/winlator/cmod/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/cmod/core/WineUtils.java
@@ -18,12 +18,8 @@ import java.util.Locale;
 
 public abstract class WineUtils {
     public static void createDosdevicesSymlinks(Container container) {
-        File dosdevicesDir = new File(container.getRootDir(), ".wine/dosdevices");
-        if (!dosdevicesDir.exists()) {
-            dosdevicesDir.mkdirs();
-        }
-        String dosdevicesPath = dosdevicesDir.getPath();
-        File[] files = dosdevicesDir.listFiles();
+        String dosdevicesPath = (new File(container.getRootDir(), ".wine/dosdevices")).getPath();
+        File[] files = (new File(dosdevicesPath)).listFiles();
         if (files != null) for (File file : files) if (file.getName().matches("[a-z]:")) file.delete();
 
         FileUtils.symlink("../drive_c", dosdevicesPath+"/c:");


### PR DESCRIPTION
Reverts issue that causes arm64ec containers to not display the C: Drive in WFM