### PR TITLE
Fix ColdClient defaulting to OFF on existing containers

### DIFF
--- a/app/src/main/java/com/winlator/cmod/container/Container.java
+++ b/app/src/main/java/com/winlator/cmod/container/Container.java
@@ -444,6 +444,7 @@ public class Container {
             data.put("lc_all", lc_all);
             data.put("launchRealSteam", launchRealSteam);
             data.put("useColdClient", useColdClient);
+            data.put("coldClientMigrated", true);
             data.put("steamType", steamType);
             data.put("allowSteamUpdates", allowSteamUpdates);
             data.put("needsUnpacking", needsUnpacking);
@@ -561,11 +562,14 @@ public class Container {
                     setLaunchRealSteam(data.getBoolean(key));
                     break;
                 case "useColdClient" :
-                    setUseColdClient(data.getBoolean(key));
+                    // Only respect explicit user choice if coldClientMigrated flag is set
+                    if (data.has("coldClientMigrated")) {
+                        setUseColdClient(data.getBoolean(key));
+                    }
+                    // Otherwise keep default true (migrating from old data)
                     break;
                 case "useLegacyDRM" :
-                    // Migrate: old useLegacyDRM=false meant ColdClient, now useColdClient=true means ColdClient
-                    setUseColdClient(!data.getBoolean(key));
+                    // Old field — always default to ColdClient on
                     break;
                 case "steamType" :
                     setSteamType(data.getString(key));


### PR DESCRIPTION
- Existing containers had `useColdClient=false` saved from old `useLegacyDRM` migration, overriding the new default
- Add `coldClientMigrated` flag to `saveData()` — only respect saved `useColdClient` value after the container has been saved with new code
- Old `useLegacyDRM` values always migrate to ColdClient ON
- Users can still toggle ColdClient off and it will persist after their first save

## Test plan
- [x] Existing container shows ColdClient toggle ON by default
- [x] Toggle ColdClient off, save, reopen — stays OFF
- [x] Toggle ColdClient on, save, reopen — stays ON