### PR TITLE
feat: Achievement unlock popup with icon downloading

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -45,6 +45,9 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.core.view.GravityCompat;
 import com.winlator.cmod.steam.enums.Marker;
+import com.winlator.cmod.steam.ui.AchievementPopupKt;
+import com.winlator.cmod.steam.ui.AchievementPopupState;
+import com.winlator.cmod.steam.ui.AchievementWatcher;
 import com.winlator.cmod.steam.utils.MarkerUtils;
 import com.winlator.cmod.steam.utils.SteamUtils;
 
@@ -197,6 +200,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
     private OnExtractFileListener onExtractFileListener;
     private WinHandler winHandler;
     private WineRequestHandler wineRequestHandler;
+    private AchievementPopupState achievementPopupState;
+    private AchievementWatcher achievementWatcher;
     private float globalCursorSpeed = 1.0f;
     private MagnifierView magnifierView;
     private DebugDialog debugDialog;
@@ -1785,6 +1790,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        if (achievementWatcher != null) {
+            achievementWatcher.stop();
+        }
         // Schedule a deferred update check 10 s after game exit
         com.winlator.cmod.core.UpdateChecker.INSTANCE.schedulePostGameCheck(this);
         if (inputDeviceManager != null) {
@@ -2479,6 +2487,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
         // Start all environment components (XServer, Audio, etc.)
         environment.startEnvironmentComponents();
 
+        // Start the achievement popup watcher
+        setupAchievementWatcher();
+
         // Start the WinHandler
         winHandler.start();
 
@@ -2493,6 +2504,68 @@ public class XServerDisplayActivity extends AppCompatActivity {
         File scriptFile = new File(path);
         FileUtils.writeString(scriptFile, content);
         scriptFile.setExecutable(true);
+    }
+
+    private void setupAchievementWatcher() {
+        if (container == null || imageFs == null) return;
+
+        // Determine appId from shortcut (Steam games only)
+        int appId = 0;
+        if (shortcut != null && "STEAM".equals(shortcut.getExtra("game_source"))) {
+            String appIdStr = shortcut.getExtra("app_id");
+            if (appIdStr != null && !appIdStr.isEmpty()) {
+                try { appId = Integer.parseInt(appIdStr); } catch (NumberFormatException ignored) {}
+            }
+        }
+        if (appId == 0) return;
+
+        // Find GSE save directory
+        String winePrefix = ImageFs.WINEPREFIX;
+        File gseSaveDir = new File(imageFs.getRootDir(),
+                winePrefix + "/drive_c/users/xuser/AppData/Roaming/GSE Saves/" + appId);
+
+        if (!gseSaveDir.isDirectory()) {
+            // Try userdata path
+            int accountId = SteamUtils.INSTANCE.getSteam3AccountId();
+            if (accountId != 0) {
+                gseSaveDir = new File(imageFs.getRootDir(),
+                        winePrefix + "/drive_c/Program Files (x86)/Steam/userdata/" + accountId + "/" + appId);
+            }
+        }
+
+        if (!gseSaveDir.isDirectory()) {
+            // Directory doesn't exist yet — watch the parent so we catch it when the game creates it
+            gseSaveDir.mkdirs();
+        }
+
+        // Find steam_settings directory
+        File steamSettingsDir = null;
+        String appDirPath = SteamBridge.getAppDirPath(appId);
+        if (appDirPath != null) {
+            File dir = new File(appDirPath, "steam_settings");
+            if (dir.isDirectory()) steamSettingsDir = dir;
+        }
+        if (steamSettingsDir == null) {
+            File dir = new File(container.getRootDir(),
+                    ".wine/drive_c/Program Files (x86)/Steam/steam_settings");
+            if (dir.isDirectory()) steamSettingsDir = dir;
+        }
+
+        // Setup popup UI
+        achievementPopupState = new AchievementPopupState();
+        ComposeView achievementPopupView = findViewById(R.id.AchievementPopupView);
+        AchievementPopupKt.setupAchievementPopup(achievementPopupView, achievementPopupState);
+
+        // Create and start watcher
+        String language = container.getLanguage();
+        File finalGseSaveDir = gseSaveDir;
+        achievementWatcher = new AchievementWatcher(
+                finalGseSaveDir,
+                steamSettingsDir,
+                language,
+                notification -> runOnUiThread(() -> achievementPopupState.show(notification))
+        );
+        achievementWatcher.start();
     }
 
     private void setupUI() {

--- a/app/src/main/java/com/winlator/cmod/steam/service/SteamService.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/service/SteamService.kt
@@ -183,6 +183,8 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import `in`.dragonbra.javasteam.steam.handlers.steamuserstats.Stats
 import com.winlator.cmod.steam.statsgen.StatType
+import com.winlator.cmod.contents.Downloader
+import com.winlator.cmod.steam.statsgen.Achievement
 import com.winlator.cmod.steam.statsgen.StatsAchievementsGenerator
 import com.winlator.cmod.steam.statsgen.VdfParser
 
@@ -3618,8 +3620,37 @@ class SteamService : Service(), IChallengeUrlChanged {
                 }
                 File(configDirectory, "achievement_name_to_block.json").writeText(mappingJson.toString(), Charsets.UTF_8)
             }
+
+            // Download achievement icons from Steam CDN
+            downloadAchievementIcons(appId, configDirectory, result.achievements)
         }.onFailure { e ->
             Timber.w(e, "Failed to generate achievements for appId=$appId")
+        }
+
+        private fun downloadAchievementIcons(appId: Int, configDirectory: String, achievements: List<Achievement>) {
+            val imgDir = File(configDirectory, "img")
+            if (!imgDir.exists()) imgDir.mkdirs()
+
+            val cdnBase = "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/$appId"
+            val iconNames = mutableSetOf<String>()
+
+            for (ach in achievements) {
+                ach.icon?.takeIf { it.isNotEmpty() }?.let { iconNames.add(it) }
+                ach.iconGray?.takeIf { it.isNotEmpty() }?.let { iconNames.add(it) }
+                ach.icongray?.takeIf { it.isNotEmpty() }?.let { iconNames.add(it) }
+            }
+
+            for (iconName in iconNames) {
+                val destFile = File(imgDir, iconName)
+                if (destFile.exists()) continue
+                val url = "$cdnBase/$iconName.jpg"
+                try {
+                    Downloader.downloadFile(url, destFile, null)
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to download achievement icon: $iconName")
+                }
+            }
+            Timber.d("Downloaded ${iconNames.size} achievement icons for appId=$appId")
         }
 
         fun getGseSaveDirs(appId: Int): List<File> {

--- a/app/src/main/java/com/winlator/cmod/steam/ui/AchievementPopup.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/ui/AchievementPopup.kt
@@ -1,0 +1,156 @@
+package com.winlator.cmod.steam.ui
+
+import android.graphics.BitmapFactory
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import java.io.File
+
+data class AchievementNotification(
+    val name: String,
+    val displayName: String,
+    val iconPath: String? = null
+)
+
+/** Java-friendly state holder for achievement notifications. */
+class AchievementPopupState {
+    internal var notification by mutableStateOf<AchievementNotification?>(null)
+
+    fun show(notification: AchievementNotification) {
+        this.notification = notification
+    }
+
+    fun dismiss() {
+        notification = null
+    }
+}
+
+fun setupAchievementPopup(
+    composeView: ComposeView,
+    state: AchievementPopupState
+) {
+    composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    composeView.setContent {
+        AchievementPopup(
+            notification = state.notification,
+            onDismissed = { state.dismiss() }
+        )
+    }
+}
+
+@Composable
+fun AchievementPopup(
+    notification: AchievementNotification?,
+    onDismissed: () -> Unit
+) {
+    var visible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(notification) {
+        if (notification != null) {
+            visible = true
+            delay(4000)
+            visible = false
+            delay(500)
+            onDismissed()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 24.dp),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = slideInVertically(
+                initialOffsetY = { -it },
+                animationSpec = tween(400)
+            ) + fadeIn(animationSpec = tween(400)),
+            exit = slideOutVertically(
+                targetOffsetY = { -it },
+                animationSpec = tween(400)
+            ) + fadeOut(animationSpec = tween(400))
+        ) {
+            val shape = RoundedCornerShape(12.dp)
+            Row(
+                modifier = Modifier
+                    .shadow(
+                        elevation = 16.dp,
+                        shape = shape,
+                        ambientColor = Color.Black,
+                        spotColor = Color.Black
+                    )
+                    .clip(shape)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(Color(0xF5141414), Color(0xF50A0A0A))
+                        )
+                    )
+                    .border(1.dp, Color(0x33FFFFFF), shape)
+                    .padding(horizontal = 16.dp, vertical = 14.dp)
+                    .widthIn(max = 340.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                val iconBitmap = remember(notification?.iconPath) {
+                    notification?.iconPath?.let { path ->
+                        val file = File(path)
+                        if (file.exists()) {
+                            runCatching { BitmapFactory.decodeFile(file.absolutePath)?.asImageBitmap() }.getOrNull()
+                        } else null
+                    }
+                }
+
+                if (iconBitmap != null) {
+                    Image(
+                        bitmap = iconBitmap,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(52.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                    )
+                }
+
+                Column(modifier = Modifier.weight(1f, fill = false)) {
+                    Text(
+                        text = "ACHIEVEMENT UNLOCKED",
+                        color = Color(0xFFFFD400),
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = 1.2.sp
+                    )
+                    Spacer(modifier = Modifier.height(3.dp))
+                    Text(
+                        text = notification?.displayName ?: "",
+                        color = Color(0xFFE0E0E0),
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/winlator/cmod/steam/ui/AchievementWatcher.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/ui/AchievementWatcher.kt
@@ -1,0 +1,140 @@
+package com.winlator.cmod.steam.ui
+
+import android.os.FileObserver
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.File
+import java.util.function.Consumer
+
+/**
+ * Watches the GSE Saves achievements.json for newly earned achievements
+ * and fires a callback with the achievement display info.
+ */
+class AchievementWatcher(
+    private val gseSaveDir: File,
+    private val steamSettingsDir: File?,
+    private val language: String,
+    private val onAchievementUnlocked: Consumer<AchievementNotification>
+) {
+    private var observer: FileObserver? = null
+    private val previouslyEarned = mutableSetOf<String>()
+
+    fun start() {
+        val achFile = File(gseSaveDir, "achievements.json")
+
+        // Seed with already-earned achievements so we only fire on NEW ones
+        loadEarned(achFile)
+
+        // Watch the GSE save directory for writes to achievements.json
+        observer = object : FileObserver(gseSaveDir.absolutePath, CLOSE_WRITE or MODIFY) {
+            override fun onEvent(event: Int, path: String?) {
+                if (path == "achievements.json") {
+                    checkForNew(achFile)
+                }
+            }
+        }
+        observer?.startWatching()
+        Timber.d("AchievementWatcher started for ${gseSaveDir.absolutePath}")
+    }
+
+    fun stop() {
+        observer?.stopWatching()
+        observer = null
+        Timber.d("AchievementWatcher stopped")
+    }
+
+    private fun loadEarned(achFile: File) {
+        if (!achFile.exists()) return
+        try {
+            val json = JSONObject(achFile.readText(Charsets.UTF_8))
+            for (name in json.keys()) {
+                val entry = json.optJSONObject(name) ?: continue
+                if (entry.optBoolean("earned", false)) {
+                    previouslyEarned.add(name)
+                }
+            }
+            Timber.d("AchievementWatcher seeded with ${previouslyEarned.size} earned achievements")
+        } catch (e: Exception) {
+            Timber.w(e, "AchievementWatcher failed to seed earned achievements")
+        }
+    }
+
+    private fun checkForNew(achFile: File) {
+        if (!achFile.exists()) return
+        try {
+            val json = JSONObject(achFile.readText(Charsets.UTF_8))
+            for (name in json.keys()) {
+                val entry = json.optJSONObject(name) ?: continue
+                if (entry.optBoolean("earned", false) && name !in previouslyEarned) {
+                    previouslyEarned.add(name)
+                    val displayName = resolveDisplayName(name)
+                    val iconPath = resolveIconPath(name)
+                    Timber.d("Achievement unlocked: $name ($displayName)")
+                    onAchievementUnlocked.accept(
+                        AchievementNotification(
+                            name = name,
+                            displayName = displayName,
+                            iconPath = iconPath
+                        )
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "AchievementWatcher failed to check for new achievements")
+        }
+    }
+
+    /**
+     * Looks up the display name from steam_settings/achievements.json
+     * which contains the full achievement metadata with localized names.
+     */
+    private fun resolveDisplayName(apiName: String): String {
+        val settingsAchFile = steamSettingsDir?.let { File(it, "achievements.json") }
+        if (settingsAchFile == null || !settingsAchFile.exists()) return apiName
+        try {
+            val arr = JSONArray(settingsAchFile.readText(Charsets.UTF_8))
+            for (i in 0 until arr.length()) {
+                val ach = arr.optJSONObject(i) ?: continue
+                if (ach.optString("name") == apiName) {
+                    val displayNameObj = ach.optJSONObject("displayName")
+                    if (displayNameObj != null) {
+                        return displayNameObj.optString(language, "")
+                            .ifEmpty { displayNameObj.optString("english", "") }
+                            .ifEmpty { apiName }
+                    }
+                    return apiName
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to resolve display name for $apiName")
+        }
+        return apiName
+    }
+
+    /**
+     * Resolves the icon file path from steam_settings/achievements.json.
+     * Icons are stored as "img/<hash>" relative to steam_settings.
+     */
+    private fun resolveIconPath(apiName: String): String? {
+        val settingsAchFile = steamSettingsDir?.let { File(it, "achievements.json") }
+        if (settingsAchFile == null || !settingsAchFile.exists()) return null
+        try {
+            val arr = JSONArray(settingsAchFile.readText(Charsets.UTF_8))
+            for (i in 0 until arr.length()) {
+                val ach = arr.optJSONObject(i) ?: continue
+                if (ach.optString("name") == apiName) {
+                    val iconRelative = ach.optString("icon", "")
+                    if (iconRelative.isNotEmpty() && steamSettingsDir != null) {
+                        val iconFile = File(steamSettingsDir, iconRelative)
+                        if (iconFile.exists()) return iconFile.absolutePath
+                    }
+                    return null
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to resolve icon for $apiName")
+        }
+        return null
+    }
+}

--- a/app/src/main/res/layout/xserver_display_activity.xml
+++ b/app/src/main/res/layout/xserver_display_activity.xml
@@ -13,6 +13,14 @@
         android:layout_height="match_parent" />
 
     <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/AchievementPopupView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="false"
+        android:focusable="false"
+        android:elevation="10dp" />
+
+    <androidx.compose.ui.platform.ComposeView
         android:id="@+id/NavigationComposeView"
         android:layout_width="336dp"
         android:layout_height="match_parent"


### PR DESCRIPTION
- Add AchievementPopup composable with slide-in/fade animation, dark gradient background, drop shadow, and subtle border
- Add AchievementWatcher using FileObserver to detect newly earned achievements from GSE Saves
- Wire up watcher in XServerDisplayActivity for Steam game shortcuts, with lifecycle cleanup
- Download achievement icons from Steam CDN during `generateAchievements()` into `steam_settings/img/`
- Add ComposeView overlay in xserver_display_activity.xml layout

## Test plan
- [ ] Launch a Steam game that has achievements
- [ ] Unlock an achievement and verify the popup slides in from the top with icon, title, and name
- [ ] Verify popup auto-dismisses after ~4 seconds
- [ ] Verify icons are downloaded to `steam_settings/img/` after game setup
- [ ] Verify icons are cleaned up when the game is uninstalled