### PR TITLE
feat: expand FPS monitor in side menu with transparency and  toggles

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -34,6 +34,9 @@ import android.widget.FrameLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -219,6 +222,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
     private boolean isPaused = false;
     private boolean isRelativeMouseMovement = false;
     private boolean isNativeRenderingEnabled = true;
+
+    private float hudTransparency = 1.0f;
+    private boolean[] hudElements = new boolean[]{true, true, true, true, true, true};
 
     // Inside the XServerDisplayActivity class
     private SensorManager sensorManager;
@@ -555,6 +561,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         String screenSize = Container.DEFAULT_SCREEN_SIZE;
         containerManager = new ContainerManager(this);
         container = containerManager.getContainerById(getIntent().getIntExtra("container_id", 0));
+        loadHUDSettings();
 
         // Determine launch target from intent extras and URI fallback.
         int containerId = getIntent().getIntExtra("container_id", 0);
@@ -1830,14 +1837,83 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 enableLogsMenu,
                 isNativeRenderingEnabled,
                 getString(R.string.session_xserver_native_rendering),
-                getString(isNativeRenderingEnabled ? R.string.session_xserver_native_rendering_enabled : R.string.session_xserver_native_rendering_disabled)
+                getString(isNativeRenderingEnabled ? R.string.session_xserver_native_rendering_enabled : R.string.session_xserver_native_rendering_disabled),
+                hudTransparency,
+                hudElements
         );
         XServerDrawerMenuKt.setupXServerDrawerComposeView(
                 navigationComposeView,
                 state,
                 this,
-                itemId -> handleDrawerAction(itemId)
+                new XServerDrawerActionListener() {
+                    @Override
+                    public void onActionSelected(int itemId) {
+                        handleDrawerAction(itemId);
+                    }
+
+                    @Override
+                    public void onHUDElementToggled(int index, boolean enabled) {
+                        hudElements[index] = enabled;
+                        if (frameRating != null) frameRating.toggleElement(index, enabled);
+                        saveHUDSettings();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onHUDTransparencyChanged(float transparency) {
+                        hudTransparency = transparency;
+                        if (frameRating != null) frameRating.setHudAlpha(transparency);
+                        saveHUDSettings();
+                        renderDrawerMenu();
+                    }
+                }
         );
+    }
+
+    private void loadHUDSettings() {
+        if (container == null) return;
+        String json = container.getExtra("hudSettings");
+        if (json != null && !json.isEmpty()) {
+            try {
+                JSONObject obj = new JSONObject(json);
+                hudTransparency = (float) obj.optDouble("transparency", 1.0);
+                hudElements[0] = obj.optBoolean("showFPS", true);
+                hudElements[1] = obj.optBoolean("showRenderer", true);
+                hudElements[2] = obj.optBoolean("showGPU", true);
+                hudElements[3] = obj.optBoolean("showCpuRam", true);
+                hudElements[4] = obj.optBoolean("showBattTemp", true);
+                hudElements[5] = obj.optBoolean("showGraph", true);
+            } catch (JSONException e) {
+                Log.e("XServerDisplayActivity", "Failed to load HUD settings", e);
+            }
+        }
+    }
+
+    private void saveHUDSettings() {
+        if (container == null) return;
+        try {
+            JSONObject obj = new JSONObject();
+            obj.put("transparency", hudTransparency);
+            obj.put("showFPS", hudElements[0]);
+            obj.put("showRenderer", hudElements[1]);
+            obj.put("showGPU", hudElements[2]);
+            obj.put("showCpuRam", hudElements[3]);
+            obj.put("showBattTemp", hudElements[4]);
+            obj.put("showGraph", hudElements[5]);
+            container.putExtra("hudSettings", obj.toString());
+            container.saveData();
+        } catch (JSONException e) {
+            Log.e("XServerDisplayActivity", "Failed to save HUD settings", e);
+        }
+    }
+
+    private void applyHUDSettings() {
+        if (frameRating != null) {
+            frameRating.setHudAlpha(hudTransparency);
+            for (int i = 0; i < hudElements.length; i++) {
+                frameRating.toggleElement(i, hudElements[i]);
+            }
+        }
     }
 
     @SuppressLint("SourceLockedOrientationActivity")
@@ -1857,12 +1933,16 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     frameRating.setRenderer(lastRendererName);
                     if (lastGpuName != null) frameRating.setGpuName(lastGpuName);
                     frameRating.setVisibility(View.GONE);
+                    applyHUDSettings();
                     rootView.addView(frameRating);
                 }
                 boolean isFpsVisible = frameRating.getVisibility() == View.VISIBLE;
                 boolean becomingVisible = !isFpsVisible;
                 frameRating.setVisibility(becomingVisible ? View.VISIBLE : View.GONE);
-                if (becomingVisible) syncFrameRatingWithExistingWindows();
+                if (becomingVisible) {
+                    syncFrameRatingWithExistingWindows();
+                    applyHUDSettings();
+                }
                 
                 if (container != null) {
                     container.setShowFPS(becomingVisible);

--- a/app/src/main/java/com/winlator/cmod/XServerDrawerMenu.kt
+++ b/app/src/main/java/com/winlator/cmod/XServerDrawerMenu.kt
@@ -43,6 +43,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
+
 data class XServerDrawerItem(
     val itemId: Int,
     val title: String,
@@ -53,10 +60,14 @@ data class XServerDrawerItem(
 
 data class XServerDrawerState(
     val items: List<XServerDrawerItem>,
+    val hudTransparency: Float = 1.0f,
+    val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
 )
 
-fun interface XServerDrawerActionListener {
+interface XServerDrawerActionListener {
     fun onActionSelected(itemId: Int)
+    fun onHUDElementToggled(index: Int, enabled: Boolean)
+    fun onHUDTransparencyChanged(transparency: Float)
 }
 
 fun buildXServerDrawerState(
@@ -70,6 +81,8 @@ fun buildXServerDrawerState(
     nativeRenderingEnabled: Boolean,
     nativeRenderingTitle: String,
     nativeRenderingSubtitle: String,
+    hudTransparency: Float = 1.0f,
+    hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
 ): XServerDrawerState {
     val items = mutableListOf(
         XServerDrawerItem(
@@ -170,7 +183,7 @@ fun buildXServerDrawerState(
         iconRes = R.drawable.icon_exit,
     )
 
-    return XServerDrawerState(items)
+    return XServerDrawerState(items, hudTransparency, hudElements)
 }
 
 fun setupXServerDrawerComposeView(
@@ -189,7 +202,7 @@ fun setupXServerDrawerComposeView(
                 onSurface = Color(0xFFE6EDF3),
             )
         ) {
-            XServerDrawerContent(state = state, onActionSelected = listener::onActionSelected)
+            XServerDrawerContent(state = state, listener = listener)
         }
     }
 }
@@ -197,7 +210,7 @@ fun setupXServerDrawerComposeView(
 @Composable
 private fun XServerDrawerContent(
     state: XServerDrawerState,
-    onActionSelected: (Int) -> Unit,
+    listener: XServerDrawerActionListener,
 ) {
     Surface(
         modifier = Modifier
@@ -215,9 +228,119 @@ private fun XServerDrawerContent(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             state.items.forEach { item ->
-                XServerDrawerRow(item = item, onClick = { onActionSelected(item.itemId) })
+                XServerDrawerRow(item = item, onClick = { listener.onActionSelected(item.itemId) })
+                if (item.itemId == R.id.main_menu_fps_monitor && item.active) {
+                    XServerHUDSettingsExpanded(state, listener)
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun XServerHUDSettingsExpanded(
+    state: XServerDrawerState,
+    listener: XServerDrawerActionListener,
+) {
+    val card = Color(0xFF1C2333)
+    val accent = Color(0xFF2F81F7)
+    val textSecondary = Color(0xFF8B949E)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(card)
+            .padding(12.dp)
+    ) {
+        // Transparency Slider
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Alpha ${(state.hudTransparency * 100).toInt()}%",
+                color = textSecondary,
+                fontSize = 11.sp,
+                modifier = Modifier.width(70.dp)
+            )
+            Slider(
+                value = state.hudTransparency,
+                onValueChange = { listener.onHUDTransparencyChanged(it) },
+                valueRange = 0.1f..1f,
+                modifier = Modifier.weight(1f),
+                colors = SliderDefaults.colors(
+                    thumbColor = accent,
+                    activeTrackColor = accent,
+                    inactiveTrackColor = accent.copy(alpha = 0.24f)
+                )
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        // Toggles Grid (3 columns, 2 rows)
+        val elementNames = listOf("FPS", "API", "GPU", "CPU", "BAT", "Graph")
+        
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            for (row in 0..1) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    for (col in 0..2) {
+                        val index = row * 3 + col
+                        if (index < elementNames.size) {
+                            HUDCheckmarkToggle(
+                                label = elementNames[index],
+                                checked = state.hudElements[index],
+                                onCheckedChange = { listener.onHUDElementToggled(index, it) },
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HUDCheckmarkToggle(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val textPrimary = Color(0xFFE6EDF3)
+    val accent = Color(0xFF2F81F7)
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.size(24.dp),
+            colors = CheckboxDefaults.colors(
+                checkedColor = accent,
+                uncheckedColor = Color(0xFF30363D),
+                checkmarkColor = Color.White
+            )
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = label,
+            color = textPrimary,
+            fontSize = 11.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 


### PR DESCRIPTION
Adds side menu options to disable and enable specific elements of the Hud.
Adds transparency slider.