### PR TITLE
fix: Shortcut env vars now replace container env vars instead of merging

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -2306,9 +2306,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
             guestProgramLauncherComponent.setGuestExecutable(guestExecutable);
 
-            envVars.putAll(container.getEnvVars());
-
-            if (shortcut != null) envVars.putAll(getShortcutSetting("envVars", container.getEnvVars()));
+            envVars.putAll(shortcut != null ? getShortcutSetting("envVars", container.getEnvVars()) : container.getEnvVars());
 
             if (!envVars.has("WINEESYNC")) {
                 envVars.put("WINEESYNC", "1");


### PR DESCRIPTION
- Container env vars were loaded first, then shortcut env vars merged on top via `putAll()` 
- Since `putAll()` only adds/overwrites keys and never removes them, deleting an env var (e.g. DXVK_HUD) from a shortcut had no effect — the container's copy survived the merge
- Changed to pick one source (shortcut or container), not both, so deletions are respected

## Test plan
- [x] Remove DXVK_HUD from shortcut env vars, launch container, verify HUD is gone
- [x] Confirmed via `adb logcat` and `/proc/<pid>/environ` that DXVK_HUD is not set