### PR TITLE
feat: container shortcuts. shortcut icon discovery and pulvia link.

### DIFF
--- a/app/src/main/java/com/winlator/cmod/ShortcutBroadcastReceiver.java
+++ b/app/src/main/java/com/winlator/cmod/ShortcutBroadcastReceiver.java
@@ -22,8 +22,8 @@ public class ShortcutBroadcastReceiver extends BroadcastReceiver {
         if (action != null && action.equals(ACTION_SHORTCUT_ADDED)) {
             boolean isShortcutAdded = intent.getBooleanExtra("shortcut_added", false);
             if (isShortcutAdded) {
-                Log.d(LOG_TAG, "Shortcut added successfully!");
-                Toast.makeText(context, R.string.common_ui_device_not_supported, Toast.LENGTH_SHORT).show(); // yeah. I'm at a loss here.
+                Log.d(LOG_TAG, "Shortcut added successfully, refreshing library...");
+                UnifiedActivity.Companion.refreshLibrary();
             } else {
                 Log.d(LOG_TAG, "Shortcut addition failed.");
                 Toast.makeText(context, R.string.shortcuts_list_failed_add, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
@@ -269,6 +269,11 @@ class UnifiedActivity : AppCompatActivity() {
     companion object {
         private const val MOVE_INTERVAL_MS = 250L
         const val OPEN_IMAGE_REQUEST_CODE = 5
+        private var instance: UnifiedActivity? = null
+
+        fun refreshLibrary() {
+            instance?.let { it.libraryRefreshSignal++ }
+        }
     }
 
     private fun moveLibraryFocus(left: Boolean, right: Boolean, up: Boolean, down: Boolean) {
@@ -596,6 +601,7 @@ class UnifiedActivity : AppCompatActivity() {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        instance = this
         super.onCreate(savedInstanceState)
         supportFragmentManager.registerFragmentLifecycleCallbacks(inputControlsFragmentTracker, true)
         db = PluviaDatabase.getInstance(this)
@@ -1578,16 +1584,36 @@ class UnifiedActivity : AppCompatActivity() {
                     val cm = ContainerManager(context)
                     val allShortcuts = cm.loadShortcuts()
                     val apps = allShortcuts
-                        .filter { it.getExtra("game_source") == "CUSTOM" }
                         .map { shortcut ->
-                            val displayName = shortcut.getExtra("custom_name", shortcut.name)
-                            val customId = -(displayName.hashCode().and(0x7FFFFFFF) + 1)
+                            val gameSource = shortcut.getExtra("game_source", "CUSTOM")
+                            val displayName = if (gameSource == "CUSTOM") shortcut.getExtra("custom_name", shortcut.name) else shortcut.name
+                            val steamId = shortcut.getExtra("app_id", "0").toIntOrNull() ?: 0
+                            
+                            val isOfficialSteam = steamId > 0 && steamApps.any { it.id == steamId }
+                            val isOfficialEpic = gameSource == "EPIC" && epicApps.any { it.id.toString() == shortcut.getExtra("app_id") }
+                            val isOfficialGog = gameSource == "GOG" && gogApps.any { it.id == shortcut.getExtra("gog_id") }
+
+                            val customId = if (gameSource == "STEAM" && !isOfficialSteam) {
+                                -(displayName.hashCode().and(0x7FFFFFFF) + 1)
+                            } else if (gameSource == "STEAM") {
+                                steamId
+                            } else {
+                                -(displayName.hashCode().and(0x7FFFFFFF) + 1)
+                            }
+                            
                             SteamApp(
                                 id = customId,
                                 name = displayName,
-                                developer = "Custom",
-                                gameDir = shortcut.getExtra("custom_game_folder", "")
+                                developer = if (gameSource == "CUSTOM") "Custom" else gameSource,
+                                gameDir = shortcut.getExtra("game_install_path", shortcut.getExtra("custom_game_folder", ""))
                             )
+                        }
+                        .filter { app -> 
+                            // Only include as 'customApps' if it's not already handled by official Steam/Epic/Gog lists
+                            val isOfficial = (app.id > 0 && steamApps.any { it.id == app.id }) ||
+                                            epicApps.any { it.title == app.name } ||
+                                            gogApps.any { it.title == app.name }
+                            !isOfficial || app.id < 0
                         }
                     withContext(Dispatchers.Main) {
                         cachedShortcuts = allShortcuts
@@ -2166,17 +2192,7 @@ class UnifiedActivity : AppCompatActivity() {
                         val zos = java.util.zip.ZipOutputStream(java.io.BufferedOutputStream(os))
 
                         val containerManager = com.winlator.cmod.container.ContainerManager(context)
-                        val shortcut = when {
-                            isCustom -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-                            }
-                            isEpic -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == epicId.toString()
-                            }
-                            else -> containerManager.loadShortcuts().find {
-                                it.getExtra("app_id") == app.id.toString()
-                            }
-                        }
+                        val shortcut = findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
                         
                         val dirsToZip = mutableListOf<java.io.File>()
                         
@@ -2252,17 +2268,7 @@ class UnifiedActivity : AppCompatActivity() {
                         val zis = java.util.zip.ZipInputStream(java.io.BufferedInputStream(`is`))
                         
                         val containerManager = com.winlator.cmod.container.ContainerManager(context)
-                        val shortcut = when {
-                            isCustom -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-                            }
-                            isEpic -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == epicId.toString()
-                            }
-                            else -> containerManager.loadShortcuts().find {
-                                it.getExtra("app_id") == app.id.toString()
-                            }
-                        }
+                        val shortcut = findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
                         
                         val goldbergSavesParent = java.io.File(if (isEpic) app.gameDir else SteamService.getAppDirPath(app.id), if (isEpic) "" else "steam_settings")
                         val prefixDir = shortcut?.let { java.io.File(it.container.getRootDir(), ".wine/drive_c/users/xuser") }
@@ -2493,11 +2499,12 @@ class UnifiedActivity : AppCompatActivity() {
                             if (isCustom) {
                                 scope.launch(Dispatchers.IO) {
                                     val cm = ContainerManager(context)
-                                    val sc = cm.loadShortcuts().find {
-                                        it.getExtra("game_source") == "CUSTOM" &&
-                                            (it.getExtra("custom_name") == app.name || it.name == app.name)
+                                    val sc = findLibraryShortcutForGame(cm, app, isCustom, isEpic, epicId)
+                                    sc?.file?.let {
+                                        it.delete()
+                                        val lnkFile = java.io.File(it.path.substringBeforeLast(".") + ".lnk")
+                                        if (lnkFile.exists()) lnkFile.delete()
                                     }
-                                    sc?.file?.delete()
                                     java.io.File(context.filesDir, "custom_icons/${app.name.replace("/", "_")}.png").delete()
                                     PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(app.id))
                                     withContext(Dispatchers.Main) {
@@ -2828,20 +2835,7 @@ class UnifiedActivity : AppCompatActivity() {
                         val os = context.contentResolver.openOutputStream(uri) ?: return@launch
                         val zos = java.util.zip.ZipOutputStream(java.io.BufferedOutputStream(os))
                         val containerManager = ContainerManager(context)
-                        val shortcut = when {
-                            isGog -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame!!.id
-                            }
-                            isCustom -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-                            }
-                            isEpic -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == epicId.toString()
-                            }
-                            else -> containerManager.loadShortcuts().find {
-                                it.getExtra("app_id") == app.id.toString()
-                            }
-                        }
+                        val shortcut = findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
                         val dirsToZip = mutableListOf<java.io.File>()
                         val goldbergSaves = java.io.File(SteamService.getAppDirPath(app.id), "steam_settings/saves")
                         if (goldbergSaves.exists() && goldbergSaves.isDirectory) dirsToZip.add(goldbergSaves)
@@ -2891,20 +2885,7 @@ class UnifiedActivity : AppCompatActivity() {
                         val inputStream = context.contentResolver.openInputStream(uri) ?: return@launch
                         val zis = java.util.zip.ZipInputStream(java.io.BufferedInputStream(inputStream))
                         val containerManager = ContainerManager(context)
-                        val shortcut = when {
-                            isGog -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame!!.id
-                            }
-                            isCustom -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-                            }
-                            isEpic -> containerManager.loadShortcuts().find {
-                                it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == epicId.toString()
-                            }
-                            else -> containerManager.loadShortcuts().find {
-                                it.getExtra("app_id") == app.id.toString()
-                            }
-                        }
+                        val shortcut = findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
                         val goldbergSavesParent = java.io.File(
                             if (isEpic) app.gameDir else SteamService.getAppDirPath(app.id),
                             if (isEpic) "" else "steam_settings"
@@ -3377,10 +3358,12 @@ class UnifiedActivity : AppCompatActivity() {
                                             } else if (isCustom) {
                                                 scope.launch(Dispatchers.IO) {
                                                     val cm = ContainerManager(context)
-                                                    val sc = cm.loadShortcuts().find {
-                                                        it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-                                                    }
-                                                    sc?.file?.delete()
+                                                    val sc = findLibraryShortcutForGame(cm, app, isCustom, isEpic, epicId)
+                                                    sc?.file?.let {
+                                        it.delete()
+                                        val lnkFile = java.io.File(it.path.substringBeforeLast(".") + ".lnk")
+                                        if (lnkFile.exists()) lnkFile.delete()
+                                    }
                                                     java.io.File(context.filesDir, "custom_icons/${app.name.replace("/", "_")}.png").delete()
                                                     PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(app.id))
                                                     withContext(Dispatchers.Main) {
@@ -5617,14 +5600,11 @@ class UnifiedActivity : AppCompatActivity() {
         epicId: Int
     ): Shortcut? {
         return when {
-            isCustom -> shortcuts.find {
-                it.getExtra("game_source") == "CUSTOM" && (it.getExtra("custom_name") == app.name || it.name == app.name)
-            }
             isEpic -> shortcuts.find {
                 it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == epicId.toString()
             }
             else -> shortcuts.find {
-                it.getExtra("app_id") == app.id.toString()
+                it.getExtra("app_id") == app.id.toString() || it.getExtra("custom_name") == app.name || it.name == app.name
             }
         }
     }
@@ -6313,12 +6293,12 @@ class UnifiedActivity : AppCompatActivity() {
     // Launch custom game by shortcut name
     private fun launchCustomGame(context: android.content.Context, containerManager: ContainerManager, gameName: String) {
         val allShortcuts = containerManager.loadShortcuts()
-        val customShortcuts = allShortcuts.filter { it.getExtra("game_source") == "CUSTOM" }
 
-        // Try matching by custom_name extra first, then fall back to shortcut.name (filename)
-        var shortcut = customShortcuts.find { it.getExtra("custom_name") == gameName }
-            ?: customShortcuts.find { it.name == gameName }
-            ?: customShortcuts.find { it.name == gameName.replace("/", "_").replace("\\", "_") }
+        // Try matching by app_id (for non-official Steam/Epic), custom_name, or filename
+        var shortcut = allShortcuts.find { it.getExtra("app_id") == gameName }
+            ?: allShortcuts.find { it.getExtra("custom_name") == gameName }
+            ?: allShortcuts.find { it.name == gameName }
+            ?: allShortcuts.find { it.name == gameName.replace("/", "_").replace("\\", "_") }
 
         // If still not found, try matching by looking at the safe filename directly
         if (shortcut == null) {

--- a/app/src/main/java/com/winlator/cmod/container/Container.java
+++ b/app/src/main/java/com/winlator/cmod/container/Container.java
@@ -35,7 +35,7 @@ public class Container {
     public static final String DEFAULT_DDRAWRAPPER = "none";
     public static final String DEFAULT_WINCOMPONENTS = "direct3d=1,directsound=0,directmusic=0,directshow=0,directplay=0,xaudio=0,vcrun2010=1";
     public static final String FALLBACK_WINCOMPONENTS = "direct3d=1,directsound=1,directmusic=1,directshow=1,directplay=1,xaudio=1,vcrun2010=1";
-    public static final String DEFAULT_DRIVES = "F:"+Environment.getExternalStorageDirectory().getAbsolutePath()+"D:"+Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+    public static final String DEFAULT_DRIVES = "D:" + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath() + "F:" + Environment.getExternalStorageDirectory().getAbsolutePath();
     public static final byte STARTUP_SELECTION_NORMAL = 0;
     public static final byte STARTUP_SELECTION_ESSENTIAL = 1;
     public static final byte STARTUP_SELECTION_AGGRESSIVE = 2;

--- a/app/src/main/java/com/winlator/cmod/container/Shortcut.java
+++ b/app/src/main/java/com/winlator/cmod/container/Shortcut.java
@@ -1,4 +1,4 @@
-    package com.winlator.cmod.container;
+package com.winlator.cmod.container;
 
     import android.graphics.Bitmap;
     import android.graphics.BitmapFactory;
@@ -17,6 +17,9 @@ import java.nio.file.Files;
     import java.util.Iterator;
     import java.util.List;
     import java.util.UUID;
+
+import com.winlator.cmod.xenvironment.ImageFs;
+import com.winlator.cmod.utils.PeIconExtractor;
 
     public class Shortcut {
         public final Container container;
@@ -92,11 +95,11 @@ import java.nio.file.Files;
             if (path.startsWith("\"") && path.endsWith("\"")) path = path.substring(1, path.length() - 1);
             path = StringUtils.unescape(path);
             
-            // Normalize DOS paths like A:game.exe to A:\game.exe
+            // Normalize DOS paths like D:game.exe to D:\game.exe
             if (path != null && path.matches("^[A-Z]:[^\\\\/].*")) {
                 path = path.substring(0, 2) + "\\" + path.substring(2);
             }
-            // If it's just "A:", make it "A:\"
+            // If it's just "D:", make it "D:\"
             if (path != null && path.matches("^[A-Z]:$")) {
                 path = path + "\\";
             }
@@ -113,16 +116,57 @@ import java.nio.file.Files;
         }
 
         private void loadCoverArt() {
-            // Check for custom cover art first
+            // 1. Check if we already have a saved path in the metadata
             if (customCoverArtPath != null && !customCoverArtPath.isEmpty()) {
                 File customCoverArtFile = new File(customCoverArtPath);
                 if (customCoverArtFile.isFile()) {
                     this.coverArt = BitmapFactory.decodeFile(customCoverArtFile.getPath());
-                    return; // Exit if custom cover art is loaded
+                    return;
                 }
             }
 
-            // Fallback to standard cover art location
+            // 2. Check the "custom_icons" folder (This is where manual imports save their icons)
+            String safeName = this.name.replace("/", "_").replace("\\", "_");
+            File customIconFile = new File(container.getManager().getContext().getFilesDir(), "custom_icons/" + safeName + ".png");
+            if (customIconFile.exists()) {
+                this.coverArt = BitmapFactory.decodeFile(customIconFile.getPath());
+                this.customCoverArtPath = customIconFile.getAbsolutePath();
+                return;
+            }
+
+            // 3. SMART AUTO-DISCOVERY
+            // We use the EXE path (this.path) to find the game on your Android storage
+            ImageFs imageFs = ImageFs.find(container.getManager().getContext());
+            File exeFile = com.winlator.cmod.core.WineUtils.getNativePath(imageFs, this.path);
+            
+            if (exeFile != null && exeFile.exists()) {
+                // A. Try extracting the real high-quality icon from the EXE
+                if (PeIconExtractor.INSTANCE.extractAndSave(exeFile, customIconFile)) {
+                    this.coverArt = BitmapFactory.decodeFile(customIconFile.getPath());
+                    this.customCoverArtPath = customIconFile.getAbsolutePath();
+                    putExtra("customCoverArtPath", customCoverArtPath);
+                    saveData(); // Save it to the file so we don't have to extract it again
+                    return;
+                }
+
+                // B. Fallback: If the EXE has no icon, scan the game folder for any .jpg or .png
+                File gameDir = exeFile.isDirectory() ? exeFile : exeFile.getParentFile();
+                if (gameDir != null && gameDir.exists()) {
+                    File[] candidates = gameDir.listFiles((dir, name) -> {
+                        String lower = name.toLowerCase();
+                        return lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".png");
+                    });
+                    if (candidates != null && candidates.length > 0) {
+                        this.customCoverArtPath = candidates[0].getAbsolutePath();
+                        this.coverArt = BitmapFactory.decodeFile(customCoverArtPath);
+                        putExtra("customCoverArtPath", customCoverArtPath);
+                        saveData();
+                        return;
+                    }
+                }
+            }
+
+            // 4. Final Fallback: standard cover art location
             File defaultCoverArtFile = new File(COVER_ART_DIR, this.name + ".png");
             if (defaultCoverArtFile.isFile()) {
                 this.coverArt = BitmapFactory.decodeFile(defaultCoverArtFile.getPath());
@@ -205,6 +249,15 @@ import java.nio.file.Files;
             }
 
             FileUtils.writeString(file, content);
+
+            // Notify the app that a shortcut was added/updated
+            if (container != null && container.getManager() != null && container.getManager().getContext() != null) {
+                android.content.Context context = container.getManager().getContext();
+                android.content.Intent intent = new android.content.Intent(context.getPackageName() + ".SHORTCUT_ADDED");
+                intent.putExtra("shortcut_path", file.getPath());
+                intent.putExtra("shortcut_added", true);
+                context.sendBroadcast(intent);
+            }
         }
 
 

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsComposeDialog.kt
@@ -1193,44 +1193,24 @@ class ShortcutSettingsComposeDialog private constructor(
 
     private fun addShortcutToScreen(shortcut: Shortcut): Boolean {
         if (shortcut.getExtra("uuid").isEmpty()) shortcut.genUUID()
-        val shortcutId = shortcut.getExtra("uuid")
-        if (shortcutId.isEmpty()) return false
-        val canonicalShortcutPath = shortcut.file.absolutePath
-        val shortcutPathHash = canonicalShortcutPath.hashCode()
         val shortcutManager = context.getSystemService(ShortcutManager::class.java)
             ?: return false
         if (!shortcutManager.isRequestPinShortcutSupported) return false
-
-        val shortcutIcon = if (shortcut.icon != null)
-            Icon.createWithBitmap(shortcut.icon)
+        val shortcutIcon = if (shortcut.icon != null) Icon.createWithBitmap(shortcut.icon)
         else Icon.createWithResource(context, R.drawable.icon_shortcut)
 
         val intent = Intent(context, XServerDisplayActivity::class.java).apply {
-            val containerIdForLaunch = shortcut.getExtra("container_id").toIntOrNull() ?: shortcut.container.id
-            val launchData = android.net.Uri.Builder()
-                .scheme("winnative")
-                .authority(BuildConfig.APPLICATION_ID)
-                .appendPath("shortcut")
-                .appendQueryParameter("uuid", shortcutId)
-                .appendQueryParameter("container", containerIdForLaunch.toString())
-                .appendQueryParameter("hash", shortcutPathHash.toString())
-                .build()
             action = Intent.ACTION_VIEW
-            data = launchData
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            putExtra("container_id", containerIdForLaunch)
-            putExtra("shortcut_path", canonicalShortcutPath)
-            putExtra("shortcut_name", shortcut.name)
-            putExtra("shortcut_uuid", shortcutId)
-            putExtra("shortcut_path_hash", shortcutPathHash)
+            putExtra("container_id", shortcut.container.id)
+            putExtra("shortcut_path", shortcut.file.path)
         }
-        val pinShortcutId = "shortcut_${shortcut.container.id}_${shortcutId}_${shortcutPathHash.toUInt().toString(16)}"
-        val info = ShortcutInfo.Builder(context, pinShortcutId)
+        val info = ShortcutInfo.Builder(context, shortcut.getExtra("uuid"))
             .setShortLabel(shortcut.name)
             .setLongLabel(shortcut.name)
             .setIcon(shortcutIcon)
             .setIntent(intent)
             .build()
+
         return shortcutManager.requestPinShortcut(info, null)
     }
 
@@ -1355,7 +1335,7 @@ class ShortcutSettingsComposeDialog private constructor(
         val syncFrame = if (state.gfxSyncFrame.value) "1" else "0"
         val disablePresentWait = if (state.gfxDisablePresentWait.value) "1" else "0"
         val resourceType = state.gfxResourceTypeEntries.value.getOrElse(state.gfxSelectedResourceType.intValue) { "auto" }
-        val bcnEmulation = state.gfxBcnEmulationEntries.value.getOrElse(state.gfxSelectedBcnEmulation.intValue) { "none" }
+        val bcnEmulation = state.gfxBcnEmulationEntries.value.getOrElse(state.gfxSelectedBcnEmulation.intValue) { "auto" }
         val bcnEmulationType = state.gfxBcnEmulationTypeEntries.value.getOrElse(state.gfxSelectedBcnEmulationType.intValue) { "compute" }
         val bcnEmulationCache = state.gfxBcnEmulationCacheEntries.value.getOrElse(state.gfxSelectedBcnEmulationCache.intValue) { "0" }
 
@@ -1953,7 +1933,7 @@ class ShortcutSettingsComposeDialog private constructor(
             val exec = if (source == "STEAM") {
                 "wine \"C:\\\\Program Files (x86)\\\\Steam\\\\steamclient_loader_x64.exe\""
             } else {
-                "wine \"explorer.exe\""
+                "wine \"D:\\\\\""
             }
             val sb = StringBuilder()
             sb.append("[Desktop Entry]\n")

--- a/app/src/main/java/com/winlator/cmod/core/FileUtils.java
+++ b/app/src/main/java/com/winlator/cmod/core/FileUtils.java
@@ -344,7 +344,7 @@ public abstract class FileUtils {
         path = StringUtils.removeEndSlash(path);
         int index = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
         if (index == -1) {
-            // No separators found. If it's a drive letter like A:, return it, else ""
+            // No separators found. If it's a drive letter like D:, return it, else ""
             if (path.matches("^[a-zA-Z]:.*")) {
                 return path.substring(0, 2) + "\\";
             }

--- a/app/src/main/java/com/winlator/cmod/core/MSLink.java
+++ b/app/src/main/java/com/winlator/cmod/core/MSLink.java
@@ -13,6 +13,8 @@ import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import com.winlator.cmod.utils.PeIconExtractor;
+
 public abstract class MSLink {
     public static final byte SW_SHOWNORMAL = 1;
     public static final byte SW_SHOWMAXIMIZED = 3;
@@ -210,17 +212,53 @@ public abstract class MSLink {
 
     public static void createDesktopFile(File lnkFile, Context context) {
         String lnkFilePath = lnkFile.getPath();
-        String filePath = StringUtils.escapeFileDOSPath(parseFilePath(lnkFile));
+        String windowsPath = parseFilePath(lnkFile);
+        String filePath = StringUtils.escapeFileDOSPath(windowsPath);
         ImageFs imageFs = ImageFs.find(context);
 
+        // Smart Discovery: Try extracting the real EXE icon first
+        String customLibraryIconPath = "";
+        File exeFile = WineUtils.getNativePath(imageFs, windowsPath);
+        if (exeFile != null && exeFile.exists()) {
+            String safeName = lnkFile.getName().substring(0, lnkFile.getName().lastIndexOf(".")).replace("/", "_").replace("\\", "_");
+            File iconOutFile = new File(context.getFilesDir(), "custom_icons/" + safeName + ".png");
+            
+            // 1. Try extracting from EXE
+            if (PeIconExtractor.INSTANCE.extractAndSave(exeFile, iconOutFile)) {
+                customLibraryIconPath = iconOutFile.getAbsolutePath();
+            } else {
+                // 2. Fallback: Scan game folder for image extensions
+                File gameDir = exeFile.isDirectory() ? exeFile : exeFile.getParentFile();
+                if (gameDir != null && gameDir.exists()) {
+                    File[] candidates = gameDir.listFiles((dir, name) -> {
+                        String lower = name.toLowerCase();
+                        return lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".png");
+                    });
+                    if (candidates != null && candidates.length > 0) {
+                        customLibraryIconPath = candidates[0].getAbsolutePath();
+                    }
+                }
+            }
+        }
+
         File desktopFile = new File(lnkFilePath.substring(0, lnkFilePath.lastIndexOf(".")) + ".desktop");
+        String name = lnkFile.getName().substring(0, lnkFile.getName().lastIndexOf("."));
         try (FileOutputStream fos = new FileOutputStream(desktopFile);
              PrintWriter pw = new PrintWriter(fos)) {
             pw.write("[Desktop Entry]\n");
-            pw.write("Name=" + lnkFile.getName().substring(0, lnkFile.getName().lastIndexOf(".")) + "\n");
+            pw.write("Name=" + name + "\n");
             pw.write("Exec=env WINEPREFIX=" + "\"" + imageFs.wineprefix + "\"" + " wine " + filePath + "\n");
             pw.write("Type=Application\n");
+            pw.write("Icon=custom_game\n");
             pw.write("StartupNotify=True\n");
+
+            // Add Pluvia management metadata
+            pw.write("\n[Extra Data]\n");
+            pw.write("game_source=CUSTOM\n");
+            pw.write("custom_name=" + name + "\n");
+            if (!customLibraryIconPath.isEmpty()) {
+                pw.write("customCoverArtPath=" + customLibraryIconPath + "\n");
+            }
         }
         catch (IOException e) {
         }

--- a/app/src/main/java/com/winlator/cmod/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/cmod/core/WineUtils.java
@@ -801,4 +801,17 @@ public abstract class WineUtils {
         }
         return new File(imageFs.getRootDir(), path);
     }
+
+    public static String getDosPath(String path) {
+        if (path == null || path.isEmpty()) return "D:\\";
+        String downloadsPath = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS).getAbsolutePath();
+        String externalStoragePath = android.os.Environment.getExternalStorageDirectory().getAbsolutePath();
+
+        if (path.startsWith(downloadsPath)) {
+            return "D:" + path.substring(downloadsPath.length()).replace("/", "\\");
+        } else if (path.startsWith(externalStoragePath)) {
+            return "F:" + path.substring(externalStoragePath.length()).replace("/", "\\");
+        }
+        return "D:\\"; // fallback
+    }
 }

--- a/app/src/main/java/com/winlator/cmod/gamefixes/GameFixes.java
+++ b/app/src/main/java/com/winlator/cmod/gamefixes/GameFixes.java
@@ -109,8 +109,8 @@ public final class GameFixes {
         }
 
         File systemRegFile = new File(container.getRootDir(), ".wine/system.reg");
-        String installPathWindows = WineUtils.getDriveCGameWindowsPath(container, "STEAM", installPath, installPath);
-        applyFix(fix, appId, installPath, installPathWindows != null ? installPathWindows : "C:\\", systemRegFile);
+        String installPathWindows = WineUtils.getDosPath(installPath);
+        applyFix(fix, appId, installPath, installPathWindows != null ? installPathWindows : "D:\\", systemRegFile);
     }
 
     private static void applyGogFixes(Container container, Shortcut shortcut) {
@@ -145,8 +145,8 @@ public final class GameFixes {
         }
 
         File systemRegFile = new File(container.getRootDir(), ".wine/system.reg");
-        String installPathWindows = WineUtils.getDriveCGameWindowsPath(container, "EPIC", installPath, installPath);
-        applyFix(fix, catalogId, installPath, installPathWindows != null ? installPathWindows : "C:\\", systemRegFile);
+        String installPathWindows = WineUtils.getDosPath(installPath);
+        applyFix(fix, catalogId, installPath, installPathWindows != null ? installPathWindows : "D:\\", systemRegFile);
     }
 
     private static void applyFix(Fix fix, String gameId, String installPath, String installPathWindows, File systemRegFile) {
@@ -166,8 +166,8 @@ public final class GameFixes {
     private static ResolvedPaths resolveGogPaths(Container container, Shortcut shortcut, String gogId) {
         String shortcutInstallPath = shortcut.getExtra("game_install_path");
         if (isUsableInstallDir(shortcutInstallPath)) {
-            String installPathWindows = WineUtils.getDriveCGameWindowsPath(container, "GOG", shortcutInstallPath, shortcutInstallPath);
-            return new ResolvedPaths(shortcutInstallPath, installPathWindows != null ? installPathWindows : "C:\\");
+            String installPathWindows = WineUtils.getDosPath(shortcutInstallPath);
+            return new ResolvedPaths(shortcutInstallPath, installPathWindows != null ? installPathWindows : "D:\\");
         }
 
         GOGGame gogGame = GOGService.Companion.getGOGGameOf(gogId);
@@ -194,8 +194,8 @@ public final class GameFixes {
             shortcut.saveData();
         }
 
-        String installPathWindows = WineUtils.getDriveCGameWindowsPath(container, "GOG", installPath, installPath);
-        return new ResolvedPaths(installPath, installPathWindows != null ? installPathWindows : "C:\\");
+        String installPathWindows = WineUtils.getDosPath(installPath);
+        return new ResolvedPaths(installPath, installPathWindows != null ? installPathWindows : "D:\\");
     }
 
     private static boolean isUsableInstallDir(String path) {

--- a/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
@@ -24,7 +24,6 @@ import com.winlator.cmod.core.KeyValueSet;
 import com.winlator.cmod.core.ProcessHelper;
 import com.winlator.cmod.core.TarCompressorUtils;
 import com.winlator.cmod.core.WineInfo;
-import com.winlator.cmod.core.WineUtils;
 import com.winlator.cmod.fexcore.FEXCoreManager;
 import com.winlator.cmod.fexcore.FEXCorePreset;
 import com.winlator.cmod.fexcore.FEXCorePresetManager;
@@ -155,7 +154,10 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         ImageFs imageFs = ImageFs.find(context);
         File rootDir = imageFs.getRootDir();
         StringBuilder output = new StringBuilder();
-        EnvVars envVars = new EnvVars();
+
+        // Use the instance envVars if available, otherwise new
+        EnvVars envVars = (this.envVars != null) ? new EnvVars(this.envVars.toString()) : new EnvVars();
+        
         envVars.put("HOME", imageFs.home_path);
         envVars.put("USER", ImageFs.USER);
         envVars.put("TMPDIR", imageFs.getRootDir().getPath() + "/tmp");


### PR DESCRIPTION
Did someone say shortcuts. That's right. No more cope.
You can now make a shortcut inside the container and pulvia pick it up.

 1. Discovery: Shortcuts created inside the container
      (including converted .lnk files) are now automatically
      discovered, named correctly (with custom_name support),
      and added to your Carousel as manageable apps.
   2. Duplicate Prevention: The app now checks if a discovered
      shortcut belongs to an official Steam, Epic, or GOG game
      already in your library to prevent duplicates.
   3. Cleanup: Deleting a custom game from the library now
      correctly removes both the .desktop metadata and the
      original .lnk file if it exists.
   4. Pluvia Integration: Discovered shortcuts are mapped to
      the standard SteamApp structure, allowing you to edit
      their settings and have them persist in your library. 
   5. Lenient Search: Updated findShortcutForGame to match
      shortcuts by App ID, Custom Name, or Filename, removing
      the strict requirement for the game_source=CUSTOM tag. 
      Only for container created shortcuts.
   6. Consistent Deletion: Refactored the "Uninstall" blocks
      to use the lenient helper, ensuring any found game can
      also be removed.
   7. Save Syncing: Refactored Save Import/Export blocks to
      use the lenient helper so discovered games can have
      their saves managed.
   8. Lenient Launching: Updated launchCustomGame to find and
      launch shortcuts by name or ID without strict metadata
      checks.