### PR TITLE
fix: Remove AIO store mode and update cloud sync card UI

### DIFF
--- a/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
@@ -504,23 +504,18 @@ class UnifiedActivity : ComponentActivity() {
     // Tab definitions
     private data class TabDef(val label: String, val key: String)
 
-    private fun buildTabs(aio: Boolean, storeVisible: Map<String, Boolean>): List<TabDef> {
+    private fun buildTabs(storeVisible: Map<String, Boolean>): List<TabDef> {
         val base = mutableListOf(TabDef(getString(R.string.common_ui_library), "library"), TabDef(getString(R.string.common_ui_downloads), "downloads"))
-        if (aio) {
-            base.add(TabDef(getString(R.string.common_ui_store), "store"))
-        } else {
-            if (storeVisible["steam"] != false) base.add(TabDef("Steam", "steam"))
-            if (storeVisible["epic"] != false) base.add(TabDef("Epic", "epic"))
-            if (storeVisible["gog"] != false) base.add(TabDef("GOG", "gog"))
-            if (storeVisible["amazon"] != false) base.add(TabDef("Amazon", "amazon"))
-        }
+        if (storeVisible["steam"] != false) base.add(TabDef("Steam", "steam"))
+        if (storeVisible["epic"] != false) base.add(TabDef("Epic", "epic"))
+        if (storeVisible["gog"] != false) base.add(TabDef("GOG", "gog"))
+        if (storeVisible["amazon"] != false) base.add(TabDef("Amazon", "amazon"))
         return base
     }
 
     // Main scaffold
     @Composable
     fun UnifiedHub() {
-        var aioMode by remember { mutableStateOf(PrefManager.aioStoreMode) }
         val storeVisible = remember { mutableStateMapOf("steam" to true, "epic" to true, "gog" to true, "amazon" to true) }
         var showAddCustomGame by remember { mutableStateOf(false) }
         var showExitDialog by remember { mutableStateOf(false) }
@@ -542,7 +537,7 @@ class UnifiedActivity : ComponentActivity() {
                     .getOrDefault(LibraryLayoutMode.GRID_4)
             )
         }
-        val tabs = remember(aioMode, storeVisible.toMap()) { buildTabs(aioMode, storeVisible) }
+        val tabs = remember(storeVisible.toMap()) { buildTabs(storeVisible) }
         var selectedIdx by rememberSaveable { mutableIntStateOf(0) }
         var selectedDownloadId by remember { mutableStateOf<String?>(null) }
         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -781,8 +776,6 @@ class UnifiedActivity : ComponentActivity() {
                     persona = persona,
                     context = context,
                     scope = scope,
-                    aioMode = aioMode,
-                    onAioToggle = { aioMode = it; PrefManager.aioStoreMode = it },
                     storeVisible = storeVisible,
                     contentFilters = contentFilters,
                     libraryLayoutMode = libraryLayoutMode,
@@ -862,7 +855,7 @@ class UnifiedActivity : ComponentActivity() {
                         ) { animatedKey ->
                             when (animatedKey) {
                                 "downloads" -> DownloadsTab(selectedDownloadId, onSelectDownload = { selectedDownloadId = it })
-                                "steam", "store" -> SteamStoreTab(isLoggedIn, filteredSteamApps, searchQuery, libraryLayoutMode)
+                                "steam" -> SteamStoreTab(isLoggedIn, filteredSteamApps, searchQuery, libraryLayoutMode)
 
                                 "epic" -> EpicStoreTab(isEpicLoggedIn, searchQuery, libraryLayoutMode) {
                                     epicLoginLauncher.launch(Intent(this@UnifiedActivity, EpicOAuthActivity::class.java))
@@ -6136,8 +6129,6 @@ class UnifiedActivity : ComponentActivity() {
         persona: com.winlator.cmod.steam.data.SteamFriend?,
         context: android.content.Context,
         scope: kotlinx.coroutines.CoroutineScope,
-        aioMode: Boolean,
-        onAioToggle: (Boolean) -> Unit,
         storeVisible: SnapshotStateMap<String, Boolean>,
         contentFilters: SnapshotStateMap<String, Boolean>,
         libraryLayoutMode: LibraryLayoutMode,
@@ -6334,9 +6325,6 @@ class UnifiedActivity : ComponentActivity() {
 
                 // ── Stores ──
                 Text(stringResource(R.string.stores_accounts_stores_header), color = TextSecondary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.4.sp, modifier = Modifier.padding(bottom = 4.dp))
-                Spacer(Modifier.height(8.dp))
-
-                DrawerFilterButton(stringResource(R.string.stores_accounts_aio_store_mode), aioMode, Modifier.fillMaxWidth()) { onAioToggle(it) }
                 Spacer(Modifier.height(8.dp))
 
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/winlator/cmod/google/GoogleScreen.kt
+++ b/app/src/main/java/com/winlator/cmod/google/GoogleScreen.kt
@@ -218,38 +218,59 @@ private fun AutoBackupCard(
     busy: Boolean,
     onToggle: (Boolean) -> Unit
 ) {
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(CardDark)
-            .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
+            .border(1.dp, CardBorder, RoundedCornerShape(12.dp))
             .clickable(enabled = !busy) { onToggle(!enabled) }
-            .padding(horizontal = 14.dp, vertical = 14.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 11.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconBox(icon = Icons.Filled.CloudSync, tint = if (enabled && googleSignedIn) StatusGreen else TextSecondary)
+            Box(
+                modifier = Modifier
+                    .size(34.dp)
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(IconBoxBg),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.CloudSync,
+                    contentDescription = null,
+                    tint = if (enabled && googleSignedIn) StatusGreen else TextSecondary,
+                    modifier = Modifier.size(17.dp)
+                )
+            }
 
-            Spacer(Modifier.width(14.dp))
+            Spacer(Modifier.width(13.dp))
 
-            Text(
-                text = stringResource(R.string.google_cloud_auto_backup),
-                color = TextPrimary,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.weight(1f)
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.google_cloud_auto_backup),
+                    color = TextPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.google_cloud_auto_backup_summary),
+                    color = TextSecondary,
+                    fontSize = 11.sp
+                )
+            }
 
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(4.dp))
 
             Switch(
                 checked = enabled && googleSignedIn,
                 onCheckedChange = { onToggle(it) },
                 enabled = !busy,
+                modifier = Modifier.scale(0.78f),
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = StatusGreen,
                     checkedTrackColor = StatusGreen.copy(alpha = 0.3f),
@@ -258,15 +279,6 @@ private fun AutoBackupCard(
                 )
             )
         }
-
-        Spacer(Modifier.height(6.dp))
-
-        Text(
-            text = stringResource(R.string.google_cloud_auto_backup_summary),
-            color = TextSecondary,
-            fontSize = 12.sp,
-            modifier = Modifier.padding(start = 52.dp)
-        )
     }
 }
 

--- a/app/src/main/java/com/winlator/cmod/steam/utils/PrefManager.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/utils/PrefManager.kt
@@ -134,10 +134,6 @@ object PrefManager {
         get() = getLong("client_id", 0L)
         set(value) { setLong("client_id", value) }
 
-    var aioStoreMode: Boolean
-        get() = getBoolean("aio_store_mode", false)
-        set(value) { setBoolean("aio_store_mode", value) }
-
     var libraryLayoutMode: String
         get() = getString("library_layout_mode", "GRID_4")
         set(value) { setString("library_layout_mode", value) }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Usynlig</string>
     <string name="stores_accounts_status_header">STATUS</string>
     <string name="stores_accounts_stores_header">BUTIKKER</string>
-    <string name="stores_accounts_aio_store_mode">AIO Butikstilstand</string>
     <string name="stores_accounts_sign_in_store_prompt">Log venligst ind for at få adgang til %1$s butikken.</string>
     <string name="stores_accounts_manage">Administrer butikskonti</string>
     <string name="stores_accounts_sign_into_store">Log ind på %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Unsichtbar</string>
     <string name="stores_accounts_status_header">STATUS</string>
     <string name="stores_accounts_stores_header">STORES</string>
-    <string name="stores_accounts_aio_store_mode">AIO-Store-Modus</string>
     <string name="stores_accounts_sign_in_store_prompt">Bitte melde dich an, um auf den %1$s Store zuzugreifen.</string>
     <string name="stores_accounts_manage">Store-Konten verwalten</string>
     <string name="stores_accounts_sign_into_store">Bei %1$s anmelden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invisible</string>
     <string name="stores_accounts_status_header">ESTADO</string>
     <string name="stores_accounts_stores_header">TIENDAS</string>
-    <string name="stores_accounts_aio_store_mode">Modo Tienda AIO</string>
     <string name="stores_accounts_sign_in_store_prompt">Por favor, inicia sesión para acceder a la tienda %1$s.</string>
     <string name="stores_accounts_manage">Gestionar cuentas de tienda</string>
     <string name="stores_accounts_sign_into_store">Iniciar sesión en %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invisible</string>
     <string name="stores_accounts_status_header">STATUT</string>
     <string name="stores_accounts_stores_header">BOUTIQUES</string>
-    <string name="stores_accounts_aio_store_mode">Mode boutique tout-en-un</string>
     <string name="stores_accounts_sign_in_store_prompt">Veuillez vous connecter pour accéder à la boutique %1$s.</string>
     <string name="stores_accounts_manage">Gérer les comptes de boutique</string>
     <string name="stores_accounts_sign_into_store">Se connecter à %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invisibile</string>
     <string name="stores_accounts_status_header">STATO</string>
     <string name="stores_accounts_stores_header">NEGOZI</string>
-    <string name="stores_accounts_aio_store_mode">Modalità negozio AIO</string>
     <string name="stores_accounts_sign_in_store_prompt">Accedi per accedere al negozio %1$s.</string>
     <string name="stores_accounts_manage">Gestisci account negozi</string>
     <string name="stores_accounts_sign_into_store">Accedi a %1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">숨김</string>
     <string name="stores_accounts_status_header">상태</string>
     <string name="stores_accounts_stores_header">스토어</string>
-    <string name="stores_accounts_aio_store_mode">통합 스토어 모드</string>
     <string name="stores_accounts_sign_in_store_prompt">%1$s 스토어에 접근하려면 로그인하세요.</string>
     <string name="stores_accounts_manage">스토어 계정 관리</string>
     <string name="stores_accounts_sign_into_store">%1$s에 로그인</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Niewidoczny</string>
     <string name="stores_accounts_status_header">STATUS</string>
     <string name="stores_accounts_stores_header">SKLEPY</string>
-    <string name="stores_accounts_aio_store_mode">Tryb AIO sklepu</string>
     <string name="stores_accounts_sign_in_store_prompt">Zaloguj się, aby uzyskać dostęp do sklepu %1$s.</string>
     <string name="stores_accounts_manage">Zarządzaj kontami sklepów</string>
     <string name="stores_accounts_sign_into_store">Zaloguj się do %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invisivel</string>
     <string name="stores_accounts_status_header">STATUS</string>
     <string name="stores_accounts_stores_header">LOJAS</string>
-    <string name="stores_accounts_aio_store_mode">Modo Loja Unificada</string>
     <string name="stores_accounts_sign_in_store_prompt">Por favor, entre para acessar a loja %1$s.</string>
     <string name="stores_accounts_manage">Gerenciar Contas das Lojas</string>
     <string name="stores_accounts_sign_into_store">Entrar em %1$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invizibil</string>
     <string name="stores_accounts_status_header">STARE</string>
     <string name="stores_accounts_stores_header">MAGAZINE</string>
-    <string name="stores_accounts_aio_store_mode">Mod magazin AIO</string>
     <string name="stores_accounts_sign_in_store_prompt">Autentifica-te pentru a accesa magazinul %1$s.</string>
     <string name="stores_accounts_manage">Gestioneaza conturile de magazin</string>
     <string name="stores_accounts_sign_into_store">Autentificare in %1$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Невидимий</string>
     <string name="stores_accounts_status_header">СТАТУС</string>
     <string name="stores_accounts_stores_header">МАГАЗИНИ</string>
-    <string name="stores_accounts_aio_store_mode">Режим єдиного магазину</string>
     <string name="stores_accounts_sign_in_store_prompt">Будь ласка, увійдіть для доступу до магазину %1$s.</string>
     <string name="stores_accounts_manage">Керування обліковими записами магазинів</string>
     <string name="stores_accounts_sign_into_store">Увійти до %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">隐身</string>
     <string name="stores_accounts_status_header">状态</string>
     <string name="stores_accounts_stores_header">商店</string>
-    <string name="stores_accounts_aio_store_mode">一站式商店模式</string>
     <string name="stores_accounts_sign_in_store_prompt">请登录以访问 %1$s 商店。</string>
     <string name="stores_accounts_manage">管理商店账户</string>
     <string name="stores_accounts_sign_into_store">登录 %1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">隱形</string>
     <string name="stores_accounts_status_header">狀態</string>
     <string name="stores_accounts_stores_header">商店</string>
-    <string name="stores_accounts_aio_store_mode">一站式商店模式</string>
     <string name="stores_accounts_sign_in_store_prompt">請登入以存取 %1$s 商店。</string>
     <string name="stores_accounts_manage">管理商店帳號</string>
     <string name="stores_accounts_sign_into_store">登入 %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,7 +167,6 @@
     <string name="stores_accounts_status_invisible">Invisible</string>
     <string name="stores_accounts_status_header">STATUS</string>
     <string name="stores_accounts_stores_header">STORES</string>
-    <string name="stores_accounts_aio_store_mode">AIO Store Mode</string>
     <string name="stores_accounts_sign_in_store_prompt">Please sign in to access the %1$s store.</string>
     <string name="stores_accounts_manage">Manage Store Accounts</string>
     <string name="stores_accounts_sign_into_store">Sign into %1$s</string>


### PR DESCRIPTION
- Remove AIO store mode from UnifiedActivity homescreen, each store tab now displays individually when selected
- Remove `aioStoreMode` property from PrefManager
- Remove AIO toggle button from drawer menu
- Remove unused `stores_accounts_aio_store_mode` strings from all 13 locales
- Update AutoBackupCard to match stores SettingsToggleCard formatting (12dp corners, 34dp icon box, 0.78f switch scale, matching padding/spacing)