### PR TITLE
Redesign Setup Wizard with unified component browser

### DIFF
--- a/app/src/main/java/com/winlator/cmod/SetupWizardActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/SetupWizardActivity.kt
@@ -15,17 +15,42 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -33,18 +58,16 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.FragmentContainerView
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -54,6 +77,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -61,6 +87,7 @@ import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.googlefonts.GoogleFont
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
@@ -80,13 +107,6 @@ import com.winlator.cmod.core.OnExtractFileListener
 import com.winlator.cmod.core.TarCompressorUtils
 import com.winlator.cmod.core.TarCompressorUtils.Type
 import com.winlator.cmod.core.WineInfo
-import com.winlator.cmod.epic.service.EpicAuthManager
-import com.winlator.cmod.epic.ui.auth.EpicOAuthActivity
-import com.winlator.cmod.gog.service.GOGAuthManager
-import com.winlator.cmod.gog.service.GOGService
-import com.winlator.cmod.gog.ui.auth.GOGOAuthActivity
-import com.winlator.cmod.steam.SteamLoginActivity
-import com.winlator.cmod.steam.service.SteamService
 import com.winlator.cmod.xenvironment.ImageFs
 import com.winlator.cmod.xenvironment.ImageFsInstaller
 import kotlinx.coroutines.Dispatchers
@@ -96,7 +116,13 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.Executors
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 import java.util.concurrent.atomic.AtomicLong
+
+private data class Particle(val x: Float, val speed: Float, val size: Float, val phaseOffset: Float)
+private data class TabInfo(val key: String, val label: String, val indicatorColor: Color, val highlight: Boolean = false)
 
 class SetupWizardActivity : FragmentActivity() {
 
@@ -307,12 +333,6 @@ class SetupWizardActivity : FragmentActivity() {
         val progress: Float? = null
     )
 
-    private data class StoreLoginState(
-        val steam: Boolean = false,
-        val epic: Boolean = false,
-        val gog: Boolean = false
-    )
-
     private val recommendedComponents = listOf(
         PackageSpec(
             label = "DXVK 2.7.1 GPLAsync",
@@ -370,6 +390,17 @@ class SetupWizardActivity : FragmentActivity() {
         persistContainerId = ::saveDefaultX86ContainerId
     )
 
+    private val recommendedUrls: Set<String> by lazy {
+        buildSet {
+            recommendedComponents.forEach { add(it.url) }
+            add(x86ProtonSpec.fallbackUrl)
+            add(arm64ProtonSpec.fallbackUrl)
+        }
+    }
+
+    private fun isRecommendedSpec(spec: RemotePackageSpec): Boolean =
+        spec.remoteUrl in recommendedUrls
+
     private val arm64ProtonSpec = RuntimeSpec(
         label = "Recommended ARM64EC",
         archToken = "arm64ec",
@@ -387,21 +418,15 @@ class SetupWizardActivity : FragmentActivity() {
     private val notifDenied = mutableStateOf(false)
 
     private val pageIndex = mutableIntStateOf(0)
-    private val isAdvancedMode = mutableStateOf(false)
     private val imageFsInstalling = mutableStateOf(false)
     private val imageFsProgress = mutableIntStateOf(0)
     private val imageFsDone = mutableStateOf(false)
-    private val recommendedComponentsDone = mutableStateOf(false)
-    private val driversVisited = mutableStateOf(false)
-    private val x86ProtonDone = mutableStateOf(false)
-    private val arm64ProtonDone = mutableStateOf(false)
     private val defaultX86SettingsDone = mutableStateOf(false)
     private val defaultArmSettingsDone = mutableStateOf(false)
     private val defaultX86ContainerName = mutableStateOf("")
     private val defaultArmContainerName = mutableStateOf("")
     private val wizardError = mutableStateOf<String?>(null)
     private val transferState = mutableStateOf<TransferState?>(null)
-    private val storeLoginState = mutableStateOf(StoreLoginState())
     private val advancedProfiles = mutableStateListOf<RemotePackageSpec>()
     private val advancedInstalledSet = mutableStateListOf<String>()
     private val advancedContainerNames = mutableStateListOf<String>()
@@ -446,49 +471,6 @@ class SetupWizardActivity : FragmentActivity() {
         refreshWizardState()
     }
 
-    private val steamLoginLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        refreshStoreState()
-    }
-
-    private val gogLoginLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val code = result.data?.getStringExtra(GOGOAuthActivity.EXTRA_AUTH_CODE)
-            if (!code.isNullOrBlank()) {
-                lifecycleScope.launch {
-                    val authResult = GOGAuthManager.authenticateWithCode(this@SetupWizardActivity, code)
-                    if (authResult.isSuccess) {
-                        GOGService.start(this@SetupWizardActivity)
-                    }
-                    refreshStoreState()
-                }
-            } else {
-                refreshStoreState()
-            }
-        } else {
-            refreshStoreState()
-        }
-    }
-
-    private val epicLoginLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val code = result.data?.getStringExtra(EpicOAuthActivity.EXTRA_AUTH_CODE)
-            lifecycleScope.launch {
-                if (!code.isNullOrBlank()) {
-                    EpicAuthManager.authenticateWithCode(this@SetupWizardActivity, code)
-                }
-                refreshStoreState()
-            }
-        } else {
-            refreshStoreState()
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -508,12 +490,13 @@ class SetupWizardActivity : FragmentActivity() {
         storageGranted.value = hasStoragePermission()
         notifGranted.value = hasNotificationPermissionSilently()
         refreshWizardState()
+        loadAdvancedProfiles()
 
         setContent {
             MaterialTheme(
                 colorScheme = darkColorScheme(
                     primary = Color(0xFF57CBDE),
-                    secondary = Color(0xFF3FB950),
+                    secondary = Color(0xFF3B82F6),
                     background = Color(0xFF0D1117),
                     surface = Color(0xFF161B22)
                 )
@@ -538,27 +521,12 @@ class SetupWizardActivity : FragmentActivity() {
         imageFsDone.value = imageFs.isValid && imageFs.version >= ImageFsInstaller.LATEST_VERSION.toInt()
 
         val preferences = prefs(this)
-        val contentsManager = ContentsManager(this)
-        contentsManager.syncContents()
-
-        val referenceRecommendedComponents = getCachedRecommendedComponentSpecs().ifEmpty { recommendedComponents }
-        recommendedComponentsDone.value =
-            preferences.getBoolean(KEY_RECOMMENDED_COMPONENTS_DONE, false) ||
-                referenceRecommendedComponents.all { isPackageInstalled(contentsManager, it) }
-        if (recommendedComponentsDone.value) {
-            preferences.edit().putBoolean(KEY_RECOMMENDED_COMPONENTS_DONE, true).apply()
-        }
-
-        driversVisited.value = preferences.getBoolean(KEY_DRIVERS_VISITED, false)
-
         val containerManager = ContainerManager(this)
         val x86Container = containerManager.getContainerById(getDefaultX86ContainerId(this))
             ?.takeIf { isContainerUsable(this, it) }
         val armContainer = containerManager.getContainerById(getDefaultArm64ContainerId(this))
             ?.takeIf { isContainerUsable(this, it) }
 
-        x86ProtonDone.value = x86Container != null
-        arm64ProtonDone.value = armContainer != null
         defaultX86ContainerName.value = x86Container?.name ?: ""
         defaultArmContainerName.value = armContainer?.name ?: ""
 
@@ -566,16 +534,6 @@ class SetupWizardActivity : FragmentActivity() {
             preferences.getBoolean(KEY_DEFAULT_X86_SETTINGS_DONE, false) && x86Container != null
         defaultArmSettingsDone.value =
             preferences.getBoolean(KEY_DEFAULT_ARM64_SETTINGS_DONE, false) && armContainer != null
-
-        refreshStoreState()
-    }
-
-    private fun refreshStoreState() {
-        storeLoginState.value = StoreLoginState(
-            steam = SteamService.isLoggedIn,
-            epic = EpicAuthManager.isLoggedIn(this),
-            gog = GOGAuthManager.isLoggedIn(this)
-        )
     }
 
     private fun hasStoragePermission(): Boolean {
@@ -750,82 +708,6 @@ class SetupWizardActivity : FragmentActivity() {
         }
     }
 
-    private fun installRecommendedComponents() {
-        if (transferState.value != null || recommendedComponentsDone.value) return
-
-        lifecycleScope.launch {
-            wizardError.value = null
-            val success = withContext(Dispatchers.IO) {
-                try {
-                    val specs = resolveRecommendedComponentSpecs()
-                    specs.forEachIndexed { index, spec ->
-                        val profile = downloadAndInstallPackage(spec, index, specs.size)
-                        if (profile == null) return@withContext false
-                    }
-                    prefs(this@SetupWizardActivity).edit()
-                        .putBoolean(KEY_RECOMMENDED_COMPONENTS_DONE, true)
-                        .apply()
-                    true
-                } catch (e: Exception) {
-                    wizardError.value = "Component install failed: ${e.message}"
-                    false
-                } finally {
-                    transferState.value = null
-                }
-            }
-            if (success) refreshWizardState()
-        }
-    }
-
-    private fun installRecommendedProton(spec: RuntimeSpec) {
-        if (transferState.value != null) return
-
-        lifecycleScope.launch {
-            wizardError.value = null
-            val created = withContext(Dispatchers.IO) {
-                try {
-                    val resolvedSpec = resolveRecommendedRuntimeSpec(spec)
-                    transferState.value = TransferState(
-                        title = spec.label,
-                        detail = getString(R.string.downloads_queue_preparing_download),
-                        currentIndex = 0,
-                        total = 2
-                    )
-
-                    val downloaded = downloadFileToCache(
-                        label = spec.label,
-                        url = resolvedSpec.url,
-                        currentIndex = 1,
-                        total = 2
-                    )
-                    if (downloaded == null) return@withContext null
-
-                    transferState.value = TransferState(
-                        title = spec.label,
-                        detail = getString(R.string.downloads_queue_installing_package),
-                        currentIndex = 2,
-                        total = 2,
-                        progress = null
-                    )
-
-                    val profile = installDownloadedPackage(downloaded, resolvedSpec.url)
-                    downloaded.delete()
-                    if (profile == null) return@withContext null
-
-                    val container = ensureContainerForProfile(profile, spec.containerDisplayName(profile))
-                    spec.persistContainerId(this@SetupWizardActivity, container.id)
-                    container
-                } catch (e: Exception) {
-                    wizardError.value = "${spec.label} failed: ${e.message}"
-                    null
-                } finally {
-                    transferState.value = null
-                }
-            }
-            if (created != null) refreshWizardState()
-        }
-    }
-
     private suspend fun downloadAndInstallPackage(
         spec: PackageSpec,
         index: Int,
@@ -833,7 +715,7 @@ class SetupWizardActivity : FragmentActivity() {
     ): ContentProfile? {
         transferState.value = TransferState(
             title = getString(R.string.setup_wizard_recommended_components),
-            detail = "Downloading ${spec.label}",
+            detail = getString(R.string.setup_wizard_downloading, spec.label),
             currentIndex = index + 1,
             total = total,
             progress = 0f
@@ -846,9 +728,19 @@ class SetupWizardActivity : FragmentActivity() {
             total = total
         ) ?: return null
 
+        // Show 100% briefly so the bar visually completes before switching
         transferState.value = TransferState(
             title = getString(R.string.setup_wizard_recommended_components),
-            detail = "Installing ${spec.label}",
+            detail = getString(R.string.setup_wizard_downloading, spec.label),
+            currentIndex = index + 1,
+            total = total,
+            progress = 1f
+        )
+        kotlinx.coroutines.delay(500)
+
+        transferState.value = TransferState(
+            title = getString(R.string.setup_wizard_recommended_components),
+            detail = getString(R.string.setup_wizard_installing_package, spec.label),
             currentIndex = index + 1,
             total = total,
             progress = null
@@ -870,7 +762,7 @@ class SetupWizardActivity : FragmentActivity() {
         val listener = Downloader.DownloadListener { downloadedBytes, totalBytes ->
             transferState.value = TransferState(
                 title = transferState.value?.title ?: label,
-                detail = "Downloading $label",
+                detail = getString(R.string.setup_wizard_downloading, label),
                 currentIndex = currentIndex,
                 total = total,
                 progress = if (totalBytes > 0) {
@@ -1221,18 +1113,27 @@ class SetupWizardActivity : FragmentActivity() {
         }
     }
 
-    private fun enterAdvancedMode() {
-        isAdvancedMode.value = true
-        pageIndex.intValue = 1
-        loadAdvancedProfiles()
-    }
-
     private fun loadAdvancedProfiles() {
         if (advancedProfiles.isNotEmpty()) return
         lifecycleScope.launch {
             val profiles = withContext(Dispatchers.IO) {
                 Downloader.clearFileMap()
-                fetchRecommendedPackages()
+                // Fetch recommended (default.json) for marking recommendations
+                val recommended = fetchRecommendedPackages()
+                // Fetch full catalog (content.json) for all categories
+                val fullCatalog = parseRecommendedPackages(
+                    Downloader.downloadString(ContentsManager.REMOTE_PROFILES)
+                )
+                // Merge: start with recommended, then add any full catalog entries not already present
+                val seen = recommended.map { it.remoteUrl }.toMutableSet()
+                val merged = recommended.toMutableList()
+                for (spec in fullCatalog) {
+                    if (spec.remoteUrl !in seen) {
+                        seen.add(spec.remoteUrl)
+                        merged.add(spec)
+                    }
+                }
+                merged
             }
             advancedProfiles.clear()
             advancedProfiles.addAll(profiles)
@@ -1245,16 +1146,86 @@ class SetupWizardActivity : FragmentActivity() {
         manager.syncContents()
         advancedInstalledSet.clear()
         advancedProfiles.forEach { spec ->
-            val installed = manager.getProfiles(spec.type).orEmpty().any {
-                it.isInstalled && it.verName.equals(spec.verName, ignoreCase = true)
+            val installedByName = manager.getProfiles(spec.type).orEmpty().any {
+                it.isInstalled && (
+                    it.verName.equals(spec.verName, ignoreCase = true) ||
+                    it.verName.contains(spec.verName, ignoreCase = true) ||
+                    spec.verName.contains(it.verName, ignoreCase = true)
+                )
             }
-            if (installed) advancedInstalledSet.add(spec.verName)
+            val installedByUrl = manager.isRemoteUrlInstalled(spec.remoteUrl)
+            if (installedByName || installedByUrl) advancedInstalledSet.add(spec.verName)
         }
         // Also refresh container names for default settings page
         val containerManager = ContainerManager(this)
         advancedContainerNames.clear()
         containerManager.containers.forEach {
             advancedContainerNames.add(it.name)
+        }
+    }
+
+    private fun installAllRecommended() {
+        if (transferState.value != null) return
+        val pending = advancedProfiles
+            .filter { isRecommendedSpec(it) && it.verName !in advancedInstalledSet }
+        if (pending.isEmpty()) return
+
+        lifecycleScope.launch {
+            wizardError.value = null
+            for ((index, spec) in pending.withIndex()) {
+                val profile = withContext(Dispatchers.IO) {
+                    try {
+                        transferState.value = TransferState(
+                            title = getString(R.string.setup_wizard_recommended_components),
+                            detail = getString(R.string.setup_wizard_downloading, spec.verName),
+                            currentIndex = index + 1,
+                            total = pending.size,
+                            progress = 0f
+                        )
+                        val downloaded = downloadFileToCache(
+                            label = spec.verName,
+                            url = spec.remoteUrl,
+                            currentIndex = index + 1,
+                            total = pending.size
+                        )
+                        if (downloaded == null) return@withContext null
+
+                        transferState.value = TransferState(
+                            title = getString(R.string.setup_wizard_recommended_components),
+                            detail = getString(R.string.setup_wizard_downloading, spec.verName),
+                            currentIndex = index + 1,
+                            total = pending.size,
+                            progress = 1f
+                        )
+                        kotlinx.coroutines.delay(500)
+
+                        transferState.value = TransferState(
+                            title = getString(R.string.setup_wizard_recommended_components),
+                            detail = getString(R.string.setup_wizard_installing_package, spec.verName),
+                            currentIndex = index + 1,
+                            total = pending.size,
+                            progress = null
+                        )
+
+                        val installed = installDownloadedPackage(downloaded, spec.remoteUrl)
+                        downloaded.delete()
+                        installed
+                    } catch (e: Exception) {
+                        wizardError.value = "Install failed: ${e.message}"
+                        null
+                    }
+                }
+                if (profile != null) {
+                    if (spec.verName !in advancedInstalledSet) {
+                        advancedInstalledSet.add(spec.verName)
+                    }
+                } else {
+                    break
+                }
+            }
+            transferState.value = null
+            refreshAdvancedInstalledSet()
+            refreshWizardState()
         }
     }
 
@@ -1278,6 +1249,16 @@ class SetupWizardActivity : FragmentActivity() {
                     )
                     if (downloaded == null) return@withContext null
 
+                    // Show 100% briefly so the bar visually completes
+                    transferState.value = TransferState(
+                        title = spec.verName,
+                        detail = getString(R.string.setup_wizard_downloading, spec.verName),
+                        currentIndex = 1,
+                        total = 1,
+                        progress = 1f
+                    )
+                    kotlinx.coroutines.delay(500)
+
                     transferState.value = TransferState(
                         title = spec.verName,
                         detail = getString(R.string.setup_wizard_installing),
@@ -1297,23 +1278,9 @@ class SetupWizardActivity : FragmentActivity() {
                 }
             }
             if (profile != null) {
-                // Auto-create container for Wine/Proton
-                if (spec.type == ContentProfile.ContentType.CONTENT_TYPE_WINE ||
-                    spec.type == ContentProfile.ContentType.CONTENT_TYPE_PROTON) {
-                    withContext(Dispatchers.IO) {
-                        try {
-                            val displayName = runtimeDisplayLabel(profile)
-                            val container = ensureContainerForProfile(profile, displayName)
-                            // Persist container IDs for default settings page
-                            if (profile.verName.contains("arm64ec", ignoreCase = true)) {
-                                saveDefaultArm64ContainerId(this@SetupWizardActivity, container.id)
-                            } else {
-                                saveDefaultX86ContainerId(this@SetupWizardActivity, container.id)
-                            }
-                        } catch (e: Exception) {
-                            wizardError.value = "Container creation failed: ${e.message}"
-                        }
-                    }
+                // Eagerly mark as installed so UI updates immediately
+                if (spec.verName !in advancedInstalledSet) {
+                    advancedInstalledSet.add(spec.verName)
                 }
                 refreshAdvancedInstalledSet()
                 refreshWizardState()
@@ -1355,304 +1322,567 @@ class SetupWizardActivity : FragmentActivity() {
     @Composable
     private fun SetupWizardScreen() {
         val page by pageIndex
-        val advanced = isAdvancedMode.value
-        val scrollState = rememberScrollState()
-        val totalPages = if (advanced) 4 else 5
-        val pageTitle = when {
-            page == 0 -> stringResource(R.string.setup_wizard_required_access)
-            advanced && page == 1 -> stringResource(R.string.setup_wizard_select_components)
-            advanced && page == 2 -> stringResource(R.string.setup_wizard_default_settings)
-            advanced && page == 3 -> stringResource(R.string.stores_accounts_title)
-            !advanced && page == 1 -> stringResource(R.string.setup_wizard_recommended_components)
-            !advanced && page == 2 -> stringResource(R.string.setup_wizard_recommended_wine_proton)
-            !advanced && page == 3 -> stringResource(R.string.setup_wizard_default_settings)
-            else -> stringResource(R.string.stores_accounts_title)
+        val totalPages = 3
+        val pageTitle = when (page) {
+            0 -> stringResource(R.string.setup_wizard_required_access)
+            1 -> stringResource(R.string.setup_wizard_select_components)
+            2 -> stringResource(R.string.setup_wizard_containers)
+            else -> ""
         }
-        val canGoNext = when {
-            page == 0 -> storageGranted.value && imageFsDone.value
-            page == 1 && !advanced -> recommendedComponentsDone.value && driversVisited.value
-            page == 1 && advanced -> true // Advanced components: always allow Next
-            page == 2 && !advanced -> x86ProtonDone.value && arm64ProtonDone.value
-            page == 2 && advanced -> true // Default settings in advanced: optional
-            page == 3 && !advanced -> defaultX86SettingsDone.value && defaultArmSettingsDone.value
+        val canGoNext = when (page) {
+            0 -> storageGranted.value && imageFsDone.value
             else -> true
         }
         val lastPage = totalPages - 1
 
+        // Particle seeds — stable across recomposition
+        val particles = remember {
+            List(20) { i ->
+                val hash = ((i * 7919 + 104729) % 10000) / 10000f
+                Particle(
+                    x = ((i * 3571 + 7321) % 10000) / 10000f,
+                    speed = 0.6f + hash * 0.4f,
+                    size = 1f + hash * 1.5f,
+                    phaseOffset = hash * 6.2832f
+                )
+            }
+        }
+
+        // Page-reactive orb anchors — orbs smoothly migrate when page changes
+        val orb1TargetX = when (page) { 0 -> 0.25f; 1 -> 0.50f; else -> 0.75f }
+        val orb1TargetY = when (page) { 0 -> 0.30f; 1 -> 0.20f; else -> 0.25f }
+        val orb2TargetX = when (page) { 0 -> 0.70f; 1 -> 0.30f; else -> 0.20f }
+        val orb2TargetY = when (page) { 0 -> 0.70f; 1 -> 0.55f; else -> 0.75f }
+        val orb3TargetX = when (page) { 0 -> 0.50f; 1 -> 0.75f; else -> 0.50f }
+        val orb3TargetY = when (page) { 0 -> 0.50f; 1 -> 0.80f; else -> 0.50f }
+
+        val orbAnim = tween<Float>(2000, easing = EaseInOut)
+        val o1x by animateFloatAsState(orb1TargetX, orbAnim, label = "o1x")
+        val o1y by animateFloatAsState(orb1TargetY, orbAnim, label = "o1y")
+        val o2x by animateFloatAsState(orb2TargetX, orbAnim, label = "o2x")
+        val o2y by animateFloatAsState(orb2TargetY, orbAnim, label = "o2y")
+        val o3x by animateFloatAsState(orb3TargetX, orbAnim, label = "o3x")
+        val o3y by animateFloatAsState(orb3TargetY, orbAnim, label = "o3y")
+
+        val infiniteTransition = rememberInfiniteTransition(label = "bgGlow")
+        val phase1 = infiniteTransition.animateFloat(
+            initialValue = 0f, targetValue = 6.2832f,
+            animationSpec = infiniteRepeatable(tween(30000, easing = LinearEasing), RepeatMode.Restart),
+            label = "phase1"
+        )
+        val phase2 = infiniteTransition.animateFloat(
+            initialValue = 6.2832f, targetValue = 0f,
+            animationSpec = infiniteRepeatable(tween(38000, easing = LinearEasing), RepeatMode.Restart),
+            label = "phase2"
+        )
+        val pulse = infiniteTransition.animateFloat(
+            initialValue = 0.85f, targetValue = 1f,
+            animationSpec = infiniteRepeatable(tween(8000, easing = EaseInOut), RepeatMode.Reverse),
+            label = "pulse"
+        )
+        val particlePhase = infiniteTransition.animateFloat(
+            initialValue = 0f, targetValue = 1f,
+            animationSpec = infiniteRepeatable(tween(20000, easing = LinearEasing), RepeatMode.Restart),
+            label = "particlePhase"
+        )
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0xFF0D1117))
+                .background(Color(0xFF0A0E14))
+                .drawBehind {
+                    val w = size.width
+                    val h = size.height
+                    val p1 = phase1.value
+                    val p2 = phase2.value
+                    val p = pulse.value
+
+                    // Orb 1 — cyan, page-reactive + gentle drift
+                    val c1 = Offset(
+                        w * (o1x + 0.04f * cos(p1)),
+                        h * (o1y + 0.03f * sin(p1))
+                    )
+                    drawCircle(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                Color(0xFF57CBDE).copy(alpha = 0.04f * p),
+                                Color(0xFF57CBDE).copy(alpha = 0.015f * p),
+                                Color.Transparent
+                            ),
+                            center = c1,
+                            radius = w * 0.6f
+                        ),
+                        radius = w * 0.6f,
+                        center = c1
+                    )
+
+                    // Orb 2 — blue, page-reactive + gentle drift
+                    val c2 = Offset(
+                        w * (o2x + 0.04f * cos(p2)),
+                        h * (o2y + 0.03f * sin(p2))
+                    )
+                    drawCircle(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                Color(0xFF3B82F6).copy(alpha = 0.035f * p),
+                                Color(0xFF3B82F6).copy(alpha = 0.01f * p),
+                                Color.Transparent
+                            ),
+                            center = c2,
+                            radius = w * 0.55f
+                        ),
+                        radius = w * 0.55f,
+                        center = c2
+                    )
+
+                    // Orb 3 — teal accent, page-reactive + gentle drift
+                    val c3 = Offset(
+                        w * (o3x + 0.03f * sin(p1 * 0.7f)),
+                        h * (o3y + 0.03f * cos(p2 * 0.6f))
+                    )
+                    drawCircle(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                Color(0xFF2DD4BF).copy(alpha = 0.02f * p),
+                                Color.Transparent
+                            ),
+                            center = c3,
+                            radius = w * 0.45f
+                        ),
+                        radius = w * 0.45f,
+                        center = c3
+                    )
+
+                    // Floating particles
+                    val pp = particlePhase.value
+                    particles.forEach { pt ->
+                        val t = (pp * pt.speed + pt.phaseOffset) % 1f
+                        val py = h * (1f - t)
+                        val px = w * pt.x + w * 0.02f * sin((t * 2f * PI).toFloat() + pt.phaseOffset)
+                        // Fade in at bottom, fade out at top
+                        val alpha = when {
+                            t < 0.15f -> t / 0.15f
+                            t > 0.85f -> (1f - t) / 0.15f
+                            else -> 1f
+                        } * 0.12f
+                        drawCircle(
+                            color = Color(0xFF57CBDE).copy(alpha = alpha),
+                            radius = pt.size.dp.toPx(),
+                            center = Offset(px, py)
+                        )
+                    }
+                }
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 20.dp, vertical = 18.dp)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(horizontal = 18.dp, vertical = 12.dp)
             ) {
+                // ---- Header ----
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Box(
-                        modifier = Modifier.weight(1f),
-                        contentAlignment = Alignment.CenterStart
-                    ) {
+                    Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = stringResource(if (advanced) R.string.setup_wizard_advanced_setup else R.string.setup_wizard_title),
+                            text = "WinNative",
                             color = Color(0xFFE6EDF3),
                             fontFamily = SyncopateFont,
-                            fontSize = 18.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.setup_wizard_step_format, page + 1, totalPages),
-                        color = Color(0xFF8B949E),
-                        fontFamily = InterFont,
-                        fontSize = 12.sp,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
-                    Box(
-                        modifier = Modifier.weight(1f),
-                        contentAlignment = Alignment.CenterEnd
-                    ) {
-                        Text(
-                            text = pageTitle,
-                            color = Color(0xFFE6EDF3),
-                            fontFamily = InterFont,
                             fontWeight = FontWeight.Bold,
-                            fontSize = 18.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            textAlign = TextAlign.End
+                            fontSize = 20.sp,
+                            letterSpacing = 1.sp
                         )
+                        Spacer(Modifier.height(3.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = stringResource(R.string.setup_wizard_title).uppercase(),
+                                color = Color(0xFF57CBDE),
+                                fontFamily = InterFont,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 9.sp,
+                                letterSpacing = 1.5.sp
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Box(
+                                modifier = Modifier
+                                    .size(3.dp)
+                                    .background(Color(0xFF4A5260), RoundedCornerShape(2.dp))
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = pageTitle,
+                                color = Color(0xFF8B949E),
+                                fontFamily = InterFont,
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
+                    StepIndicator(current = page, total = totalPages)
                 }
-                Spacer(Modifier.height(18.dp))
 
-                Column(
+                Spacer(Modifier.height(10.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Color(0xFF1B2330))
+                )
+                Spacer(Modifier.height(12.dp))
+
+                // ---- Content ----
+                BoxWithConstraints(
                     modifier = Modifier
                         .weight(1f)
-                        .verticalScroll(scrollState)
-                        .widthIn(max = 720.dp)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center
                 ) {
-                    if (advanced) {
-                        when (page) {
-                            0 -> PagePermissions()
-                            1 -> PageAdvancedComponents()
-                            2 -> PageDefaultSettings()
-                            3 -> PageStores()
-                        }
-                    } else {
-                        when (page) {
-                            0 -> PagePermissions()
-                            1 -> PageComponents()
-                            2 -> PageWineAndProton()
-                            3 -> PageDefaultSettings()
-                            4 -> PageStores()
+                    val isCompact = maxWidth < 500.dp
+                    AnimatedContent(
+                        targetState = page,
+                        transitionSpec = {
+                            val forward = targetState > initialState
+                            val enter = slideInHorizontally(
+                                animationSpec = tween(220)
+                            ) { if (forward) it / 4 else -it / 4 } +
+                                fadeIn(tween(160, delayMillis = 40))
+                            val exit = slideOutHorizontally(
+                                animationSpec = tween(220)
+                            ) { if (forward) -it / 4 else it / 4 } +
+                                fadeOut(tween(140))
+                            (enter togetherWith exit).using(
+                                SizeTransform(clip = false)
+                            )
+                        },
+                        modifier = Modifier.fillMaxSize(),
+                        label = "pageTransition"
+                    ) { targetPage ->
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            when (targetPage) {
+                                0 -> PagePermissions(isCompact)
+                                1 -> PageAdvancedComponents(isCompact)
+                                2 -> PageDefaultSettings()
+                            }
                         }
                     }
 
                     wizardError.value?.let { message ->
-                        Spacer(Modifier.height(14.dp))
                         Text(
                             text = message,
                             color = Color(0xFFFF7B72),
                             fontFamily = InterFont,
-                            fontSize = 13.sp
+                            fontSize = 11.sp,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .fillMaxWidth()
                         )
                     }
                 }
 
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(10.dp))
+
+                // ---- Action bar ----
                 Row(
                     modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    if (page == 1 && !advanced) {
-                        OutlinedButton(
-                            onClick = { enterAdvancedMode() },
-                            shape = RoundedCornerShape(14.dp),
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = Color(0xFFE6EDF3)
-                            )
-                        ) {
-                            Text(stringResource(R.string.setup_wizard_advanced_user), fontFamily = InterFont)
-                        }
-                    } else {
-                        OutlinedButton(
-                            onClick = {
-                                if (page > 0) pageIndex.intValue -= 1
-                                else if (advanced) {
-                                    isAdvancedMode.value = false
-                                    pageIndex.intValue = 1
-                                }
-                            },
-                            enabled = page > 0 || advanced,
-                            shape = RoundedCornerShape(14.dp),
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = Color(0xFFE6EDF3),
-                                disabledContentColor = Color(0xFF6E7681)
-                            )
-                        ) {
-                            Text(stringResource(R.string.common_ui_back), fontFamily = InterFont)
-                        }
-                    }
+                    GhostPillButton(
+                        label = stringResource(R.string.common_ui_back),
+                        enabled = page > 0 && transferState.value == null,
+                        onClick = { if (page > 0) pageIndex.intValue -= 1 }
+                    )
 
                     if (page < lastPage) {
-                        Button(
-                            onClick = { if (canGoNext) pageIndex.intValue += 1 },
-                            enabled = canGoNext,
-                            shape = RoundedCornerShape(14.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = Color(0xFF238636),
-                                disabledContainerColor = Color(0xFF30363D),
-                                disabledContentColor = Color(0xFF8B949E)
-                            )
-                        ) {
-                            Text(stringResource(R.string.setup_wizard_next), fontFamily = InterFont, fontWeight = FontWeight.Bold)
-                        }
+                        AccentPillButton(
+                            label = stringResource(R.string.setup_wizard_next),
+                            enabled = canGoNext && transferState.value == null,
+                            onClick = { if (canGoNext) pageIndex.intValue += 1 }
+                        )
                     } else {
-                        Button(
-                            onClick = { finishWizard() },
-                            shape = RoundedCornerShape(14.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF238636))
-                        ) {
-                            Text(stringResource(R.string.setup_wizard_finish), fontFamily = InterFont, fontWeight = FontWeight.Bold)
-                        }
+                        AccentPillButton(
+                            label = stringResource(R.string.setup_wizard_finish),
+                            enabled = transferState.value == null,
+                            onClick = { finishWizard() }
+                        )
                     }
                 }
             }
 
-            transferState.value?.let { transfer ->
-                TransferDialog(transfer)
+            // Transfer strip — floats at bottom, outside the Column
+            val transfer = transferState.value
+            if (transfer != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.safeDrawing)
+                        .padding(horizontal = 18.dp, vertical = 12.dp)
+                ) {
+                    TransferStrip(transfer)
+                }
             }
         }
     }
 
     @Composable
-    private fun PagePermissions() {
+    private fun TransferStrip(state: TransferState) {
+        val animatedProgress by animateFloatAsState(
+            targetValue = state.progress ?: 0f,
+            animationSpec = tween(durationMillis = 400, easing = LinearEasing),
+            label = "transferProgress"
+        )
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFF111722), RoundedCornerShape(12.dp))
+                .border(1.dp, Color(0xFF1F3A4A), RoundedCornerShape(12.dp))
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Box(modifier = Modifier.weight(1f)) {
-                WizardActionCard(
-                    title = stringResource(R.string.setup_wizard_allow_file_access),
-                    subtitle = stringResource(R.string.common_ui_required),
-                    completed = storageGranted.value,
-                    buttonLabel = stringResource(if (storageGranted.value) R.string.setup_wizard_granted else R.string.setup_wizard_grant),
-                    onClick = { requestFileAccess() }
+            if (state.progress == null) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    color = Color(0xFF57CBDE),
+                    strokeWidth = 2.dp
                 )
+                Spacer(Modifier.width(12.dp))
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .background(Color(0xFF57CBDE), RoundedCornerShape(4.dp))
+                )
+                Spacer(Modifier.width(10.dp))
             }
-            Box(modifier = Modifier.weight(1f)) {
-                WizardActionCard(
-                    title = stringResource(R.string.common_ui_notifications),
-                    subtitle = stringResource(R.string.common_ui_optional),
-                    completed = notifGranted.value,
-                    buttonLabel = when {
-                        notifGranted.value -> stringResource(R.string.setup_wizard_granted)
-                        notifDenied.value -> stringResource(R.string.setup_wizard_denied)
-                        else -> stringResource(R.string.setup_wizard_allow)
-                    },
-                    onClick = { requestNotifications() }
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = state.title,
+                        color = Color(0xFFF0F6FC),
+                        fontFamily = InterFont,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 13.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    if (state.total > 0) {
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = "${state.currentIndex}/${state.total}",
+                            color = Color(0xFF57CBDE),
+                            fontFamily = SyncopateFont,
+                            fontSize = 11.sp
+                        )
+                    }
+                }
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = state.detail,
+                    color = Color(0xFFB8C5D1),
+                    fontFamily = InterFont,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(6.dp))
+                if (state.progress != null) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(6.dp)
+                            .background(Color(0xFF223140), RoundedCornerShape(3.dp))
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(animatedProgress.coerceIn(0f, 1f))
+                                .fillMaxHeight()
+                                .background(Color(0xFF57CBDE), RoundedCornerShape(3.dp))
+                        )
+                    }
+                } else {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(6.dp),
+                        color = Color(0xFF57CBDE),
+                        trackColor = Color(0xFF223140)
+                    )
+                }
+            }
+            if (state.progress != null) {
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = "${(animatedProgress * 100f).toInt()}%",
+                    color = Color(0xFF57CBDE),
+                    fontFamily = SyncopateFont,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
                 )
             }
         }
-        Spacer(Modifier.height(12.dp))
-        WizardActionCard(
-            title = stringResource(R.string.setup_wizard_install_system_files),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = imageFsDone.value,
-            buttonLabel = when {
-                imageFsDone.value -> stringResource(R.string.common_ui_installed)
-                imageFsInstalling.value -> stringResource(R.string.setup_wizard_installing)
-                else -> stringResource(R.string.setup_wizard_install_system_files)
-            },
-            onClick = { installImageFs() },
-            enabled = !imageFsInstalling.value
-        )
+    }
 
-        if (imageFsInstalling.value) {
-            Spacer(Modifier.height(12.dp))
-            LinearProgressIndicator(
-                progress = { imageFsProgress.intValue / 100f },
+    @Composable
+    private fun StepIndicator(current: Int, total: Int) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            for (i in 0 until total) {
+                val active = i == current
+                val completed = i < current
+                val reached = active || completed
+                val bg = if (reached) Color(0xFF57CBDE) else Color(0xFF0A0E14)
+                val borderC = if (reached) Color(0xFF57CBDE) else Color(0xFF2A323E)
+                val textC = if (reached) Color(0xFF0A0E14) else Color(0xFF8B949E)
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .background(bg, RoundedCornerShape(12.dp))
+                        .border(1.5.dp, borderC, RoundedCornerShape(12.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "${i + 1}",
+                        color = textC,
+                        fontFamily = InterFont,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 11.sp
+                    )
+                }
+                if (i < total - 1) {
+                    Box(
+                        modifier = Modifier
+                            .width(18.dp)
+                            .height(2.dp)
+                            .background(if (i < current) Color(0xFF57CBDE) else Color(0xFF2A323E))
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun GhostPillButton(
+        label: String,
+        enabled: Boolean = true,
+        onClick: () -> Unit
+    ) {
+        OutlinedButton(
+            onClick = onClick,
+            enabled = enabled,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(1.dp, if (enabled) Color(0xFF3A4350) else Color(0xFF1B2330)),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = Color(0xFFE6EDF3),
+                disabledContentColor = Color(0xFF3A4350)
+            )
+        ) {
+            Text(label, fontFamily = InterFont, fontSize = 13.sp, fontWeight = FontWeight.Medium)
+        }
+    }
+
+    @Composable
+    private fun AccentPillButton(
+        label: String,
+        enabled: Boolean,
+        onClick: () -> Unit
+    ) {
+        val borderColor by animateColorAsState(
+            targetValue = if (enabled) Color(0xFF57CBDE) else Color(0xFF1B2330),
+            animationSpec = tween(300),
+            label = "accentBorder"
+        )
+        OutlinedButton(
+            onClick = onClick,
+            enabled = enabled,
+            shape = RoundedCornerShape(12.dp),
+            border = BorderStroke(1.5.dp, borderColor),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = Color(0xFF57CBDE),
+                disabledContentColor = Color(0xFF4A5260)
+            )
+        ) {
+            Text(label, fontFamily = InterFont, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+        }
+    }
+
+    @Composable
+    private fun PagePermissions(isCompact: Boolean) {
+        val fileAccessCard: @Composable (Modifier) -> Unit = { mod ->
+            WizardActionCard(
+                modifier = mod,
+                title = stringResource(R.string.setup_wizard_allow_file_access),
+                subtitle = stringResource(R.string.common_ui_required),
+                completed = storageGranted.value,
+                buttonLabel = stringResource(if (storageGranted.value) R.string.setup_wizard_granted else R.string.setup_wizard_grant),
+                onClick = { requestFileAccess() }
+            )
+        }
+        val notifCard: @Composable (Modifier) -> Unit = { mod ->
+            WizardActionCard(
+                modifier = mod,
+                title = stringResource(R.string.common_ui_notifications),
+                subtitle = stringResource(R.string.common_ui_optional),
+                completed = notifGranted.value,
+                buttonLabel = when {
+                    notifGranted.value -> stringResource(R.string.setup_wizard_granted)
+                    notifDenied.value -> stringResource(R.string.setup_wizard_denied)
+                    else -> stringResource(R.string.setup_wizard_allow)
+                },
+                onClick = { requestNotifications() }
+            )
+        }
+        val systemCard: @Composable (Modifier) -> Unit = { mod ->
+            WizardActionCard(
+                modifier = mod,
+                title = stringResource(R.string.setup_wizard_install_system_files),
+                subtitle = stringResource(R.string.common_ui_required),
+                completed = imageFsDone.value,
+                buttonLabel = when {
+                    imageFsDone.value -> stringResource(R.string.common_ui_installed)
+                    imageFsInstalling.value -> "${imageFsProgress.intValue}%"
+                    else -> stringResource(R.string.setup_wizard_install_system_files)
+                },
+                onClick = { installImageFs() },
+                enabled = !imageFsInstalling.value,
+                progress = if (imageFsInstalling.value) imageFsProgress.intValue / 100f else null
+            )
+        }
+
+        if (isCompact) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)
+            ) {
+                fileAccessCard(Modifier.fillMaxWidth())
+                notifCard(Modifier.fillMaxWidth())
+                systemCard(Modifier.fillMaxWidth())
+            }
+        } else {
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                color = Color(0xFF57CBDE),
-                trackColor = Color(0xFF21262D)
-            )
-            Spacer(Modifier.height(6.dp))
-            Text(
-                text = "${imageFsProgress.intValue}%",
-                color = Color(0xFF57CBDE),
-                fontFamily = SyncopateFont,
-                fontSize = 12.sp
-            )
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                fileAccessCard(Modifier.weight(1f))
+                notifCard(Modifier.weight(1f))
+                systemCard(Modifier.weight(1f))
+            }
         }
     }
 
     @Composable
-    private fun PageComponents() {
-        Text(
-            text = stringResource(R.string.setup_wizard_recommended_components_description),
-            color = Color(0xFF8B949E),
-            fontFamily = InterFont,
-            fontSize = 13.sp
-        )
-        Spacer(Modifier.height(18.dp))
-
-        WizardActionCard(
-            title = stringResource(R.string.setup_wizard_recommended_components),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = recommendedComponentsDone.value,
-            buttonLabel = stringResource(if (recommendedComponentsDone.value) R.string.common_ui_installed else R.string.setup_wizard_download_and_install),
-            onClick = { installRecommendedComponents() },
-            enabled = transferState.value == null
-        )
-        Spacer(Modifier.height(12.dp))
-        WizardActionCard(
-            title = stringResource(R.string.settings_drivers_title),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = driversVisited.value,
-            buttonLabel = stringResource(if (driversVisited.value) R.string.common_ui_done else R.string.setup_wizard_open_drivers),
-            onClick = { openDrivers() },
-            enabled = imageFsDone.value
-        )
-    }
-
-    @Composable
-    private fun PageWineAndProton() {
-        Text(
-            text = stringResource(R.string.setup_wizard_each_button_downloads_description),
-            color = Color(0xFF8B949E),
-            fontFamily = InterFont,
-            fontSize = 13.sp
-        )
-        Spacer(Modifier.height(18.dp))
-
-        WizardActionCard(
-            title = stringResource(R.string.setup_wizard_recommended_x86_64),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = x86ProtonDone.value,
-            buttonLabel = stringResource(if (x86ProtonDone.value) R.string.setup_wizard_ready else R.string.setup_wizard_download_and_create),
-            onClick = { installRecommendedProton(x86ProtonSpec) },
-            enabled = transferState.value == null
-        )
-        Spacer(Modifier.height(12.dp))
-        WizardActionCard(
-            title = stringResource(R.string.setup_wizard_recommended_arm64ec),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = arm64ProtonDone.value,
-            buttonLabel = stringResource(if (arm64ProtonDone.value) R.string.setup_wizard_ready else R.string.setup_wizard_download_and_create),
-            onClick = { installRecommendedProton(arm64ProtonSpec) },
-            enabled = transferState.value == null
-        )
-    }
-
-    @Composable
-    private fun PageAdvancedComponents() {
+    private fun PageAdvancedComponents(isCompact: Boolean) {
         val typeOrder = listOf(
             ContentProfile.ContentType.CONTENT_TYPE_WINE,
             ContentProfile.ContentType.CONTENT_TYPE_PROTON,
@@ -1671,102 +1901,262 @@ class SetupWizardActivity : FragmentActivity() {
             ContentProfile.ContentType.CONTENT_TYPE_FEXCORE to "FEXCore",
             ContentProfile.ContentType.CONTENT_TYPE_WOWBOX64 to "Wowbox64"
         )
-        var selectedTab by remember { mutableStateOf(typeOrder[0]) }
+        val recommendedLabel = stringResource(R.string.setup_wizard_recommended_label)
+        val driversLabel = stringResource(R.string.settings_drivers_title)
+        var selectedTab by remember { mutableStateOf("recommended") }
 
-        Text(
-            text = stringResource(R.string.setup_wizard_choose_components_description),
-            color = Color(0xFF8B949E),
-            fontFamily = InterFont,
-            fontSize = 13.sp
-        )
-        Spacer(Modifier.height(14.dp))
-
-        // Also show Drivers button
-        WizardActionCard(
-            title = stringResource(R.string.settings_drivers_title),
-            subtitle = stringResource(R.string.common_ui_required),
-            completed = driversVisited.value,
-            buttonLabel = stringResource(if (driversVisited.value) R.string.common_ui_done else R.string.setup_wizard_open_drivers),
-            onClick = { openDrivers() },
-            enabled = imageFsDone.value
-        )
-        Spacer(Modifier.height(14.dp))
-
-        // Tab row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
+        // Build tab keys/labels
+        val tabs = buildList {
+            add(TabInfo("recommended", recommendedLabel, Color(0xFF57CBDE), highlight = true))
+            add(TabInfo("drivers", driversLabel,
+                if (selectedTab == "drivers") Color(0xFF57CBDE) else Color(0xFF4A5568)))
             typeOrder.forEach { type ->
-                val isSelected = type == selectedTab
-                val hasInstalled = advancedProfiles.any {
-                    it.type == type && it.verName in advancedInstalledSet
+                val key = type.name
+                val hasInstalled = advancedProfiles.any { it.type == type && it.verName in advancedInstalledSet }
+                val indicator = when {
+                    selectedTab == key -> Color(0xFF57CBDE)
+                    hasInstalled -> Color(0xFF3B82F6)
+                    else -> Color(0xFF4A5568)
                 }
-                Surface(
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { selectedTab = type },
-                    color = when {
-                        isSelected -> Color(0xFF238636)
-                        hasInstalled -> Color(0xFF1F6F43)
-                        else -> Color(0xFF21262D)
-                    },
-                    shape = RoundedCornerShape(10.dp)
-                ) {
-                    Text(
-                        text = typeLabels[type] ?: type.toString(),
-                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
-                        color = Color(0xFFE6EDF3),
-                        fontFamily = InterFont,
-                        fontSize = 10.sp,
-                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                        textAlign = TextAlign.Center,
-                        maxLines = 1
-                    )
+                add(TabInfo(key, typeLabels[type] ?: type.toString(), indicator))
+            }
+        }
+
+        // Content panel (shared between layouts)
+        @Composable
+        fun ContentPanel(modifier: Modifier) {
+            Box(
+                modifier = modifier
+                    .background(Color(0xFF111722), RoundedCornerShape(12.dp))
+                    .border(1.dp, Color(0xFF1B2330), RoundedCornerShape(12.dp))
+                    .padding(10.dp)
+            ) {
+                when (selectedTab) {
+                    "drivers" -> {
+                        if (!imageFsDone.value) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.setup_wizard_system_image_not_installed),
+                                    color = Color(0xFF8B949E),
+                                    fontFamily = InterFont,
+                                    fontSize = 12.sp
+                                )
+                            }
+                        } else {
+                            val driversFragmentId = remember { android.view.View.generateViewId() }
+                            AndroidView(
+                                modifier = Modifier.fillMaxSize(),
+                                factory = { ctx ->
+                                    FragmentContainerView(ctx).apply {
+                                        id = driversFragmentId
+                                    }
+                                },
+                                update = { view ->
+                                    val fm = supportFragmentManager
+                                    if (fm.findFragmentById(driversFragmentId) == null) {
+                                        fm.beginTransaction()
+                                            .replace(driversFragmentId, AdrenotoolsFragment())
+                                            .commitNowAllowingStateLoss()
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    else -> {
+                        val tabProfiles: List<RemotePackageSpec> = if (selectedTab == "recommended") {
+                            advancedProfiles
+                                .filter { isRecommendedSpec(it) }
+                                .sortedWith(compareBy({ typeOrder.indexOf(it.type) }, { it.verName }))
+                        } else {
+                            val type = typeOrder.firstOrNull { it.name == selectedTab }
+                            if (type == null) emptyList()
+                            else advancedProfiles
+                                .filter { it.type == type }
+                                .sortedByDescending { isRecommendedSpec(it) }
+                        }
+                        when {
+                            advancedProfiles.isEmpty() -> {
+                                Row(
+                                    modifier = Modifier.align(Alignment.Center),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(18.dp),
+                                        color = Color(0xFF57CBDE),
+                                        strokeWidth = 2.dp
+                                    )
+                                    Spacer(Modifier.width(10.dp))
+                                    Text(
+                                        text = stringResource(R.string.setup_wizard_loading_components),
+                                        color = Color(0xFF8B949E),
+                                        fontFamily = InterFont,
+                                        fontSize = 12.sp
+                                    )
+                                }
+                            }
+                            tabProfiles.isEmpty() -> {
+                                Text(
+                                    text = stringResource(R.string.setup_wizard_no_components_available),
+                                    color = Color(0xFF8B949E),
+                                    fontFamily = InterFont,
+                                    fontSize = 12.sp,
+                                    modifier = Modifier.align(Alignment.Center)
+                                )
+                            }
+                            else -> {
+                                val isRecommendedTab = selectedTab == "recommended"
+                                val allRecommendedInstalled = isRecommendedTab &&
+                                    tabProfiles.all { it.verName in advancedInstalledSet }
+
+                                LazyColumn(
+                                    modifier = Modifier.fillMaxSize(),
+                                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                                ) {
+                                    if (isRecommendedTab) {
+                                        item {
+                                            Box(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                contentAlignment = Alignment.CenterEnd
+                                            ) {
+                                                OutlinedButton(
+                                                    onClick = { installAllRecommended() },
+                                                    enabled = transferState.value == null && !allRecommendedInstalled,
+                                                    shape = RoundedCornerShape(8.dp),
+                                                    border = BorderStroke(
+                                                        1.dp,
+                                                        if (allRecommendedInstalled) Color(0xFF1E3A5F)
+                                                        else if (transferState.value != null) Color(0xFF1B2330)
+                                                        else Color(0xFF2A5A6A)
+                                                    ),
+                                                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp),
+                                                    modifier = Modifier.height(30.dp),
+                                                    colors = ButtonDefaults.outlinedButtonColors(
+                                                        contentColor = if (allRecommendedInstalled) Color(0xFF3B82F6) else Color(0xFF8BB8C5),
+                                                        disabledContentColor = if (allRecommendedInstalled) Color(0xFF3B82F6) else Color(0xFF4A5260)
+                                                    )
+                                                ) {
+                                                    Text(
+                                                        text = stringResource(
+                                                            if (allRecommendedInstalled) R.string.common_ui_installed
+                                                            else R.string.setup_wizard_install_all_recommended
+                                                        ),
+                                                        fontFamily = InterFont,
+                                                        fontWeight = FontWeight.SemiBold,
+                                                        fontSize = 11.sp
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                    items(tabProfiles) { spec ->
+                                        val installed = spec.verName in advancedInstalledSet
+                                        AdvancedComponentCard(
+                                            name = spec.verName,
+                                            installed = installed,
+                                            onClick = { installAdvancedComponent(spec) },
+                                            enabled = transferState.value == null && !installed,
+                                            recommended = isRecommendedSpec(spec)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
-        Spacer(Modifier.height(12.dp))
 
-        // Component list for selected tab
-        val tabProfiles = advancedProfiles.filter { it.type == selectedTab }
-
-        if (advancedProfiles.isEmpty()) {
+        @Composable
+        fun TabItem(tab: TabInfo, fillWidth: Boolean, fontSize: TextUnit) {
+            val isSelected = selectedTab == tab.key
+            val interactionSource = remember { MutableInteractionSource() }
+            val bgColor = if (isSelected) Color(0xFF1A2A3A) else Color.Transparent
+            val labelColor = when {
+                isSelected -> Color(0xFFE6EDF3)
+                tab.highlight -> Color(0xFF57CBDE)
+                else -> Color(0xFFCDD9E5)
+            }
             Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                horizontalArrangement = Arrangement.Center
+                modifier = Modifier
+                    .then(if (fillWidth) Modifier.fillMaxWidth() else Modifier)
+                    .background(bgColor, RoundedCornerShape(8.dp))
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null
+                    ) { selectedTab = tab.key }
+                    .padding(horizontal = 10.dp, vertical = 7.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    color = Color(0xFF57CBDE),
-                    strokeWidth = 2.dp
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .background(tab.indicatorColor, RoundedCornerShape(3.dp))
                 )
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(if (fillWidth) 8.dp else 6.dp))
                 Text(
-                    text = stringResource(R.string.setup_wizard_loading_components),
-                    color = Color(0xFF8B949E),
+                    text = tab.label,
+                    color = labelColor,
                     fontFamily = InterFont,
-                    fontSize = 13.sp
+                    fontSize = fontSize,
+                    fontWeight = if (isSelected || tab.highlight) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1
                 )
             }
-        } else if (tabProfiles.isEmpty()) {
-            Text(
-                text = stringResource(R.string.setup_wizard_no_components_available),
-                color = Color(0xFF8B949E),
-                fontFamily = InterFont,
-                fontSize = 13.sp,
-                modifier = Modifier.padding(vertical = 16.dp)
-            )
-        } else {
-            tabProfiles.forEach { spec ->
-                val installed = spec.verName in advancedInstalledSet
-                AdvancedComponentCard(
-                    name = spec.verName,
-                    installed = installed,
-                    onClick = { installAdvancedComponent(spec) },
-                    enabled = transferState.value == null && !installed
+        }
+
+        if (isCompact) {
+            // Compact: horizontal scrolling tab strip on top, content below
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF111722), RoundedCornerShape(12.dp))
+                        .border(1.dp, Color(0xFF1B2330), RoundedCornerShape(12.dp))
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 6.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    tabs.forEach { tab -> TabItem(tab, fillWidth = false, fontSize = 12.sp) }
+                }
+
+                ContentPanel(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
                 )
-                Spacer(Modifier.height(8.dp))
+            }
+        } else {
+            // Wide: side-by-side rail + content
+            Row(
+                modifier = Modifier.fillMaxSize(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                // Left rail
+                Column(
+                    modifier = Modifier
+                        .weight(0.38f)
+                        .fillMaxHeight()
+                        .background(Color(0xFF111722), RoundedCornerShape(12.dp))
+                        .border(1.dp, Color(0xFF1B2330), RoundedCornerShape(12.dp))
+                        .verticalScroll(rememberScrollState())
+                        .padding(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    tabs.forEach { tab -> TabItem(tab, fillWidth = true, fontSize = 13.sp) }
+                }
+
+                ContentPanel(
+                    modifier = Modifier
+                        .weight(0.62f)
+                        .fillMaxHeight()
+                )
             }
         }
     }
@@ -1776,310 +2166,370 @@ class SetupWizardActivity : FragmentActivity() {
         name: String,
         installed: Boolean,
         onClick: () -> Unit,
-        enabled: Boolean = true
+        enabled: Boolean = true,
+        recommended: Boolean = false
     ) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = Color(0xFF161B22),
-            shape = RoundedCornerShape(14.dp)
+        val bgColor = Color(0xFF12171F)
+        val outlineColor = Color(0xFF222A36)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(bgColor, RoundedCornerShape(12.dp))
+                .border(1.dp, outlineColor, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
+            Column(modifier = Modifier.weight(1f)) {
+                if (recommended) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(4.dp)
+                                .background(Color(0xFF3B82F6), RoundedCornerShape(50))
+                        )
+                        Spacer(Modifier.width(5.dp))
+                        Text(
+                            text = stringResource(R.string.setup_wizard_recommended_label),
+                            color = Color(0xFF8BB8C5),
+                            fontFamily = InterFont,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 9.sp,
+                            letterSpacing = 0.5.sp
+                        )
+                    }
+                    Spacer(Modifier.height(3.dp))
+                }
+                Text(
+                    text = name,
+                    color = Color(0xFFE6EDF3),
+                    fontFamily = InterFont,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Button(
+                onClick = onClick,
+                enabled = enabled && !installed,
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier.height(28.dp),
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (installed) Color(0xFF16253A) else Color(0xFF1A3A4A),
+                    contentColor = if (installed) Color(0xFF3B82F6) else Color(0xFF57CBDE),
+                    disabledContainerColor = if (installed) Color(0xFF16253A) else Color(0xFF14191F),
+                    disabledContentColor = if (installed) Color(0xFF3B82F6) else Color(0xFF4A5260)
+                )
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = name,
-                        color = Color(0xFFE6EDF3),
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 14.sp
-                    )
-                }
-                Button(
-                    onClick = onClick,
-                    enabled = enabled && !installed,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.height(34.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (installed) Color(0xFF1F6F43) else Color(0xFF57CBDE),
-                        contentColor = if (installed) Color.White else Color.Black,
-                        disabledContainerColor = if (installed) Color(0xFF1F6F43) else Color(0xFF30363D),
-                        disabledContentColor = if (installed) Color.White else Color(0xFF8B949E)
-                    )
-                ) {
-                    Text(
-                        text = stringResource(if (installed) R.string.common_ui_installed else R.string.common_ui_install),
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 12.sp
-                    )
-                }
+                Text(
+                    text = stringResource(if (installed) R.string.common_ui_installed else R.string.common_ui_install),
+                    fontFamily = InterFont,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp
+                )
             }
         }
     }
 
     @Composable
     private fun PageDefaultSettings() {
-        Text(
-            text = stringResource(R.string.setup_wizard_containers_description),
-            color = Color(0xFF8B949E),
-            fontFamily = InterFont,
-            fontSize = 13.sp
-        )
-        Spacer(Modifier.height(18.dp))
+        val contentsManager = remember {
+            ContentsManager(this@SetupWizardActivity).also { it.syncContents() }
+        }
+        val installedRuntimes = remember(advancedInstalledSet.toList()) {
+            val wineProfiles = contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_WINE)
+                .orEmpty().filter { it.isInstalled }
+            val protonProfiles = contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_PROTON)
+                .orEmpty().filter { it.isInstalled }
+            (wineProfiles + protonProfiles)
+        }
 
-        val x86Id = getDefaultX86ContainerId(this)
-        val armId = getDefaultArm64ContainerId(this)
-
-        WizardActionCard(
-            title = defaultX86ContainerName.value.ifBlank { "x86-64 container" },
-            subtitle = stringResource(R.string.setup_wizard_default_settings),
-            completed = defaultX86SettingsDone.value,
-            buttonLabel = stringResource(if (defaultX86SettingsDone.value) R.string.setup_wizard_configured else R.string.common_ui_open),
-            onClick = {
-                if (x86Id > 0) openContainerDefaultSettings(x86Id, "x86")
-            },
-            enabled = x86Id > 0
-        )
-        Spacer(Modifier.height(12.dp))
-        WizardActionCard(
-            title = defaultArmContainerName.value.ifBlank { "ARM64EC container" },
-            subtitle = stringResource(R.string.setup_wizard_default_settings),
-            completed = defaultArmSettingsDone.value,
-            buttonLabel = stringResource(if (defaultArmSettingsDone.value) R.string.setup_wizard_configured else R.string.common_ui_open),
-            onClick = {
-                if (armId > 0) openContainerDefaultSettings(armId, "arm64")
-            },
-            enabled = armId > 0
-        )
+        if (installedRuntimes.isEmpty()) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.setup_wizard_no_runtime_installed),
+                    color = Color(0xFF8B949E),
+                    fontFamily = InterFont,
+                    fontSize = 13.sp,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = stringResource(R.string.setup_wizard_no_runtime_hint),
+                    color = Color(0xFF6B7580),
+                    fontFamily = InterFont,
+                    fontSize = 11.sp,
+                    textAlign = TextAlign.Center
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                LazyColumn(
+                    modifier = Modifier.widthIn(max = 420.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(installedRuntimes) { profile ->
+                        RuntimeContainerCard(profile)
+                    }
+                }
+            }
+        }
     }
 
     @Composable
-    private fun PageStores() {
-        val storeState by storeLoginState
+    private fun RuntimeContainerCard(profile: ContentProfile) {
+        val entryName = ContentsManager.getEntryName(profile)
+        val displayName = runtimeDisplayLabel(profile)
+        val isArm64 = profile.verName.contains("arm64ec", ignoreCase = true)
+        val archLabel = if (isArm64) "ARM64EC" else "x86-64"
 
-        Text(
-            text = stringResource(R.string.setup_wizard_store_sign_in_optional),
-            color = Color(0xFF8B949E),
-            fontFamily = InterFont,
-            fontSize = 13.sp
-        )
-        Spacer(Modifier.height(18.dp))
+        val containerManager = remember { ContainerManager(this@SetupWizardActivity) }
+        var existingContainer by remember { mutableStateOf(
+            containerManager.containers.firstOrNull { it.wineVersion == entryName }
+        ) }
+        var creating by remember { mutableStateOf(false) }
 
-        StoreActionCard(
-            name = "Steam",
-            signedIn = storeState.steam,
-            accent = Color(0xFF66C0F4),
-            onClick = {
-                steamLoginLauncher.launch(Intent(this, SteamLoginActivity::class.java))
+        val hasContainer = existingContainer != null
+        val bgColor = Color(0xFF12171F)
+        val outlineColor = if (hasContainer) Color(0xFF1E3A5F) else Color(0xFF222A36)
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(bgColor, RoundedCornerShape(12.dp))
+                .border(1.dp, outlineColor, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .background(
+                                if (hasContainer) Color(0xFF3B82F6) else Color(0xFF4A5260),
+                                RoundedCornerShape(3.dp)
+                            )
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = archLabel,
+                        color = if (hasContainer) Color(0xFF3B82F6) else Color(0xFF8B949E),
+                        fontFamily = InterFont,
+                        fontSize = 9.sp,
+                        letterSpacing = 1.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = displayName,
+                    color = Color(0xFFE6EDF3),
+                    fontFamily = InterFont,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
-        )
-        Spacer(Modifier.height(12.dp))
-        StoreActionCard(
-            name = "Epic Games",
-            signedIn = storeState.epic,
-            accent = Color(0xFF8BAFD4),
-            onClick = {
-                epicLoginLauncher.launch(Intent(this, EpicOAuthActivity::class.java))
+            Spacer(Modifier.width(8.dp))
+            if (existingContainer == null) {
+                Button(
+                    onClick = {
+                        if (creating) return@Button
+                        creating = true
+                        lifecycleScope.launch {
+                            wizardError.value = null
+                            val container = withContext(Dispatchers.IO) {
+                                try {
+                                    val c = ensureContainerForProfile(profile, displayName)
+                                    if (isArm64) {
+                                        saveDefaultArm64ContainerId(this@SetupWizardActivity, c.id)
+                                    } else {
+                                        saveDefaultX86ContainerId(this@SetupWizardActivity, c.id)
+                                    }
+                                    c
+                                } catch (e: Exception) {
+                                    wizardError.value = "Container creation failed: ${e.message}"
+                                    null
+                                }
+                            }
+                            existingContainer = container
+                            creating = false
+                            refreshAdvancedInstalledSet()
+                            refreshWizardState()
+                        }
+                    },
+                    enabled = !creating && transferState.value == null,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.height(28.dp),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF57CBDE),
+                        contentColor = Color(0xFF0A0E14),
+                        disabledContainerColor = Color(0xFF1B2330),
+                        disabledContentColor = Color(0xFF4A5260)
+                    )
+                ) {
+                    if (creating) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            color = Color(0xFF0A0E14),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(Modifier.width(6.dp))
+                    }
+                    Text(
+                        text = stringResource(if (creating) R.string.setup_wizard_creating_container else R.string.setup_wizard_create_container),
+                        fontFamily = InterFont,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.sp
+                    )
+                }
+            } else {
+                Button(
+                    onClick = {
+                        val id = existingContainer!!.id
+                        val type = if (isArm64) "arm64" else "x86"
+                        openContainerDefaultSettings(id, type)
+                    },
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.height(28.dp),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF1B2733),
+                        contentColor = Color(0xFFB8C5D1)
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.setup_wizard_default_settings),
+                        fontFamily = InterFont,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.sp
+                    )
+                }
             }
-        )
-        Spacer(Modifier.height(12.dp))
-        StoreActionCard(
-            name = "GOG",
-            signedIn = storeState.gog,
-            accent = Color(0xFFA855F7),
-            onClick = {
-                gogLoginLauncher.launch(Intent(this, GOGOAuthActivity::class.java))
-            }
-        )
-        Spacer(Modifier.height(12.dp))
-        StoreActionCard(
-            name = "Amazon Games",
-            signedIn = false,
-            accent = Color(0xFFFF9900),
-            onClick = {},
-            enabled = false,
-            buttonLabel = stringResource(R.string.common_ui_coming_soon)
-        )
+        }
     }
 
     @Composable
     private fun WizardActionCard(
+        modifier: Modifier = Modifier,
         title: String,
         subtitle: String,
         completed: Boolean,
         buttonLabel: String,
         onClick: () -> Unit,
-        enabled: Boolean = true
-    ) {
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF161B22)
-            ),
-            shape = RoundedCornerShape(18.dp)
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = title,
-                        color = Color(0xFFE6EDF3),
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 15.sp
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = subtitle,
-                        color = if (completed) Color(0xFF3FB950) else Color(0xFF8B949E),
-                        fontFamily = InterFont,
-                        fontSize = 12.sp
-                    )
-                }
-
-                Button(
-                    onClick = onClick,
-                    enabled = enabled && !completed,
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (completed) Color(0xFF1F6F43) else Color(0xFF57CBDE),
-                        contentColor = if (completed) Color.White else Color.Black,
-                        disabledContainerColor = if (completed) Color(0xFF1F6F43) else Color(0xFF30363D),
-                        disabledContentColor = if (completed) Color.White else Color(0xFF8B949E)
-                    )
-                ) {
-                    Text(
-                        text = buttonLabel,
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-            }
-        }
-    }
-
-    @Composable
-    private fun StoreActionCard(
-        name: String,
-        signedIn: Boolean,
-        accent: Color,
-        onClick: () -> Unit,
         enabled: Boolean = true,
-        buttonLabel: String = if (signedIn) stringResource(R.string.common_ui_signed_in) else stringResource(R.string.common_ui_sign_in)
+        progress: Float? = null
     ) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = Color(0xFF161B22),
-            shape = RoundedCornerShape(18.dp)
+        val borderColor = when {
+            completed -> Color(0xFF1E3A5F)
+            progress != null -> Color(0xFF57CBDE)
+            else -> Color(0xFF1B2330)
+        }
+        Column(
+            modifier = modifier
+                .background(Color(0xFF111722), RoundedCornerShape(12.dp))
+                .border(1.dp, borderColor, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 11.dp)
         ) {
-            Row(
+            // Status chip
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .background(
+                            when {
+                                completed -> Color(0xFF3B82F6)
+                                progress != null -> Color(0xFF57CBDE)
+                                else -> Color(0xFF4A5260)
+                            },
+                            RoundedCornerShape(3.dp)
+                        )
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = subtitle.uppercase(),
+                    color = if (completed) Color(0xFF3B82F6) else Color(0xFF8B949E),
+                    fontFamily = InterFont,
+                    fontSize = 9.sp,
+                    letterSpacing = 1.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = title,
+                color = Color(0xFFE6EDF3),
+                fontFamily = InterFont,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 13.sp,
+                lineHeight = 16.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (progress != null) {
+                val animatedProgress by animateFloatAsState(
+                    targetValue = progress,
+                    animationSpec = tween(durationMillis = 400, easing = LinearEasing),
+                    label = "cardProgress"
+                )
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    progress = { animatedProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(3.dp),
+                    color = Color(0xFF57CBDE),
+                    trackColor = Color(0xFF1B2330)
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Button(
+                onClick = onClick,
+                enabled = enabled && !completed,
+                shape = RoundedCornerShape(8.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .height(32.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (completed) Color(0xFF16253A) else Color(0xFF57CBDE),
+                    contentColor = if (completed) Color(0xFF3B82F6) else Color(0xFF0A0E14),
+                    disabledContainerColor = when {
+                        completed -> Color(0xFF16253A)
+                        progress != null -> Color(0xFF16253A)
+                        else -> Color(0xFF1B2330)
+                    },
+                    disabledContentColor = when {
+                        completed -> Color(0xFF3B82F6)
+                        progress != null -> Color(0xFFE6EDF3)
+                        else -> Color(0xFF4A5260)
+                    }
+                )
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = name,
-                        color = Color(0xFFE6EDF3),
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 15.sp
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = stringResource(if (signedIn) R.string.common_ui_connected else R.string.common_ui_optional),
-                        color = if (signedIn) Color(0xFF3FB950) else Color(0xFF8B949E),
-                        fontFamily = InterFont,
-                        fontSize = 12.sp
-                    )
-                }
-                Button(
-                    onClick = onClick,
-                    enabled = enabled && !signedIn,
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (signedIn) Color(0xFF1F6F43) else accent,
-                        contentColor = if (signedIn) Color.White else Color.Black,
-                        disabledContainerColor = if (signedIn) Color(0xFF1F6F43) else Color(0xFF30363D),
-                        disabledContentColor = if (signedIn) Color.White else Color(0xFF8B949E)
-                    )
-                ) {
-                    Text(
-                        text = buttonLabel,
-                        fontFamily = InterFont,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-            }
-        }
-    }
-
-    @Composable
-    private fun TransferDialog(state: TransferState) {
-        AlertDialog(
-            onDismissRequest = {},
-            confirmButton = {},
-            title = {
                 Text(
-                    text = state.title,
+                    text = buttonLabel,
                     fontFamily = InterFont,
                     fontWeight = FontWeight.Bold,
-                    color = Color(0xFFE6EDF3)
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-            },
-            text = {
-                Column {
-                    Text(
-                        text = state.detail,
-                        fontFamily = InterFont,
-                        color = Color(0xFF8B949E),
-                        fontSize = 13.sp
-                    )
-                    Spacer(Modifier.height(12.dp))
-                    if (state.progress != null) {
-                        LinearProgressIndicator(
-                            progress = { state.progress },
-                            modifier = Modifier.fillMaxWidth(),
-                            color = Color(0xFF57CBDE),
-                            trackColor = Color(0xFF21262D)
-                        )
-                        Spacer(Modifier.height(8.dp))
-                        Text(
-                            text = "${(state.progress * 100f).toInt()}%",
-                            fontFamily = SyncopateFont,
-                            color = Color(0xFF57CBDE),
-                            fontSize = 12.sp
-                        )
-                    } else {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(28.dp),
-                            color = Color(0xFF57CBDE),
-                            strokeWidth = 3.dp
-                        )
-                    }
-                    Spacer(Modifier.height(10.dp))
-                    Text(
-                        text = "${state.currentIndex} / ${state.total}",
-                        fontFamily = InterFont,
-                        color = Color(0xFF8B949E),
-                        fontSize = 12.sp,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            },
-            containerColor = Color(0xFF161B22),
-            shape = RoundedCornerShape(18.dp)
-        )
+            }
+        }
     }
+
 }
 
 private fun contentVersionIdentifier(profile: ContentProfile): String {

--- a/app/src/main/java/com/winlator/cmod/contents/ContentsManager.java
+++ b/app/src/main/java/com/winlator/cmod/contents/ContentsManager.java
@@ -453,6 +453,10 @@ public class ContentsManager {
         localProfile.isInstalled = true;
     }
 
+    public boolean isRemoteUrlInstalled(String remoteUrl) {
+        return getRemoteProfileAlias(remoteUrl) != null;
+    }
+
     private String getRemoteProfileAlias(String remoteUrl) {
         if (remoteUrl == null || remoteUrl.isEmpty()) {
             return null;

--- a/app/src/main/java/com/winlator/cmod/contents/Downloader.java
+++ b/app/src/main/java/com/winlator/cmod/contents/Downloader.java
@@ -289,8 +289,11 @@ public class Downloader {
                 output.flush();
             }
 
-            if (listener != null && lengthOfFile > 0 && total != lengthOfFile) {
-                listener.onProgress(total, lengthOfFile);
+            // Always report 100% on successful completion — Content-Length
+            // can differ from actual bytes received (CDN quirks, chunked
+            // encoding, etc.), so use total/total to guarantee 100%.
+            if (listener != null) {
+                listener.onProgress(total, total);
             }
             return true;
         } catch (Exception e) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -810,6 +810,14 @@ Installeret sti:
     <string name="setup_wizard_ready">Klar</string>
     <string name="setup_wizard_download_and_create">Download + Opret</string>
     <string name="setup_wizard_configured">Konfigureret</string>
+    <string name="setup_wizard_downloading">Downloader %1$s</string>
+    <string name="setup_wizard_installing_package">Installerer %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Ingen Wine- eller Proton-pakker installeret endnu.</string>
+    <string name="setup_wizard_no_runtime_hint">Installer en Wine- eller Proton-pakke fra det forrige trin, eller spring over for nu.</string>
+    <string name="setup_wizard_recommended_label">Anbefalet</string>
+    <string name="setup_wizard_install_all_recommended">Installer alle anbefalede</string>
+    <string name="setup_wizard_create_container">Opret container</string>
+    <string name="setup_wizard_creating_container">Opretter\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Godkendelse</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -810,6 +810,14 @@ Installierter Pfad:
     <string name="setup_wizard_ready">Bereit</string>
     <string name="setup_wizard_download_and_create">Herunterladen + Erstellen</string>
     <string name="setup_wizard_configured">Konfiguriert</string>
+    <string name="setup_wizard_downloading">%1$s wird heruntergeladen</string>
+    <string name="setup_wizard_installing_package">%1$s wird installiert</string>
+    <string name="setup_wizard_no_runtime_installed">Noch keine Wine- oder Proton-Pakete installiert.</string>
+    <string name="setup_wizard_no_runtime_hint">Installieren Sie ein Wine- oder Proton-Paket im vorherigen Schritt, oder überspringen Sie dies vorerst.</string>
+    <string name="setup_wizard_recommended_label">Empfohlen</string>
+    <string name="setup_wizard_install_all_recommended">Alle empfohlenen installieren</string>
+    <string name="setup_wizard_create_container">Container erstellen</string>
+    <string name="setup_wizard_creating_container">Wird erstellt\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorisierung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -810,6 +810,14 @@ Ruta instalada:
     <string name="setup_wizard_ready">Listo</string>
     <string name="setup_wizard_download_and_create">Descargar + Crear</string>
     <string name="setup_wizard_configured">Configurado</string>
+    <string name="setup_wizard_downloading">Descargando %1$s</string>
+    <string name="setup_wizard_installing_package">Instalando %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Aún no hay paquetes de Wine o Proton instalados.</string>
+    <string name="setup_wizard_no_runtime_hint">Instala un paquete de Wine o Proton en el paso anterior, o sáltalo por ahora.</string>
+    <string name="setup_wizard_recommended_label">Recomendado</string>
+    <string name="setup_wizard_install_all_recommended">Instalar todos los recomendados</string>
+    <string name="setup_wizard_create_container">Crear contenedor</string>
+    <string name="setup_wizard_creating_container">Creando\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorización</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -810,6 +810,14 @@ Chemin installé :
     <string name="setup_wizard_ready">Prêt</string>
     <string name="setup_wizard_download_and_create">Télécharger + Créer</string>
     <string name="setup_wizard_configured">Configuré</string>
+    <string name="setup_wizard_downloading">Téléchargement de %1$s</string>
+    <string name="setup_wizard_installing_package">Installation de %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Aucun paquet Wine ou Proton installé pour le moment.</string>
+    <string name="setup_wizard_no_runtime_hint">Installez un paquet Wine ou Proton à l\'étape précédente, ou passez cette étape pour le moment.</string>
+    <string name="setup_wizard_recommended_label">Recommandé</string>
+    <string name="setup_wizard_install_all_recommended">Installer tous les recommandés</string>
+    <string name="setup_wizard_create_container">Créer un conteneur</string>
+    <string name="setup_wizard_creating_container">Création\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorisation</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -810,6 +810,14 @@ Percorso installato:
     <string name="setup_wizard_ready">Pronto</string>
     <string name="setup_wizard_download_and_create">Scarica + Crea</string>
     <string name="setup_wizard_configured">Configurato</string>
+    <string name="setup_wizard_downloading">Download di %1$s</string>
+    <string name="setup_wizard_installing_package">Installazione di %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Nessun pacchetto Wine o Proton installato.</string>
+    <string name="setup_wizard_no_runtime_hint">Installa un pacchetto Wine o Proton dal passaggio precedente, oppure salta per ora.</string>
+    <string name="setup_wizard_recommended_label">Consigliato</string>
+    <string name="setup_wizard_install_all_recommended">Installa tutti i consigliati</string>
+    <string name="setup_wizard_create_container">Crea contenitore</string>
+    <string name="setup_wizard_creating_container">Creazione\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorizzazione</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -810,6 +810,14 @@
     <string name="setup_wizard_ready">준비 완료</string>
     <string name="setup_wizard_download_and_create">다운로드 + 생성</string>
     <string name="setup_wizard_configured">구성됨</string>
+    <string name="setup_wizard_downloading">%1$s 다운로드 중</string>
+    <string name="setup_wizard_installing_package">%1$s 설치 중</string>
+    <string name="setup_wizard_no_runtime_installed">아직 Wine 또는 Proton 패키지가 설치되지 않았습니다.</string>
+    <string name="setup_wizard_no_runtime_hint">이전 단계에서 Wine 또는 Proton 패키지를 설치하거나, 지금은 건너뛰세요.</string>
+    <string name="setup_wizard_recommended_label">추천</string>
+    <string name="setup_wizard_install_all_recommended">추천 항목 모두 설치</string>
+    <string name="setup_wizard_create_container">컨테이너 생성</string>
+    <string name="setup_wizard_creating_container">생성 중\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">인증</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -810,6 +810,14 @@ Zainstalowana ścieżka:
     <string name="setup_wizard_ready">Gotowe</string>
     <string name="setup_wizard_download_and_create">Pobierz + Utwórz</string>
     <string name="setup_wizard_configured">Skonfigurowano</string>
+    <string name="setup_wizard_downloading">Pobieranie %1$s</string>
+    <string name="setup_wizard_installing_package">Instalowanie %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Nie zainstalowano jeszcze żadnych pakietów Wine ani Proton.</string>
+    <string name="setup_wizard_no_runtime_hint">Zainstaluj pakiet Wine lub Proton w poprzednim kroku, lub pomiń na razie.</string>
+    <string name="setup_wizard_recommended_label">Zalecane</string>
+    <string name="setup_wizard_install_all_recommended">Zainstaluj wszystkie zalecane</string>
+    <string name="setup_wizard_create_container">Utwórz kontener</string>
+    <string name="setup_wizard_creating_container">Tworzenie\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autoryzacja</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -810,6 +810,14 @@ Caminho instalado:
     <string name="setup_wizard_ready">Pronto</string>
     <string name="setup_wizard_download_and_create">Baixar + Criar</string>
     <string name="setup_wizard_configured">Configurado</string>
+    <string name="setup_wizard_downloading">Baixando %1$s</string>
+    <string name="setup_wizard_installing_package">Instalando %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Nenhum pacote Wine ou Proton instalado ainda.</string>
+    <string name="setup_wizard_no_runtime_hint">Instale um pacote Wine ou Proton na etapa anterior, ou pule por enquanto.</string>
+    <string name="setup_wizard_recommended_label">Recomendado</string>
+    <string name="setup_wizard_install_all_recommended">Instalar todos os recomendados</string>
+    <string name="setup_wizard_create_container">Criar contêiner</string>
+    <string name="setup_wizard_creating_container">Criando\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorizacao</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -810,6 +810,14 @@ Cale instalata:
     <string name="setup_wizard_ready">Pregatit</string>
     <string name="setup_wizard_download_and_create">Descarca + Creeaza</string>
     <string name="setup_wizard_configured">Configurat</string>
+    <string name="setup_wizard_downloading">Se descarcă %1$s</string>
+    <string name="setup_wizard_installing_package">Se instalează %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Niciun pachet Wine sau Proton instalat încă.</string>
+    <string name="setup_wizard_no_runtime_hint">Instalează un pachet Wine sau Proton din pasul anterior, sau sari peste acest pas deocamdată.</string>
+    <string name="setup_wizard_recommended_label">Recomandat</string>
+    <string name="setup_wizard_install_all_recommended">Instalează toate recomandate</string>
+    <string name="setup_wizard_create_container">Creează container</string>
+    <string name="setup_wizard_creating_container">Se creează\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Autorizare</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -810,6 +810,14 @@
     <string name="setup_wizard_ready">Готово</string>
     <string name="setup_wizard_download_and_create">Завантажити + Створити</string>
     <string name="setup_wizard_configured">Налаштовано</string>
+    <string name="setup_wizard_downloading">Завантаження %1$s</string>
+    <string name="setup_wizard_installing_package">Встановлення %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">Пакети Wine або Proton ще не встановлені.</string>
+    <string name="setup_wizard_no_runtime_hint">Встановіть пакет Wine або Proton на попередньому кроці, або пропустіть поки що.</string>
+    <string name="setup_wizard_recommended_label">Рекомендовано</string>
+    <string name="setup_wizard_install_all_recommended">Встановити всі рекомендовані</string>
+    <string name="setup_wizard_create_container">Створити контейнер</string>
+    <string name="setup_wizard_creating_container">Створення\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Авторизація</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -810,6 +810,14 @@
     <string name="setup_wizard_ready">就绪</string>
     <string name="setup_wizard_download_and_create">下载 + 创建</string>
     <string name="setup_wizard_configured">已配置</string>
+    <string name="setup_wizard_downloading">正在下载 %1$s</string>
+    <string name="setup_wizard_installing_package">正在安装 %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">尚未安装任何 Wine 或 Proton 软件包。</string>
+    <string name="setup_wizard_no_runtime_hint">请在上一步安装 Wine 或 Proton 软件包，或暂时跳过。</string>
+    <string name="setup_wizard_recommended_label">推荐</string>
+    <string name="setup_wizard_install_all_recommended">安装所有推荐</string>
+    <string name="setup_wizard_create_container">创建容器</string>
+    <string name="setup_wizard_creating_container">正在创建\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">授权</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -810,6 +810,14 @@
     <string name="setup_wizard_ready">就緒</string>
     <string name="setup_wizard_download_and_create">下載 + 建立</string>
     <string name="setup_wizard_configured">已設定</string>
+    <string name="setup_wizard_downloading">正在下載 %1$s</string>
+    <string name="setup_wizard_installing_package">正在安裝 %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">尚未安裝任何 Wine 或 Proton 套件。</string>
+    <string name="setup_wizard_no_runtime_hint">請在上一步安裝 Wine 或 Proton 套件，或暫時跳過。</string>
+    <string name="setup_wizard_recommended_label">推薦</string>
+    <string name="setup_wizard_install_all_recommended">安裝所有推薦</string>
+    <string name="setup_wizard_create_container">建立容器</string>
+    <string name="setup_wizard_creating_container">正在建立\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">授權</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -806,6 +806,7 @@ Installed path:
     <string name="setup_wizard_loading_components">Loading components\u2026</string>
     <string name="setup_wizard_no_components_available">No components available for this category.</string>
     <string name="setup_wizard_default_settings">Default Settings</string>
+    <string name="setup_wizard_containers">Container Setup</string>
     <string name="setup_wizard_containers_description">Open each container and set the defaults you want every new game to inherit. New games will target the x86-64 container by default.</string>
     <string name="setup_wizard_store_sign_in_optional">Store sign-in is optional. Each sign-in returns here when it finishes.</string>
     <string name="setup_wizard_granted">Granted</string>
@@ -826,6 +827,14 @@ Installed path:
     <string name="setup_wizard_ready">Ready</string>
     <string name="setup_wizard_download_and_create">Download + Create</string>
     <string name="setup_wizard_configured">Configured</string>
+    <string name="setup_wizard_downloading">Downloading %1$s</string>
+    <string name="setup_wizard_installing_package">Installing %1$s</string>
+    <string name="setup_wizard_no_runtime_installed">No Wine or Proton packages installed yet.</string>
+    <string name="setup_wizard_no_runtime_hint">Install a Wine or Proton package from the previous step, or skip this for now.</string>
+    <string name="setup_wizard_recommended_label">Recommended</string>
+    <string name="setup_wizard_install_all_recommended">Install All Recommended</string>
+    <string name="setup_wizard_create_container">Create Container</string>
+    <string name="setup_wizard_creating_container">Creating\u2026</string>
 
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Authorization</string>


### PR DESCRIPTION
- Consolidate wizard from 5 pages down to 3 (permissions, components, containers)
- Merge recommended and advanced flows into a single tabbed component browser with a "Recommended" tab, per-type category tabs, and an inline Drivers tab
- Add "Install All Recommended" button to batch-install all uninstalled recommended packages in one pass
- Replace modal transfer dialog with a non-blocking bottom transfer strip showing progress inline
- Add animated background with page-reactive orbs, floating particles, and slide transitions between pages
- Replace container setup page with per-runtime container creation cards that let users create containers directly from installed Wine/Proton packages
- Fix installed package detection: use URL-based alias lookup from ContentsManager to correctly detect packages whose installed verName differs from the spec verName (e.g. DXVK ARM64EC)
- Guarantee 100% progress reporting on download completion in Downloader
- Remove store login page (Steam/Epic/GOG) from wizard flow
- Add responsive compact/wide layouts for permissions and component pages
- Localize all new strings (install all, recommended label, create container, downloading, installing) across 12 languages

## Test plan
- [x] Walk through the full wizard on a fresh install — verify permissions page, component browser, and container setup all work
- [x] Use "Install All Recommended" and confirm it skips already-installed packages and installs only missing ones
- [x] Verify DXVK ARM64EC and other packages with mismatched verNames show as "Installed" after install
- [x] Test compact (phone) and wide (tablet/landscape) layouts on both pages
- [x] Confirm transfer strip appears during downloads and shows correct progress/counts