### PR TITLE
fix: Make container notification silent and rebrand to WinNative

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -268,9 +268,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
     };
 
     private void createNotifcationChannel() {
-        String name = "Winlator";
+        String name = "WinNative";
         String description = getString(R.string.session_xserver_notification_description);
-        int importance = NotificationManager.IMPORTANCE_HIGH;
+        int importance = NotificationManager.IMPORTANCE_LOW;
         NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance);
         channel.setDescription(description);
         NotificationManager notificationManager = getSystemService(NotificationManager.class);
@@ -992,9 +992,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_stat_ab_gear_0011)
-                .setContentTitle("Winlator")
-                .setContentText("Winlator is running, do not kill or swipe this notification")
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentTitle("WinNative")
+                .setContentText(getString(R.string.session_xserver_notification_content))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setContentIntent(pendingIntent)
                 .setAutoCancel(false);
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -494,7 +494,8 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="session_xserver_native_rendering_disabled">Software WSI-fallback</string>
     <string name="session_xserver_native_rendering_enabled_toast">Native rendering aktiveret (træder i kraft ved næste start)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Native rendering deaktiveret (træder i kraft ved næste start)</string>
-    <string name="session_xserver_notification_description">Winlator XServer-beskeder</string>
+    <string name="session_xserver_notification_description">WinNative XServer-beskeder</string>
+    <string name="session_xserver_notification_content">WinNative kører, luk ikke eller swipe denne notifikation væk</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Tastatur</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -494,7 +494,8 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="session_xserver_native_rendering_disabled">Software-WSI-Fallback</string>
     <string name="session_xserver_native_rendering_enabled_toast">Natives Rendering aktiviert (wirksam beim nächsten Start)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Natives Rendering deaktiviert (wirksam beim nächsten Start)</string>
-    <string name="session_xserver_notification_description">Winlator XServer-Nachrichten</string>
+    <string name="session_xserver_notification_description">WinNative XServer-Nachrichten</string>
+    <string name="session_xserver_notification_content">WinNative läuft, beenden oder wischen Sie diese Benachrichtigung nicht weg</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Tastatur</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -494,7 +494,8 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Respaldo de WSI por software</string>
     <string name="session_xserver_native_rendering_enabled_toast">Renderizado nativo activado (tendrá efecto en el próximo inicio)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Renderizado nativo desactivado (tendrá efecto en el próximo inicio)</string>
-    <string name="session_xserver_notification_description">Mensajes de XServer de Winlator</string>
+    <string name="session_xserver_notification_description">Mensajes de XServer de WinNative</string>
+    <string name="session_xserver_notification_content">WinNative se está ejecutando, no elimines ni deslices esta notificación</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Teclado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -494,7 +494,8 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Repli logiciel WSI</string>
     <string name="session_xserver_native_rendering_enabled_toast">Rendu natif activé (prend effet au prochain lancement)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Rendu natif désactivé (prend effet au prochain lancement)</string>
-    <string name="session_xserver_notification_description">Messages XServer de Winlator</string>
+    <string name="session_xserver_notification_description">Messages XServer de WinNative</string>
+    <string name="session_xserver_notification_content">WinNative est en cours d\'exécution, ne supprimez pas et ne balayez pas cette notification</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Clavier</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -494,7 +494,8 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Fallback software WSI</string>
     <string name="session_xserver_native_rendering_enabled_toast">Rendering nativo abilitato (effettivo al prossimo avvio)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Rendering nativo disabilitato (effettivo al prossimo avvio)</string>
-    <string name="session_xserver_notification_description">Messaggi XServer di Winlator</string>
+    <string name="session_xserver_notification_description">Messaggi XServer di WinNative</string>
+    <string name="session_xserver_notification_content">WinNative è in esecuzione, non chiudere o scorrere via questa notifica</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Tastiera</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -494,7 +494,8 @@
     <string name="session_xserver_native_rendering_disabled">소프트웨어 WSI 폴백</string>
     <string name="session_xserver_native_rendering_enabled_toast">네이티브 렌더링 활성화됨 (다음 실행 시 적용)</string>
     <string name="session_xserver_native_rendering_disabled_toast">네이티브 렌더링 비활성화됨 (다음 실행 시 적용)</string>
-    <string name="session_xserver_notification_description">Winlator XServer 메시지</string>
+    <string name="session_xserver_notification_description">WinNative XServer 메시지</string>
+    <string name="session_xserver_notification_content">WinNative가 실행 중입니다. 이 알림을 종료하거나 스와이프하지 마세요</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">키보드</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -494,7 +494,8 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Programowy fallback WSI</string>
     <string name="session_xserver_native_rendering_enabled_toast">Renderowanie natywne włączone (zacznie działać po ponownym uruchomieniu)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Renderowanie natywne wyłączone (zacznie działać po ponownym uruchomieniu)</string>
-    <string name="session_xserver_notification_description">Wiadomości Winlator XServer</string>
+    <string name="session_xserver_notification_description">Wiadomości WinNative XServer</string>
+    <string name="session_xserver_notification_content">WinNative jest uruchomiony, nie zamykaj ani nie usuwaj tego powiadomienia</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Klawiatura</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -494,7 +494,8 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Fallback de WSI por software</string>
     <string name="session_xserver_native_rendering_enabled_toast">Renderizacao nativa ativada (tera efeito no proximo inicio)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Renderizacao nativa desativada (tera efeito no proximo inicio)</string>
-    <string name="session_xserver_notification_description">Mensagens do XServer do Winlator</string>
+    <string name="session_xserver_notification_description">Mensagens do XServer do WinNative</string>
+    <string name="session_xserver_notification_content">WinNative está em execução, não feche ou deslize esta notificação</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Teclado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -494,7 +494,8 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="session_xserver_native_rendering_disabled">Alternativa software WSI</string>
     <string name="session_xserver_native_rendering_enabled_toast">Randarea nativa activata (intra in vigoare la urmatoarea lansare)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Randarea nativa dezactivata (intra in vigoare la urmatoarea lansare)</string>
-    <string name="session_xserver_notification_description">Mesaje Winlator XServer</string>
+    <string name="session_xserver_notification_description">Mesaje WinNative XServer</string>
+    <string name="session_xserver_notification_content">WinNative rulează, nu închideți sau glisați această notificare</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Tastatura</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -494,7 +494,8 @@
     <string name="session_xserver_native_rendering_disabled">Програмний WSI-резерв</string>
     <string name="session_xserver_native_rendering_enabled_toast">Нативний рендеринг увімкнено (набуде чинності при наступному запуску)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Нативний рендеринг вимкнено (набуде чинності при наступному запуску)</string>
-    <string name="session_xserver_notification_description">Повідомлення Winlator XServer</string>
+    <string name="session_xserver_notification_description">Повідомлення WinNative XServer</string>
+    <string name="session_xserver_notification_content">WinNative працює, не закривайте та не змахуйте це сповіщення</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Клавіатура</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -494,7 +494,8 @@
     <string name="session_xserver_native_rendering_disabled">软件 WSI 回退</string>
     <string name="session_xserver_native_rendering_enabled_toast">原生渲染已启用（下次启动时生效）</string>
     <string name="session_xserver_native_rendering_disabled_toast">原生渲染已禁用（下次启动时生效）</string>
-    <string name="session_xserver_notification_description">Winlator XServer 消息</string>
+    <string name="session_xserver_notification_description">WinNative XServer 消息</string>
+    <string name="session_xserver_notification_content">WinNative 正在运行，请勿关闭或滑动移除此通知</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">键盘</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -494,7 +494,8 @@
     <string name="session_xserver_native_rendering_disabled">軟體 WSI 備援</string>
     <string name="session_xserver_native_rendering_enabled_toast">原生渲染已啟用（下次啟動時生效）</string>
     <string name="session_xserver_native_rendering_disabled_toast">原生渲染已停用（下次啟動時生效）</string>
-    <string name="session_xserver_notification_description">Winlator XServer 訊息</string>
+    <string name="session_xserver_notification_description">WinNative XServer 訊息</string>
+    <string name="session_xserver_notification_content">WinNative 正在運行，請勿關閉或滑動移除此通知</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">鍵盤</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,7 +494,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_xserver_native_rendering_disabled">Software WSI fallback</string>
     <string name="session_xserver_native_rendering_enabled_toast">Native rendering enabled (takes effect on next launch)</string>
     <string name="session_xserver_native_rendering_disabled_toast">Native rendering disabled (takes effect on next launch)</string>
-    <string name="session_xserver_notification_description">Winlator XServer Messages</string>
+    <string name="session_xserver_notification_description">WinNative XServer Messages</string>
+    <string name="session_xserver_notification_content">WinNative is running, do not kill or swipe this notification</string>
 
     <!-- Session > Drawer Menu -->
     <string name="session_drawer_keyboard">Keyboard</string>


### PR DESCRIPTION
- Lower notification channel importance from HIGH to LOW (no banner, no sound)
- Rebrand notification title, content, and channel name from Winlator to WinNative
- Extract hardcoded notification content text to translatable string resource (`session_xserver_notification_content`)
- Add translations across all 12 locales