### PR TITLE
feat: Git tag-based versioning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,19 @@ ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
 }
 
+// Git based versioning
+def gitVersionName = {
+    def tag = "git describe --tags --abbrev=0".execute().text.trim()
+    if (tag.isEmpty()) return "0.1.0-prealpha"
+    return tag.startsWith("v") ? tag.substring(1) : tag
+}.call()
+
+def gitVersionCode = {
+    def count = "git tag -l v*".execute().text.trim()
+    if (count.isEmpty()) return 1
+    return count.split("\n").length
+}.call()
+
 android {
     namespace 'com.winlator.cmod'
     compileSdk 35
@@ -35,8 +48,8 @@ android {
         applicationId "com.winnative.cmod"
         minSdkVersion 26
         targetSdkVersion 28
-        versionCode 21
-        versionName "7.1.4x-cmod"
+        versionCode gitVersionCode
+        versionName gitVersionName
 
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
- Replace hardcoded versionName/versionCode with git tag-based versioning
- versionName is derived from the latest `v*` tag (e.g. `v0.1.0-prealpha` → `"0.1.0-prealpha"`)
- versionCode is the total number of `v*` tags (auto-increments with each new tag)
- Falls back to `0.1.0-prealpha` / versionCode `1` when no tags exist

## Test plan
- [x] Build without any git tags — should default to `0.1.0-prealpha` / versionCode 1
- [x] Create tag `git tag v0.1.0-prealpha` and rebuild — should pick up the tag
- [x] Create additional tag `git tag v0.2.0` and rebuild — versionCode should increment