### PR TITLE
Remove Amazon store integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **WinNative** is an advanced, high-performance Windows (x86_64) emulation environment for Android. It bridges the gap between desktop gaming and mobile by unifying the best technologies from **Winlator Bionic** and **Pluvia**.
 
-Designed for enthusiasts and power users, WinNative delivers the full Winlator experience while making it easy to connect your Steam, Epic, GOG, and Amazon game libraries.
+Designed for enthusiasts and power users, WinNative delivers the full Winlator experience while making it easy to connect your Steam, Epic, and GOG game libraries.
 
 ---
 

--- a/app/src/main/java/com/winlator/cmod/StoresFragment.kt
+++ b/app/src/main/java/com/winlator/cmod/StoresFragment.kt
@@ -58,10 +58,6 @@ class StoresFragment : Fragment() {
         ActivityResultContracts.OpenDocumentTree()
     ) { uri -> uri?.let { persistUri(it); PrefManager.gogDownloadFolder = it.toString(); refresh() } }
 
-    private val amazonFolderLauncher = registerForActivityResult(
-        ActivityResultContracts.OpenDocumentTree()
-    ) { uri -> uri?.let { persistUri(it); PrefManager.amazonDownloadFolder = it.toString(); refresh() } }
-
     private val gogLoginLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
@@ -156,7 +152,6 @@ class StoresFragment : Fragment() {
                         onPickSteamFolder    = { steamFolderLauncher.launch(null) },
                         onPickEpicFolder     = { epicFolderLauncher.launch(null) },
                         onPickGogFolder      = { gogFolderLauncher.launch(null) },
-                        onPickAmazonFolder   = { amazonFolderLauncher.launch(null) },
                     )
                 }
             }
@@ -224,7 +219,6 @@ class StoresFragment : Fragment() {
             steamFolder     = resolveUri(PrefManager.steamDownloadFolder,   ctx),
             epicFolder      = resolveUri(PrefManager.epicDownloadFolder,    ctx),
             gogFolder       = resolveUri(PrefManager.gogDownloadFolder,     ctx),
-            amazonFolder    = resolveUri(PrefManager.amazonDownloadFolder,  ctx),
         )
     }
 

--- a/app/src/main/java/com/winlator/cmod/StoresScreen.kt
+++ b/app/src/main/java/com/winlator/cmod/StoresScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FolderShared
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Speed
@@ -99,7 +98,6 @@ data class StoreState(
     val steamFolder: String = "",
     val epicFolder: String = "",
     val gogFolder: String = "",
-    val amazonFolder: String = "",
 )
 
 // Root
@@ -127,7 +125,6 @@ fun StoresScreen(
     onPickSteamFolder: () -> Unit,
     onPickEpicFolder: () -> Unit,
     onPickGogFolder: () -> Unit,
-    onPickAmazonFolder: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -144,7 +141,6 @@ fun StoresScreen(
             icon = Icons.Filled.Gamepad,
             accentColor = Color(0xFF66C0F4),
             isLoggedIn = state.isSteamLoggedIn,
-            isComingSoon = false,
             onSignIn = onSteamSignIn,
             onSignOut = onSteamSignOut,
         )
@@ -153,7 +149,6 @@ fun StoresScreen(
             icon = Icons.Filled.Gamepad,
             accentColor = Color(0xFF8BAFD4),
             isLoggedIn = state.isEpicLoggedIn,
-            isComingSoon = false,
             onSignIn = onEpicSignIn,
             onSignOut = onEpicSignOut,
         )
@@ -162,18 +157,8 @@ fun StoresScreen(
             icon = Icons.Filled.Gamepad,
             accentColor = Color(0xFFA855F7),
             isLoggedIn = state.isGogLoggedIn,
-            isComingSoon = false,
             onSignIn = onGogSignIn,
             onSignOut = onGogSignOut,
-        )
-        StoreCard(
-            name = "Amazon Games",
-            icon = Icons.Filled.Gamepad,
-            accentColor = Color(0xFFFF9900),
-            isLoggedIn = false,
-            isComingSoon = true,
-            onSignIn = {},
-            onSignOut = {},
         )
 
         SectionLabel("Download Settings", modifier = Modifier.padding(top = 8.dp))
@@ -205,7 +190,6 @@ fun StoresScreen(
                     FolderPathCard("Steam Downloads",  state.steamFolder,  onPickSteamFolder)
                     FolderPathCard("Epic Downloads",   state.epicFolder,   onPickEpicFolder)
                     FolderPathCard("GOG Downloads",    state.gogFolder,    onPickGogFolder)
-                    FolderPathCard("Amazon Downloads", state.amazonFolder, onPickAmazonFolder)
                 }
             }
         }
@@ -298,7 +282,6 @@ private fun StoreCard(
     icon: ImageVector,
     accentColor: Color,
     isLoggedIn: Boolean,
-    isComingSoon: Boolean,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
 ) {
@@ -368,77 +351,42 @@ private fun StoreCard(
                     fontWeight = FontWeight.SemiBold,
                 )
                 Spacer(Modifier.height(4.dp))
-                if (isComingSoon) {
-                    Text(text = stringResource(R.string.common_ui_coming_soon), color = TextSecondary, fontSize = 12.sp)
-                } else {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Box(contentAlignment = Alignment.Center) {
-                            if (isLoggedIn) {
-                                Box(
-                                    modifier = Modifier
-                                        .size(10.dp)
-                                        .scale(pulseScale)
-                                        .clip(CircleShape)
-                                        .background(StatusGreen.copy(alpha = pulseAlpha)),
-                                )
-                            }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(contentAlignment = Alignment.Center) {
+                        if (isLoggedIn) {
                             Box(
                                 modifier = Modifier
-                                    .size(6.dp)
+                                    .size(10.dp)
+                                    .scale(pulseScale)
                                     .clip(CircleShape)
-                                    .background(
-                                        if (isLoggedIn) StatusGreen
-                                        else TextSecondary.copy(alpha = 0.4f)
-                                    ),
+                                    .background(StatusGreen.copy(alpha = pulseAlpha)),
                             )
                         }
-                        Spacer(Modifier.width(6.dp))
-                        Text(
-                            text = if (isLoggedIn) stringResource(R.string.common_ui_signed_in) else stringResource(R.string.google_cloud_status_not_signed_in),
-                            color = if (isLoggedIn) StatusGreen else TextSecondary,
-                            fontSize = 12.sp,
+                        Box(
+                            modifier = Modifier
+                                .size(6.dp)
+                                .clip(CircleShape)
+                                .background(
+                                    if (isLoggedIn) StatusGreen
+                                    else TextSecondary.copy(alpha = 0.4f)
+                                ),
                         )
                     }
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = if (isLoggedIn) stringResource(R.string.common_ui_signed_in) else stringResource(R.string.google_cloud_status_not_signed_in),
+                        color = if (isLoggedIn) StatusGreen else TextSecondary,
+                        fontSize = 12.sp,
+                    )
                 }
             }
 
-            if (isComingSoon) {
-                ComingSoonBadge()
-            } else {
-                ActionButton(
-                    label = if (isLoggedIn) "Sign Out" else "Sign In",
-                    textColor = if (isLoggedIn) DangerRed else accentColor,
-                    onClick = if (isLoggedIn) ({ showSignOutDialog = true }) else onSignIn,
-                )
-            }
+            ActionButton(
+                label = if (isLoggedIn) "Sign Out" else "Sign In",
+                textColor = if (isLoggedIn) DangerRed else accentColor,
+                onClick = if (isLoggedIn) ({ showSignOutDialog = true }) else onSignIn,
+            )
         }
-    }
-}
-
-@Composable
-private fun ComingSoonBadge() {
-    Row(
-        modifier = Modifier
-            .clip(RoundedCornerShape(6.dp))
-            .background(Color(0xFF262638))
-            .border(1.dp, Color(0xFF363650), RoundedCornerShape(6.dp))
-            .padding(horizontal = 10.dp, vertical = 5.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Icon(
-            imageVector = Icons.Filled.Lock,
-            contentDescription = null,
-            tint = TextSecondary,
-            modifier = Modifier.size(10.dp),
-        )
-        Text(
-            text = stringResource(R.string.common_ui_coming_soon).uppercase(),
-            color = TextSecondary,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 0.8.sp,
-        )
     }
 }
 

--- a/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
@@ -694,14 +694,13 @@ class UnifiedActivity : AppCompatActivity() {
         if (storeVisible["steam"] != false) base.add(TabDef("Steam", "steam"))
         if (storeVisible["epic"] != false) base.add(TabDef("Epic", "epic"))
         if (storeVisible["gog"] != false) base.add(TabDef("GOG", "gog"))
-        if (storeVisible["amazon"] != false) base.add(TabDef("Amazon", "amazon"))
         return base
     }
 
     // Main scaffold
     @Composable
     fun UnifiedHub() {
-        val storeVisible = remember { mutableStateMapOf("steam" to true, "epic" to true, "gog" to true, "amazon" to true) }
+        val storeVisible = remember { mutableStateMapOf("steam" to true, "epic" to true, "gog" to true) }
         var showAddCustomGame by remember { mutableStateOf(false) }
         var showExitDialog by remember { mutableStateOf(false) }
         var searchQueryTfv by remember { mutableStateOf(TextFieldValue("")) }
@@ -1046,7 +1045,6 @@ class UnifiedActivity : AppCompatActivity() {
                                 "gog" -> GOGStoreTab(isGogLoggedIn, searchQuery, libraryLayoutMode) {
                                     gogLoginLauncher.launch(Intent(this@UnifiedActivity, GOGOAuthActivity::class.java))
                                 }
-                                "amazon" -> StorePlaceholderTab("Amazon Games")
                                 else -> {}
                             }
                         }
@@ -5370,32 +5368,6 @@ class UnifiedActivity : AppCompatActivity() {
         }
     }
 
-    // Store placeholder tabs
-    @Composable
-    fun StorePlaceholderTab(storeName: String) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Icon(
-                    Icons.Outlined.Store,
-                    contentDescription = null,
-                    tint = TextSecondary,
-                    modifier = Modifier.size(64.dp)
-                )
-                Spacer(Modifier.height(16.dp))
-                Text("$storeName", style = MaterialTheme.typography.headlineSmall, color = TextPrimary, fontWeight = FontWeight.Bold)
-                Spacer(Modifier.height(8.dp))
-                Text(stringResource(R.string.common_ui_coming_soon), style = MaterialTheme.typography.bodyMedium, color = TextSecondary)
-                Spacer(Modifier.height(24.dp))
-                Button(
-                    onClick = { /* TODO: Wire sign-in flow */ },
-                    colors = ButtonDefaults.buttonColors(containerColor = Accent),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Text("Sign In to $storeName")
-                }
-            }
-        }
-    }
 
     // Game Manager Dialog
     @Composable
@@ -6594,7 +6566,7 @@ class UnifiedActivity : AppCompatActivity() {
                 Spacer(Modifier.height(8.dp))
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     DrawerFilterButton("GOG", storeVisible["gog"] == true, Modifier.weight(1f)) { storeVisible["gog"] = it }
-                    DrawerFilterButton("Amazon", storeVisible["amazon"] == true, Modifier.weight(1f)) { storeVisible["amazon"] = it }
+                    Spacer(Modifier.weight(1f))
                 }
 
                 Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/winlator/cmod/core/PreloaderDialogContent.kt
+++ b/app/src/main/java/com/winlator/cmod/core/PreloaderDialogContent.kt
@@ -98,7 +98,6 @@ private fun platformStringRes(source: String): Int? = when (source.uppercase()) 
     "EPIC" -> R.string.preloader_platform_epic
     "GOG" -> R.string.preloader_platform_gog
     "CUSTOM" -> R.string.preloader_platform_custom
-    "AMAZON" -> R.string.preloader_platform_amazon
     else -> null
 }
 
@@ -107,7 +106,6 @@ private fun platformColor(source: String): Color = when (source.uppercase()) {
     "EPIC" -> Color(0xFF8A8A8A)
     "GOG" -> Color(0xFFAB47BC)
     "CUSTOM" -> Color(0xFF4CAF50)
-    "AMAZON" -> Color(0xFFFF9800)
     else -> Color(0xFF57CBDE)
 }
 

--- a/app/src/main/java/com/winlator/cmod/google/CloudSyncManager.kt
+++ b/app/src/main/java/com/winlator/cmod/google/CloudSyncManager.kt
@@ -52,19 +52,10 @@ object CloudSyncManager {
     private const val ZIP_STEAM = "stores/steam.json"
     private const val ZIP_EPIC = "stores/epic_credentials.json"
     private const val ZIP_GOG = "stores/gog_auth.json"
-    private const val ZIP_AMAZON = "stores/amazon_credentials.json"
 
     private const val STORE_STEAM = "Steam"
     private const val STORE_EPIC = "Epic"
     private const val STORE_GOG = "GOG"
-    private const val STORE_AMAZON = "Amazon"
-
-    private const val AMAZON_PRIMARY_RELATIVE_PATH = "amazon/credentials.json"
-    private val AMAZON_DISCOVERY_PATHS = listOf(
-        AMAZON_PRIMARY_RELATIVE_PATH,
-        "amazon/auth.json",
-        "amazon_auth.json"
-    )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val syncMutex = Mutex()
@@ -644,7 +635,6 @@ object CloudSyncManager {
         exportSteam(context)?.let { stores[STORE_STEAM] = it }
         exportEpic(context)?.let { stores[STORE_EPIC] = it }
         exportGog(context)?.let { stores[STORE_GOG] = it }
-        exportAmazon(context)?.let { stores[STORE_AMAZON] = it }
 
         val createdAt = System.currentTimeMillis()
         val fingerprint = computeFingerprint(stores)
@@ -687,16 +677,6 @@ object CloudSyncManager {
         return if (file.exists()) file.readBytes() else null
     }
 
-    private fun exportAmazon(context: Context): ByteArray? {
-        for (relativePath in AMAZON_DISCOVERY_PATHS) {
-            val file = File(context.filesDir, relativePath)
-            if (file.exists()) {
-                return file.readBytes()
-            }
-        }
-        return null
-    }
-
     private fun restoreMissingStores(context: Context, payload: StorePayload): Set<String> {
         val restored = linkedSetOf<String>()
 
@@ -710,9 +690,6 @@ object CloudSyncManager {
                 }
                 STORE_GOG -> if (!GOGAuthManager.hasStoredCredentials(context) && restoreGog(context, bytes)) {
                     restored += STORE_GOG
-                }
-                STORE_AMAZON -> if (restoreAmazon(context, bytes)) {
-                    restored += STORE_AMAZON
                 }
             }
         }
@@ -773,19 +750,6 @@ object CloudSyncManager {
         }
     }
 
-    private fun restoreAmazon(context: Context, bytes: ByteArray): Boolean {
-        return runCatching {
-            Timber.tag(TAG).i("Restoring Amazon login tokens from cloud payload")
-            val file = File(context.filesDir, AMAZON_PRIMARY_RELATIVE_PATH)
-            file.parentFile?.mkdirs()
-            file.writeBytes(bytes)
-            true
-        }.getOrElse { error ->
-            Timber.tag(TAG).e(error, "Failed to restore Amazon login tokens")
-            false
-        }
-    }
-
     private fun payloadToZip(payload: StorePayload): ByteArray {
         val output = ByteArrayOutputStream()
         ZipOutputStream(output).use { zip ->
@@ -802,7 +766,6 @@ object CloudSyncManager {
                     STORE_STEAM -> ZIP_STEAM
                     STORE_EPIC -> ZIP_EPIC
                     STORE_GOG -> ZIP_GOG
-                    STORE_AMAZON -> ZIP_AMAZON
                     else -> null
                 }
                 if (entryName != null) {
@@ -831,7 +794,6 @@ object CloudSyncManager {
                     ZIP_STEAM -> stores[STORE_STEAM] = entryBytes
                     ZIP_EPIC -> stores[STORE_EPIC] = entryBytes
                     ZIP_GOG -> stores[STORE_GOG] = entryBytes
-                    ZIP_AMAZON -> stores[STORE_AMAZON] = entryBytes
                 }
                 zip.closeEntry()
                 entry = zip.nextEntry

--- a/app/src/main/java/com/winlator/cmod/steam/enums/GameSource.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/enums/GameSource.kt
@@ -4,7 +4,6 @@ enum class GameSource {
     STEAM,
     CUSTOM_GAME,
     GOG,
-    EPIC,
-    AMAZON
+    EPIC
     // Add other platforms here..
 }

--- a/app/src/main/java/com/winlator/cmod/steam/utils/PrefManager.kt
+++ b/app/src/main/java/com/winlator/cmod/steam/utils/PrefManager.kt
@@ -159,10 +159,6 @@ object PrefManager {
         get() = getString("gog_download_folder", "")
         set(value) { setString("gog_download_folder", value) }
 
-    var amazonDownloadFolder: String
-        get() = getString("amazon_download_folder", "")
-        set(value) { setString("amazon_download_folder", value) }
-
     var downloadQueueSize: Int
         get() = getInt("download_queue_size", 1)
         set(value) { setInt("download_queue_size", value) }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -920,6 +920,5 @@ Installeret sti:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Brugerdefineret spil</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -920,6 +920,5 @@ Installierter Pfad:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Eigenes Spiel</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -920,6 +920,5 @@ Ruta instalada:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Juego personalizado</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -920,6 +920,5 @@ Chemin installé :
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Jeu personnalisé</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -920,6 +920,5 @@ Percorso installato:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Gioco personalizzato</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -920,6 +920,5 @@
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">커스텀 게임</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -920,6 +920,5 @@ Zainstalowana ścieżka:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Gra niestandardowa</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -920,6 +920,5 @@ Caminho instalado:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Jogo personalizado</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -920,6 +920,5 @@ Cale instalata:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Joc personalizat</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -920,6 +920,5 @@
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Власна гра</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -920,6 +920,5 @@
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">自定义游戏</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -920,6 +920,5 @@
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">自訂遊戲</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -948,6 +948,5 @@ Installed path:
     <string name="preloader_platform_epic">Epic Games</string>
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Custom Game</string>
-    <string name="preloader_platform_amazon">Amazon</string>
 
 </resources>


### PR DESCRIPTION
- Drop Amazon tab, filter, and placeholder from UnifiedActivity
- Remove Amazon card and downloads folder from StoresScreen/StoresFragment
- Strip Amazon export/restore from CloudSyncManager
- Remove AMAZON from GameSource, amazonDownloadFolder pref, and preloader platform mapping
- Delete preloader_platform_amazon from all string resources
- Update README to list only Steam, Epic, and GOG