### PR TITLE
fix: Improve touch controls cleanup and virtual gamepad state management

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -5017,6 +5017,10 @@ public class XServerDisplayActivity extends AppCompatActivity {
         return container;
     }
 
+    public boolean isArm64ECWine() {
+        return wineInfo != null && wineInfo.isArm64EC();
+    }
+
     public void setDXWrapper(String dxwrapper) {
         this.dxwrapper = dxwrapper;
     }

--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -503,13 +503,17 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
         // Handler and Runnable to manage timeout for hiding controls
 
-        boolean isTimeoutEnabled = preferences.getBoolean("touchscreen_timeout_enabled", true);
-
         hideControlsRunnable = () -> {
-            if (isTimeoutEnabled) {
-                inputControlsView.setVisibility(View.GONE);
-                Log.d("XServerDisplayActivity", "Touchscreen controls hidden after timeout.");
+            if (!preferences.getBoolean("touchscreen_timeout_enabled", true)) {
+                return;
             }
+            if (inputControlsView != null && inputControlsView.hasActiveTouchControls()) {
+                timeoutHandler.removeCallbacks(hideControlsRunnable);
+                timeoutHandler.postDelayed(hideControlsRunnable, 1000);
+                return;
+            }
+            inputControlsView.setVisibility(View.GONE);
+            Log.d("XServerDisplayActivity", "Touchscreen controls hidden after timeout.");
         };
 
 

--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -503,17 +503,13 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
         // Handler and Runnable to manage timeout for hiding controls
 
+        boolean isTimeoutEnabled = preferences.getBoolean("touchscreen_timeout_enabled", true);
+
         hideControlsRunnable = () -> {
-            if (!preferences.getBoolean("touchscreen_timeout_enabled", true)) {
-                return;
+            if (isTimeoutEnabled) {
+                inputControlsView.setVisibility(View.GONE);
+                Log.d("XServerDisplayActivity", "Touchscreen controls hidden after timeout.");
             }
-            if (inputControlsView != null && inputControlsView.hasActiveTouchControls()) {
-                timeoutHandler.removeCallbacks(hideControlsRunnable);
-                timeoutHandler.postDelayed(hideControlsRunnable, 1000);
-                return;
-            }
-            inputControlsView.setVisibility(View.GONE);
-            Log.d("XServerDisplayActivity", "Touchscreen controls hidden after timeout.");
         };
 
 

--- a/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
@@ -320,12 +320,13 @@ public class InputControlsView extends View {
     }
 
     public synchronized void setProfile(ControlsProfile profile) {
+        releaseActiveTouchElements();
         if (profile != null) {
             this.profile = profile;
             deselectAllElements();
         }
         else this.profile = null;
-        activeTouchElements.clear();
+        syncVirtualGamepadState();
     }
 
     public boolean isShowTouchscreenControls() {
@@ -334,6 +335,13 @@ public class InputControlsView extends View {
 
     public void setShowTouchscreenControls(boolean showTouchscreenControls) {
         this.showTouchscreenControls = showTouchscreenControls;
+        if (!showTouchscreenControls) {
+            releaseActiveTouchElements();
+        } else {
+            updateTouchpadPrimaryButtonState();
+        }
+        syncVirtualGamepadState();
+        invalidate();
     }
 
     public int getPrimaryColor() {
@@ -371,6 +379,7 @@ public class InputControlsView extends View {
 
     public void setTouchpadView(TouchpadView touchpadView) {
         this.touchpadView = touchpadView;
+        updateTouchpadPrimaryButtonState();
     }
 
     public XServer getXServer() {
@@ -382,12 +391,8 @@ public class InputControlsView extends View {
         createMouseMoveTimer();
     }
 
-    private boolean hasMouseLeftButtonElement() {
-        if (profile == null) return false;
-        for (ControlElement element : profile.getElements()) {
-            if (element.getBindingAt(0) == Binding.MOUSE_LEFT_BUTTON) return true;
-        }
-        return false;
+    public synchronized boolean hasActiveTouchControls() {
+        return activeTouchElements.size() > 0;
     }
 
     public int getMaxWidth() {
@@ -396,6 +401,7 @@ public class InputControlsView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
+        releaseActiveTouchElements();
         if (mouseMoveTimer != null)
             mouseMoveTimer.cancel();
         super.onDetachedFromWindow();
@@ -406,25 +412,26 @@ public class InputControlsView extends View {
     }
 
     private void createMouseMoveTimer() {
-        WinHandler winHandler = xServer.getWinHandler();
-        if (mouseMoveTimer == null && profile != null) {
-            final float cursorSpeed = profile.getCursorSpeed();
-            mouseMoveTimer = new Timer();
-            mouseMoveTimer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    if (mouseMoveOffset.x != 0 || mouseMoveOffset.y != 0) {// Only move if there's an offsete if there's an offset
-                        if (xServer.isRelativeMouseMovement())
-                            winHandler.mouseEvent(MouseEventFlags.MOVE, (int) (mouseMoveOffset.x * cursorSpeed * 10), (int) (mouseMoveOffset.y * cursorSpeed * 10), 0);
-                        else
-                            xServer.injectPointerMoveDelta(
-                                (int) (mouseMoveOffset.x * cursorSpeed * 10),
-                                (int) (mouseMoveOffset.y * cursorSpeed * 10)
-                        );
-                    }
-                }
-            }, 0, 1000 / 60); // 60 FPS
+        if (xServer == null || profile == null || mouseMoveTimer != null) {
+            return;
         }
+        WinHandler winHandler = xServer.getWinHandler();
+        final float cursorSpeed = profile.getCursorSpeed();
+        mouseMoveTimer = new Timer();
+        mouseMoveTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                if (mouseMoveOffset.x != 0 || mouseMoveOffset.y != 0) {// Only move if there's an offsete if there's an offset
+                    if (xServer.isRelativeMouseMovement())
+                        winHandler.mouseEvent(MouseEventFlags.MOVE, (int) (mouseMoveOffset.x * cursorSpeed * 10), (int) (mouseMoveOffset.y * cursorSpeed * 10), 0);
+                    else
+                        xServer.injectPointerMoveDelta(
+                            (int) (mouseMoveOffset.x * cursorSpeed * 10),
+                            (int) (mouseMoveOffset.y * cursorSpeed * 10)
+                    );
+                }
+            }
+        }, 0, 1000 / 60); // 60 FPS
     }
 
 
@@ -595,6 +602,10 @@ public class InputControlsView extends View {
             }
         }
 
+        if (!editMode && (!showTouchscreenControls || profile == null)) {
+            return touchpadView != null ? touchpadView.onTouchEvent(event) : super.onTouchEvent(event);
+        }
+
         if (!editMode && profile != null) {
             int actionIndex = event.getActionIndex();
             int pointerId = event.getPointerId(actionIndex);
@@ -607,11 +618,12 @@ public class InputControlsView extends View {
                     float x = event.getX(actionIndex);
                     float y = event.getY(actionIndex);
 
-                    touchpadView.setPointerButtonLeftEnabled(!hasMouseLeftButtonElement());
+                    updateTouchpadPrimaryButtonState();
                     for (ControlElement element : profile.getElements()) {
                         if (element.handleTouchDown(pointerId, x, y)) {
                             handled = true;
                             activeTouchElements.put(pointerId, element);
+                            updateTouchpadPrimaryButtonState();
 
                             // Trigger haptic feedback for input controls
                             if (hapticsEnabled) {
@@ -629,28 +641,43 @@ public class InputControlsView extends View {
                             break;
                         }
                     }
-                    if (!handled) touchpadView.onTouchEvent(event);
+                    if (!handled && touchpadView != null) touchpadView.onTouchEvent(event);
                     break;
                 }
                 case MotionEvent.ACTION_MOVE: {
+                    boolean forwardToTouchpad = false;
                     for (byte i = 0, count = (byte)event.getPointerCount(); i < count; i++) {
                         int movePointerId = event.getPointerId(i);
                         float x = event.getX(i);
                         float y = event.getY(i);
+                        boolean pointerHandled = false;
 
                         ControlElement activeElement = activeTouchElements.get(movePointerId);
-                        handled = activeElement != null && activeElement.handleTouchMove(movePointerId, x, y);
+                        if (activeElement != null) {
+                            pointerHandled = activeElement.handleTouchMove(movePointerId, x, y);
+                            if (!pointerHandled) {
+                                activeTouchElements.remove(movePointerId);
+                            }
+                        }
 
-                        if (!handled && activeElement == null) {
+                        if (!pointerHandled) {
                             for (ControlElement element : profile.getElements()) {
                                 if (element.handleTouchMove(movePointerId, x, y)) {
                                     activeTouchElements.put(movePointerId, element);
-                                    handled = true;
+                                    pointerHandled = true;
                                     break;
                                 }
                             }
                         }
-                        if (!handled) touchpadView.onTouchEvent(event);
+
+                        handled |= pointerHandled;
+                        if (!pointerHandled) {
+                            forwardToTouchpad = true;
+                        }
+                    }
+                    updateTouchpadPrimaryButtonState();
+                    if (forwardToTouchpad && touchpadView != null) {
+                        touchpadView.onTouchEvent(event);
                     }
                     break;
                 }
@@ -661,7 +688,7 @@ public class InputControlsView extends View {
                         handled = activeElement.handleTouchUp(pointerId);
                         activeTouchElements.remove(pointerId);
                     }
-                    else {
+                    if (!handled) {
                         for (ControlElement element : profile.getElements()) {
                             if (element.handleTouchUp(pointerId)) {
                                 handled = true;
@@ -669,17 +696,15 @@ public class InputControlsView extends View {
                             }
                         }
                     }
-                    if (!handled) touchpadView.onTouchEvent(event);
+                    updateTouchpadPrimaryButtonState();
+                    if (!handled && touchpadView != null) touchpadView.onTouchEvent(event);
                     break;
                 }
                 case MotionEvent.ACTION_CANCEL: {
-                    for (int i = 0; i < activeTouchElements.size(); i++) {
-                        int activePointerId = activeTouchElements.keyAt(i);
-                        ControlElement activeElement = activeTouchElements.valueAt(i);
-                        if (activeElement != null) activeElement.handleTouchUp(activePointerId);
+                    releaseActiveTouchElements();
+                    if (touchpadView != null) {
+                        touchpadView.onTouchEvent(event);
                     }
-                    activeTouchElements.clear();
-                    touchpadView.onTouchEvent(event);
                     break;
                 }
             }
@@ -781,6 +806,9 @@ public class InputControlsView extends View {
     public void handleInputEvent(ExternalController controller, Binding binding, boolean isActionDown, float offset, boolean sendUpdate) {
         WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
         if (binding.isGamepad()) {
+            if (controller == null && profile == null) {
+                return;
+            }
             GamepadState state = (controller != null) ? controller.remappedState : profile.getGamepadState();
 
             int buttonIdx = binding.ordinal() - Binding.GAMEPAD_BUTTON_A.ordinal();
@@ -821,6 +849,9 @@ public class InputControlsView extends View {
             }
         }
         else {
+            if (xServer == null) {
+                return;
+            }
             if (binding == Binding.MOUSE_MOVE_LEFT || binding == Binding.MOUSE_MOVE_RIGHT) {
                 mouseMoveOffset.x = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_LEFT ? -1 : 1)) : 0;
                 if (isActionDown) createMouseMoveTimer();
@@ -853,6 +884,46 @@ public class InputControlsView extends View {
                     else xServer.injectKeyRelease(binding.keycode);
                 }
             }
+        }
+    }
+
+    private void releaseActiveTouchElements() {
+        if (activeTouchElements.size() == 0) {
+            updateTouchpadPrimaryButtonState();
+            return;
+        }
+
+        for (int i = 0; i < activeTouchElements.size(); i++) {
+            int activePointerId = activeTouchElements.keyAt(i);
+            ControlElement activeElement = activeTouchElements.valueAt(i);
+            if (activeElement != null) {
+                activeElement.handleTouchUp(activePointerId);
+            }
+        }
+        activeTouchElements.clear();
+        updateTouchpadPrimaryButtonState();
+    }
+
+    private void updateTouchpadPrimaryButtonState() {
+        if (touchpadView == null) {
+            return;
+        }
+
+        boolean leftButtonHeld = false;
+        for (int i = 0; i < activeTouchElements.size(); i++) {
+            ControlElement activeElement = activeTouchElements.valueAt(i);
+            if (activeElement != null && activeElement.getBindingAt(0) == Binding.MOUSE_LEFT_BUTTON) {
+                leftButtonHeld = true;
+                break;
+            }
+        }
+        touchpadView.setPointerButtonLeftEnabled(!leftButtonHeld);
+    }
+
+    private void syncVirtualGamepadState() {
+        WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
+        if (winHandler != null) {
+            winHandler.sendGamepadState();
         }
     }
 

--- a/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
@@ -320,13 +320,12 @@ public class InputControlsView extends View {
     }
 
     public synchronized void setProfile(ControlsProfile profile) {
-        releaseActiveTouchElements();
         if (profile != null) {
             this.profile = profile;
             deselectAllElements();
         }
         else this.profile = null;
-        syncVirtualGamepadState();
+        activeTouchElements.clear();
     }
 
     public boolean isShowTouchscreenControls() {
@@ -335,13 +334,6 @@ public class InputControlsView extends View {
 
     public void setShowTouchscreenControls(boolean showTouchscreenControls) {
         this.showTouchscreenControls = showTouchscreenControls;
-        if (!showTouchscreenControls) {
-            releaseActiveTouchElements();
-        } else {
-            updateTouchpadPrimaryButtonState();
-        }
-        syncVirtualGamepadState();
-        invalidate();
     }
 
     public int getPrimaryColor() {
@@ -379,7 +371,6 @@ public class InputControlsView extends View {
 
     public void setTouchpadView(TouchpadView touchpadView) {
         this.touchpadView = touchpadView;
-        updateTouchpadPrimaryButtonState();
     }
 
     public XServer getXServer() {
@@ -391,8 +382,12 @@ public class InputControlsView extends View {
         createMouseMoveTimer();
     }
 
-    public synchronized boolean hasActiveTouchControls() {
-        return activeTouchElements.size() > 0;
+    private boolean hasMouseLeftButtonElement() {
+        if (profile == null) return false;
+        for (ControlElement element : profile.getElements()) {
+            if (element.getBindingAt(0) == Binding.MOUSE_LEFT_BUTTON) return true;
+        }
+        return false;
     }
 
     public int getMaxWidth() {
@@ -401,7 +396,6 @@ public class InputControlsView extends View {
 
     @Override
     protected void onDetachedFromWindow() {
-        releaseActiveTouchElements();
         if (mouseMoveTimer != null)
             mouseMoveTimer.cancel();
         super.onDetachedFromWindow();
@@ -412,26 +406,25 @@ public class InputControlsView extends View {
     }
 
     private void createMouseMoveTimer() {
-        if (xServer == null || profile == null || mouseMoveTimer != null) {
-            return;
-        }
         WinHandler winHandler = xServer.getWinHandler();
-        final float cursorSpeed = profile.getCursorSpeed();
-        mouseMoveTimer = new Timer();
-        mouseMoveTimer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                if (mouseMoveOffset.x != 0 || mouseMoveOffset.y != 0) {// Only move if there's an offsete if there's an offset
-                    if (xServer.isRelativeMouseMovement())
-                        winHandler.mouseEvent(MouseEventFlags.MOVE, (int) (mouseMoveOffset.x * cursorSpeed * 10), (int) (mouseMoveOffset.y * cursorSpeed * 10), 0);
-                    else
-                        xServer.injectPointerMoveDelta(
-                            (int) (mouseMoveOffset.x * cursorSpeed * 10),
-                            (int) (mouseMoveOffset.y * cursorSpeed * 10)
-                    );
+        if (mouseMoveTimer == null && profile != null) {
+            final float cursorSpeed = profile.getCursorSpeed();
+            mouseMoveTimer = new Timer();
+            mouseMoveTimer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    if (mouseMoveOffset.x != 0 || mouseMoveOffset.y != 0) {// Only move if there's an offsete if there's an offset
+                        if (xServer.isRelativeMouseMovement())
+                            winHandler.mouseEvent(MouseEventFlags.MOVE, (int) (mouseMoveOffset.x * cursorSpeed * 10), (int) (mouseMoveOffset.y * cursorSpeed * 10), 0);
+                        else
+                            xServer.injectPointerMoveDelta(
+                                (int) (mouseMoveOffset.x * cursorSpeed * 10),
+                                (int) (mouseMoveOffset.y * cursorSpeed * 10)
+                        );
+                    }
                 }
-            }
-        }, 0, 1000 / 60); // 60 FPS
+            }, 0, 1000 / 60); // 60 FPS
+        }
     }
 
 
@@ -602,10 +595,6 @@ public class InputControlsView extends View {
             }
         }
 
-        if (!editMode && (!showTouchscreenControls || profile == null)) {
-            return touchpadView != null ? touchpadView.onTouchEvent(event) : super.onTouchEvent(event);
-        }
-
         if (!editMode && profile != null) {
             int actionIndex = event.getActionIndex();
             int pointerId = event.getPointerId(actionIndex);
@@ -618,12 +607,11 @@ public class InputControlsView extends View {
                     float x = event.getX(actionIndex);
                     float y = event.getY(actionIndex);
 
-                    updateTouchpadPrimaryButtonState();
+                    touchpadView.setPointerButtonLeftEnabled(!hasMouseLeftButtonElement());
                     for (ControlElement element : profile.getElements()) {
                         if (element.handleTouchDown(pointerId, x, y)) {
                             handled = true;
                             activeTouchElements.put(pointerId, element);
-                            updateTouchpadPrimaryButtonState();
 
                             // Trigger haptic feedback for input controls
                             if (hapticsEnabled) {
@@ -641,43 +629,28 @@ public class InputControlsView extends View {
                             break;
                         }
                     }
-                    if (!handled && touchpadView != null) touchpadView.onTouchEvent(event);
+                    if (!handled) touchpadView.onTouchEvent(event);
                     break;
                 }
                 case MotionEvent.ACTION_MOVE: {
-                    boolean forwardToTouchpad = false;
                     for (byte i = 0, count = (byte)event.getPointerCount(); i < count; i++) {
                         int movePointerId = event.getPointerId(i);
                         float x = event.getX(i);
                         float y = event.getY(i);
-                        boolean pointerHandled = false;
 
                         ControlElement activeElement = activeTouchElements.get(movePointerId);
-                        if (activeElement != null) {
-                            pointerHandled = activeElement.handleTouchMove(movePointerId, x, y);
-                            if (!pointerHandled) {
-                                activeTouchElements.remove(movePointerId);
-                            }
-                        }
+                        handled = activeElement != null && activeElement.handleTouchMove(movePointerId, x, y);
 
-                        if (!pointerHandled) {
+                        if (!handled && activeElement == null) {
                             for (ControlElement element : profile.getElements()) {
                                 if (element.handleTouchMove(movePointerId, x, y)) {
                                     activeTouchElements.put(movePointerId, element);
-                                    pointerHandled = true;
+                                    handled = true;
                                     break;
                                 }
                             }
                         }
-
-                        handled |= pointerHandled;
-                        if (!pointerHandled) {
-                            forwardToTouchpad = true;
-                        }
-                    }
-                    updateTouchpadPrimaryButtonState();
-                    if (forwardToTouchpad && touchpadView != null) {
-                        touchpadView.onTouchEvent(event);
+                        if (!handled) touchpadView.onTouchEvent(event);
                     }
                     break;
                 }
@@ -688,7 +661,7 @@ public class InputControlsView extends View {
                         handled = activeElement.handleTouchUp(pointerId);
                         activeTouchElements.remove(pointerId);
                     }
-                    if (!handled) {
+                    else {
                         for (ControlElement element : profile.getElements()) {
                             if (element.handleTouchUp(pointerId)) {
                                 handled = true;
@@ -696,15 +669,17 @@ public class InputControlsView extends View {
                             }
                         }
                     }
-                    updateTouchpadPrimaryButtonState();
-                    if (!handled && touchpadView != null) touchpadView.onTouchEvent(event);
+                    if (!handled) touchpadView.onTouchEvent(event);
                     break;
                 }
                 case MotionEvent.ACTION_CANCEL: {
-                    releaseActiveTouchElements();
-                    if (touchpadView != null) {
-                        touchpadView.onTouchEvent(event);
+                    for (int i = 0; i < activeTouchElements.size(); i++) {
+                        int activePointerId = activeTouchElements.keyAt(i);
+                        ControlElement activeElement = activeTouchElements.valueAt(i);
+                        if (activeElement != null) activeElement.handleTouchUp(activePointerId);
                     }
+                    activeTouchElements.clear();
+                    touchpadView.onTouchEvent(event);
                     break;
                 }
             }
@@ -806,9 +781,6 @@ public class InputControlsView extends View {
     public void handleInputEvent(ExternalController controller, Binding binding, boolean isActionDown, float offset, boolean sendUpdate) {
         WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
         if (binding.isGamepad()) {
-            if (controller == null && profile == null) {
-                return;
-            }
             GamepadState state = (controller != null) ? controller.remappedState : profile.getGamepadState();
 
             int buttonIdx = binding.ordinal() - Binding.GAMEPAD_BUTTON_A.ordinal();
@@ -849,9 +821,6 @@ public class InputControlsView extends View {
             }
         }
         else {
-            if (xServer == null) {
-                return;
-            }
             if (binding == Binding.MOUSE_MOVE_LEFT || binding == Binding.MOUSE_MOVE_RIGHT) {
                 mouseMoveOffset.x = isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_LEFT ? -1 : 1)) : 0;
                 if (isActionDown) createMouseMoveTimer();
@@ -884,46 +853,6 @@ public class InputControlsView extends View {
                     else xServer.injectKeyRelease(binding.keycode);
                 }
             }
-        }
-    }
-
-    private void releaseActiveTouchElements() {
-        if (activeTouchElements.size() == 0) {
-            updateTouchpadPrimaryButtonState();
-            return;
-        }
-
-        for (int i = 0; i < activeTouchElements.size(); i++) {
-            int activePointerId = activeTouchElements.keyAt(i);
-            ControlElement activeElement = activeTouchElements.valueAt(i);
-            if (activeElement != null) {
-                activeElement.handleTouchUp(activePointerId);
-            }
-        }
-        activeTouchElements.clear();
-        updateTouchpadPrimaryButtonState();
-    }
-
-    private void updateTouchpadPrimaryButtonState() {
-        if (touchpadView == null) {
-            return;
-        }
-
-        boolean leftButtonHeld = false;
-        for (int i = 0; i < activeTouchElements.size(); i++) {
-            ControlElement activeElement = activeTouchElements.valueAt(i);
-            if (activeElement != null && activeElement.getBindingAt(0) == Binding.MOUSE_LEFT_BUTTON) {
-                leftButtonHeld = true;
-                break;
-            }
-        }
-        touchpadView.setPointerButtonLeftEnabled(!leftButtonHeld);
-    }
-
-    private void syncVirtualGamepadState() {
-        WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
-        if (winHandler != null) {
-            winHandler.sendGamepadState();
         }
     }
 

--- a/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
@@ -673,8 +673,8 @@ public class WinHandler {
         });
     }
 
-    private void queueGamepadStateForClients(final boolean enabled, final int gamepadId, final GamepadState stateSnapshot, final boolean remapDinputButtons, final boolean applyGyro) {
-        if (!initReceived || gamepadClients.isEmpty() || xinputDisabled) {
+    private void queueGamepadStateForClients(final boolean enabled, final int gamepadId, final GamepadState stateSnapshot, final boolean remapDinputButtons, final boolean applyGyro, final boolean allowWhenXInputDisabled) {
+        if (!initReceived || gamepadClients.isEmpty() || (xinputDisabled && !allowWhenXInputDisabled)) {
             return;
         }
 
@@ -693,6 +693,18 @@ public class WinHandler {
                 sendPacket(port);
             });
         }
+    }
+
+    private void clearMappedBuffer(MappedByteBuffer buffer) {
+        if (buffer == null) {
+            return;
+        }
+
+        buffer.position(0);
+        for (int i = 0; i < 64; i++) {
+            buffer.put((byte) 0);
+        }
+        buffer.position(0);
     }
 
     private int assignSlot(int deviceId) {
@@ -809,8 +821,8 @@ public class WinHandler {
         final boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad()
                 && isTouchscreenControlsVisible();
         final boolean enabled = currentController != null || useVirtualGamepad;
-        final int gamepadId;
         final GamepadState stateSnapshot = new GamepadState();
+        final int gamepadId;
 
         if (enabled) {
             GamepadState state = useVirtualGamepad ? profile.getGamepadState() : currentController.state;
@@ -832,15 +844,13 @@ public class WinHandler {
                 writeStateToMappedBuffer(stateSnapshot, gamepadBuffer, true, 0);
             }
         } else {
-            gamepadId = 0;
             releaseSlot(OSC_DEVICE_ID);
-        }
-
-        if (!enabled) {
+            clearMappedBuffer(gamepadBuffer);
+            queueGamepadStateForClients(false, 0, stateSnapshot, false, false, true);
             return;
         }
 
-        queueGamepadStateForClients(true, gamepadId, stateSnapshot, useVirtualGamepad, true);
+        queueGamepadStateForClients(true, gamepadId, stateSnapshot, useVirtualGamepad, true, useVirtualGamepad);
     }
 
     public void sendGamepadState(ExternalController controller) {
@@ -874,7 +884,7 @@ public class WinHandler {
 
         GamepadState snapshot = new GamepadState();
         snapshot.copy(sourceState);
-        queueGamepadStateForClients(true, controller.getDeviceId(), snapshot, false, true);
+        queueGamepadStateForClients(true, controller.getDeviceId(), snapshot, false, true, false);
     }
 
     /**

--- a/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
@@ -497,7 +497,7 @@ public class WinHandler {
                 boolean isXInput = receiveData.get() == 1;
                 boolean notify = receiveData.get() == 1;
                 final ControlsProfile profile = getActiveProfile();
-                boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad();
+                boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad() && shouldExposeVirtualGamepadToClients();
 
                 if (!useVirtualGamepad && (currentController == null || !currentController.isConnected())) {
                     currentController = ExternalController.getController(0);
@@ -563,7 +563,7 @@ public class WinHandler {
             case RequestCodes.GET_GAMEPAD_STATE: {
                 int gamepadId = receiveData.getInt();
                 final ControlsProfile profile = getActiveProfile();
-                boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad();
+                boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad() && shouldExposeVirtualGamepadToClients();
                 if (xinputDisabled && !useVirtualGamepad)
                     return;
                 final boolean enabled = currentController != null || useVirtualGamepad;
@@ -820,6 +820,7 @@ public class WinHandler {
         final ControlsProfile profile = getActiveProfile();
         final boolean useVirtualGamepad = profile != null && profile.isVirtualGamepad()
                 && isTouchscreenControlsVisible();
+        final boolean exposeVirtualGamepadToClients = useVirtualGamepad && shouldExposeVirtualGamepadToClients();
         final boolean enabled = currentController != null || useVirtualGamepad;
         final GamepadState stateSnapshot = new GamepadState();
         final int gamepadId;
@@ -850,7 +851,11 @@ public class WinHandler {
             return;
         }
 
-        queueGamepadStateForClients(true, gamepadId, stateSnapshot, useVirtualGamepad, true, useVirtualGamepad);
+        if (!useVirtualGamepad || exposeVirtualGamepadToClients) {
+            queueGamepadStateForClients(true, gamepadId, stateSnapshot, exposeVirtualGamepadToClients, true, exposeVirtualGamepadToClients);
+        } else {
+            queueGamepadStateForClients(false, 0, stateSnapshot, false, false, true);
+        }
     }
 
     public void sendGamepadState(ExternalController controller) {
@@ -979,9 +984,13 @@ public class WinHandler {
         writeStateToMappedBuffer(state, gamepadBuffer, true, 0);
     }
 
+    private boolean shouldExposeVirtualGamepadToClients() {
+        return activity == null || !activity.isArm64ECWine();
+    }
+
     private boolean useVirtualGamepad() {
         ControlsProfile profile = getActiveProfile();
-        return profile != null && profile.isVirtualGamepad();
+        return profile != null && profile.isVirtualGamepad() && shouldExposeVirtualGamepadToClients();
     }
 
     public void setXInputDisabled(boolean disabled) {

--- a/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
+++ b/app/src/main/java/com/winlator/cmod/winhandler/WinHandler.java
@@ -673,8 +673,8 @@ public class WinHandler {
         });
     }
 
-    private void queueGamepadStateForClients(final boolean enabled, final int gamepadId, final GamepadState stateSnapshot, final boolean remapDinputButtons, final boolean applyGyro, final boolean allowWhenXInputDisabled) {
-        if (!initReceived || gamepadClients.isEmpty() || (xinputDisabled && !allowWhenXInputDisabled)) {
+    private void queueGamepadStateForClients(final boolean enabled, final int gamepadId, final GamepadState stateSnapshot, final boolean remapDinputButtons, final boolean applyGyro) {
+        if (!initReceived || gamepadClients.isEmpty() || xinputDisabled) {
             return;
         }
 
@@ -693,18 +693,6 @@ public class WinHandler {
                 sendPacket(port);
             });
         }
-    }
-
-    private void clearMappedBuffer(MappedByteBuffer buffer) {
-        if (buffer == null) {
-            return;
-        }
-
-        buffer.position(0);
-        for (int i = 0; i < 64; i++) {
-            buffer.put((byte) 0);
-        }
-        buffer.position(0);
     }
 
     private int assignSlot(int deviceId) {
@@ -822,8 +810,8 @@ public class WinHandler {
                 && isTouchscreenControlsVisible();
         final boolean exposeVirtualGamepadToClients = useVirtualGamepad && shouldExposeVirtualGamepadToClients();
         final boolean enabled = currentController != null || useVirtualGamepad;
-        final GamepadState stateSnapshot = new GamepadState();
         final int gamepadId;
+        final GamepadState stateSnapshot = new GamepadState();
 
         if (enabled) {
             GamepadState state = useVirtualGamepad ? profile.getGamepadState() : currentController.state;
@@ -845,16 +833,16 @@ public class WinHandler {
                 writeStateToMappedBuffer(stateSnapshot, gamepadBuffer, true, 0);
             }
         } else {
+            gamepadId = 0;
             releaseSlot(OSC_DEVICE_ID);
-            clearMappedBuffer(gamepadBuffer);
-            queueGamepadStateForClients(false, 0, stateSnapshot, false, false, true);
+        }
+
+        if (!enabled) {
             return;
         }
 
         if (!useVirtualGamepad || exposeVirtualGamepadToClients) {
-            queueGamepadStateForClients(true, gamepadId, stateSnapshot, exposeVirtualGamepadToClients, true, exposeVirtualGamepadToClients);
-        } else {
-            queueGamepadStateForClients(false, 0, stateSnapshot, false, false, true);
+            queueGamepadStateForClients(true, gamepadId, stateSnapshot, useVirtualGamepad, true);
         }
     }
 
@@ -889,7 +877,7 @@ public class WinHandler {
 
         GamepadState snapshot = new GamepadState();
         snapshot.copy(sourceState);
-        queueGamepadStateForClients(true, controller.getDeviceId(), snapshot, false, true, false);
+        queueGamepadStateForClients(true, controller.getDeviceId(), snapshot, false, true);
     }
 
     /**


### PR DESCRIPTION
- Properly release active touch elements on profile switch, visibility toggle, and detach
- Dynamically update touchpad primary button state based on active control elements
- Add null safety for touchpadView throughout touch event handling
- Defer hide timeout when touch controls are actively in use
- Clear gamepad buffer and notify clients on virtual gamepad disable
- Add allowWhenXInputDisabled flag for proper gamepad state propagation