### PR TITLE
fix: Defer isLoaded until content sync completes and disable Save while loading

### DIFF
--- a/app/src/main/java/com/winlator/cmod/ContainersFragment.java
+++ b/app/src/main/java/com/winlator/cmod/ContainersFragment.java
@@ -113,6 +113,11 @@ public class ContainersFragment extends Fragment {
     }
 
     private void loadContainersList() {
+        Context context = getContext();
+        if (context == null) {
+            return;
+        }
+        manager = new ContainerManager(context);
         ArrayList<Container> containers = manager.getContainers();
         recyclerView.setAdapter(new ContainersAdapter(containers));
         emptyTextView.setVisibility(containers.isEmpty() ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ContainerSettingsComposeDialog.kt
@@ -714,7 +714,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
     private fun resolveSelectedWineVersionIdentifier(): String {
         wineVersionIdentifiers.getOrNull(state.selectedWineVersion.intValue)?.let { return it }
 
-        contentsManager.syncContents()
+        // Profiles were already synced in loadContentsAsync(); query what's available
+        // without re-scanning disk on the main thread.
         val installedProfiles = (
             contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_WINE).orEmpty() +
                 contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_PROTON).orEmpty()

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ContainerSettingsComposeDialog.kt
@@ -472,7 +472,6 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         // DXVK/WineD3D loaders iterate contents profiles; deferred to
         // populateContentsDependentData() after contentsManager.syncContents.
         updateEmulatorFrameVisibility()
-        state.isLoaded.value = true
     }
 
     private fun loadContentsAsync() {
@@ -480,10 +479,17 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             try {
                 contentsManager.syncContents()
                 activity.runOnUiThread {
-                    populateContentsDependentData()
+                    try {
+                        populateContentsDependentData()
+                    } finally {
+                        state.isLoaded.value = true
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error syncing contents", e)
+                activity.runOnUiThread {
+                    state.isLoaded.value = true
+                }
             }
         }
     }
@@ -619,9 +625,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
 
         val desktopTheme = buildDesktopThemeString()
 
-        val selectedWineStr = wineVersionIdentifiers.getOrNull(
-            state.selectedWineVersion.intValue
-        ) ?: WineInfo.MAIN_WINE_VERSION.identifier()
+        val selectedWineStr = resolveSelectedWineVersionIdentifier()
 
         if (c != null) {
             c.setName(name)
@@ -705,6 +709,25 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 AppUtils.showToast(context, "Error: " + e.message)
             }
         }
+    }
+
+    private fun resolveSelectedWineVersionIdentifier(): String {
+        wineVersionIdentifiers.getOrNull(state.selectedWineVersion.intValue)?.let { return it }
+
+        contentsManager.syncContents()
+        val installedProfiles = (
+            contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_WINE).orEmpty() +
+                contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_PROTON).orEmpty()
+            )
+            .filter { it.isInstalled }
+            .sortedWith(
+                compareByDescending<ContentProfile> { it.verCode }
+                    .thenByDescending { it.verName.lowercase(Locale.ROOT) }
+            )
+
+        return installedProfiles.firstOrNull()
+            ?.let(ContentsManager::getEntryName)
+            ?: WineInfo.MAIN_WINE_VERSION.identifier()
     }
 
     private fun saveMouseWarpOverride(c: Container) {

--- a/app/src/main/java/com/winlator/cmod/contentdialog/GameSettings.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/GameSettings.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -632,29 +633,7 @@ private fun CompactBottomBar(
         ) {
             Text(stringResource(R.string.common_ui_cancel), color = TextSecondary, fontSize = 11.sp, fontWeight = FontWeight.Medium)
         }
-        Box(
-            modifier = Modifier
-                .height(28.dp)
-                .clip(RoundedCornerShape(7.dp))
-                .border(
-                    1.dp,
-                    if (saveEnabled) AccentBlue.copy(alpha = 0.5f) else CardBorder,
-                    RoundedCornerShape(7.dp)
-                )
-                .background(
-                    if (saveEnabled) AccentBlue.copy(alpha = 0.1f) else CardSurface
-                )
-                .clickable(enabled = saveEnabled) { onSave() }
-                .padding(horizontal = 14.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                stringResource(R.string.common_ui_save),
-                color = if (saveEnabled) AccentBlue else TextDim,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.Medium
-            )
-        }
+        SaveButton(enabled = saveEnabled, onClick = onSave, height = 28.dp, corner = 7.dp, fontSize = 11.sp)
     }
 }
 
@@ -755,30 +734,49 @@ private fun Sidebar(
                     fontWeight = FontWeight.Medium
                 )
             }
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(32.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .border(
-                        1.dp,
-                        if (saveEnabled) AccentBlue.copy(alpha = 0.5f) else CardBorder,
-                        RoundedCornerShape(8.dp)
-                    )
-                    .background(
-                        if (saveEnabled) AccentBlue.copy(alpha = 0.1f) else CardSurface
-                    )
-                    .clickable(enabled = saveEnabled) { onSave() },
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    stringResource(R.string.common_ui_save),
-                    color = if (saveEnabled) AccentBlue else TextDim,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium
-                )
-            }
+            SaveButton(
+                enabled = saveEnabled,
+                onClick = onSave,
+                height = 32.dp,
+                corner = 8.dp,
+                fontSize = 12.sp,
+                modifier = Modifier.weight(1f)
+            )
         }
+    }
+}
+
+@Composable
+private fun SaveButton(
+    enabled: Boolean,
+    onClick: () -> Unit,
+    height: Dp,
+    corner: Dp,
+    fontSize: TextUnit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(height)
+            .clip(RoundedCornerShape(corner))
+            .border(
+                1.dp,
+                if (enabled) AccentBlue.copy(alpha = 0.5f) else CardBorder,
+                RoundedCornerShape(corner)
+            )
+            .background(
+                if (enabled) AccentBlue.copy(alpha = 0.1f) else CardSurface
+            )
+            .clickable(enabled = enabled) { onClick() }
+            .padding(horizontal = 14.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            stringResource(R.string.common_ui_save),
+            color = if (enabled) AccentBlue else TextDim,
+            fontSize = fontSize,
+            fontWeight = FontWeight.Medium
+        )
     }
 }
 

--- a/app/src/main/java/com/winlator/cmod/contentdialog/GameSettings.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/GameSettings.kt
@@ -407,6 +407,7 @@ fun GameSettingsContent(
     val sections = remember(isSteam) { buildSections(isSteam) }
     val selectedIdx by state.currentSection
     val currentSectionId = sections.getOrNull(selectedIdx)?.first ?: SEC_GENERAL
+    val saveEnabled by state.isLoaded
 
     BoxWithConstraints(
         modifier = Modifier
@@ -422,6 +423,7 @@ fun GameSettingsContent(
                 // Top action bar: title on left, Cancel/Save on right
                 CompactBottomBar(
                     title = state.name.value,
+                    saveEnabled = saveEnabled,
                     onSave = { callbacks.onConfirm() },
                     onCancel = { callbacks.onDismiss() }
                 )
@@ -459,6 +461,7 @@ fun GameSettingsContent(
                     sections = sections.map { it.second },
                     currentIndex = selectedIdx,
                     onSectionSelected = { state.currentSection.intValue = it },
+                    saveEnabled = saveEnabled,
                     onSave = { callbacks.onConfirm() },
                     onCancel = { callbacks.onDismiss() },
                     modifier = Modifier
@@ -587,6 +590,7 @@ private fun CompactTopBar(
 @Composable
 private fun CompactBottomBar(
     title: String,
+    saveEnabled: Boolean,
     onSave: () -> Unit,
     onCancel: () -> Unit
 ) {
@@ -632,13 +636,24 @@ private fun CompactBottomBar(
             modifier = Modifier
                 .height(28.dp)
                 .clip(RoundedCornerShape(7.dp))
-                .border(1.dp, AccentBlue.copy(alpha = 0.5f), RoundedCornerShape(7.dp))
-                .background(AccentBlue.copy(alpha = 0.1f))
-                .clickable { onSave() }
+                .border(
+                    1.dp,
+                    if (saveEnabled) AccentBlue.copy(alpha = 0.5f) else CardBorder,
+                    RoundedCornerShape(7.dp)
+                )
+                .background(
+                    if (saveEnabled) AccentBlue.copy(alpha = 0.1f) else CardSurface
+                )
+                .clickable(enabled = saveEnabled) { onSave() }
                 .padding(horizontal = 14.dp),
             contentAlignment = Alignment.Center
         ) {
-            Text(stringResource(R.string.common_ui_save), color = AccentBlue, fontSize = 11.sp, fontWeight = FontWeight.Medium)
+            Text(
+                stringResource(R.string.common_ui_save),
+                color = if (saveEnabled) AccentBlue else TextDim,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium
+            )
         }
     }
 }
@@ -652,6 +667,7 @@ private fun Sidebar(
     sections: List<SidebarSection>,
     currentIndex: Int,
     onSectionSelected: (Int) -> Unit,
+    saveEnabled: Boolean,
     onSave: () -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier
@@ -744,14 +760,20 @@ private fun Sidebar(
                     .weight(1f)
                     .height(32.dp)
                     .clip(RoundedCornerShape(8.dp))
-                    .border(1.dp, AccentBlue.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
-                    .background(AccentBlue.copy(alpha = 0.1f))
-                    .clickable { onSave() },
+                    .border(
+                        1.dp,
+                        if (saveEnabled) AccentBlue.copy(alpha = 0.5f) else CardBorder,
+                        RoundedCornerShape(8.dp)
+                    )
+                    .background(
+                        if (saveEnabled) AccentBlue.copy(alpha = 0.1f) else CardSurface
+                    )
+                    .clickable(enabled = saveEnabled) { onSave() },
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     stringResource(R.string.common_ui_save),
-                    color = AccentBlue,
+                    color = if (saveEnabled) AccentBlue else TextDim,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Medium
                 )

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsComposeDialog.kt
@@ -495,8 +495,6 @@ class ShortcutSettingsComposeDialog private constructor(
         // Show Box64/FEXCore frames based on saved emulator selection immediately,
         // before the async content sync runs
         updateEmulatorFrameVisibility()
-
-        state.isLoaded.value = true
     }
 
     private fun loadContentsAsync() {
@@ -504,10 +502,17 @@ class ShortcutSettingsComposeDialog private constructor(
             try {
                 contentsManager.syncContents()
                 activity.runOnUiThread {
-                    populateContentsDependentData()
+                    try {
+                        populateContentsDependentData()
+                    } finally {
+                        state.isLoaded.value = true
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error syncing contents", e)
+                activity.runOnUiThread {
+                    state.isLoaded.value = true
+                }
             }
         }
     }


### PR DESCRIPTION
- Move `isLoaded` flag to after async `populateContentsDependentData()` completes so the Save button stays disabled until wine/proton profiles are ready (both container and shortcut settings dialogs)
- Add `resolveSelectedWineVersionIdentifier()` fallback when the saved wine version index is stale after a content update
- Refresh `ContainerManager` in `loadContainersList()` so the container list reflects changes after creation/deletion
- Disable and dim the Save button in both compact and sidebar layouts while content is still loading
- Set `isLoaded = true` in the error path so the UI doesn't stay permanently locked if content sync fails