### PR TITLE
chore: Add missing locale translations

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -952,4 +952,36 @@ Installeret sti:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Brugerdefineret spil</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Grafik</string>
+    <string name="container_backups_title">Sikkerhedskopier</string>
+    <string name="container_backups_prompt">Vælg en handling for denne containersikkerhedskopi.</string>
+    <string name="container_backups_backing_up">Sikkerhedskopierer container…</string>
+    <string name="container_backups_restoring">Gendanner container…</string>
+    <string name="container_backups_checking">Kontrollerer containersikkerhedskopier…</string>
+    <string name="container_backups_select_title">Vælg sikkerhedskopi der skal gendannes</string>
+    <string name="container_backups_no_files">Der blev ikke fundet nogen containersikkerhedskopier i Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Sekundær binding</string>
+    <string name="input_controls_editor_tap_to_switch">Tryk for at skifte</string>
+    <string name="input_controls_editor_download_profile">Download profil</string>
+    <string name="container_config_emulator_section">Emulator</string>
+    <string name="container_no_wine_installed">Ingen Wine eller Proton er installeret. Installer en først.</string>
+    <string name="session_drawer_fps_monitor">FPS-overvågning</string>
+    <string name="session_drawer_fps_monitor_subtitle">Vis ydeevnestatistik i realtid</string>
+    <string name="session_drawer_dual_series_battery">Dual Series-batteri</string>
+    <string name="settings_general_check_for_updates">Søg efter opdateringer</string>
+    <string name="settings_general_check_for_updates_summary">Søg automatisk efter nye appversioner ved opstart og med jævne mellemrum.</string>
+    <string name="setup_wizard_containers">Containeropsætning</string>
+    <string name="google_cloud_auto_backup">Automatisk sikkerhedskopi af Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Sikkerhedskopiér automatisk spilsaves til Google Drive hver gang du afslutter et spil.</string>
+    <string name="cloud_saves_title">Cloud-saves</string>
+    <string name="cloud_saves_backup">Sikkerhedskopiér cloud-save</string>
+    <string name="cloud_saves_restore">Gendan cloud-save</string>
+    <string name="cloud_sync_title">Cloud Sync</string>
+    <string name="cloud_sync_enabled_summary">Download cloud-saves ved opstart og synkroniser/sikkerhedskopiér dem ved afslutning.</string>
+    <string name="cloud_sync_disabled_summary">Start dette spil uden download af cloud-save eller synkronisering ved afslutning.</string>
+    <string name="cloud_saves_backing_up">Sikkerhedskopierer cloud-save…</string>
+    <string name="cloud_saves_restoring">Gendanner cloud-save…</string>
+
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -952,4 +952,36 @@ Installierter Pfad:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Eigenes Spiel</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Grafik</string>
+    <string name="container_backups_title">Sicherungen</string>
+    <string name="container_backups_prompt">Wähle eine Aktion für diese Containersicherung.</string>
+    <string name="container_backups_backing_up">Container wird gesichert…</string>
+    <string name="container_backups_restoring">Container wird wiederhergestellt…</string>
+    <string name="container_backups_checking">Containersicherungen werden geprüft…</string>
+    <string name="container_backups_select_title">Sicherung zum Wiederherstellen auswählen</string>
+    <string name="container_backups_no_files">Keine Containersicherungen in Google Drive gefunden.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Sekundäre Belegung</string>
+    <string name="input_controls_editor_tap_to_switch">Tippen zum Wechseln</string>
+    <string name="input_controls_editor_download_profile">Profil herunterladen</string>
+    <string name="container_config_emulator_section">Emulator</string>
+    <string name="container_no_wine_installed">Kein Wine oder Proton installiert. Installiere zuerst eines.</string>
+    <string name="session_drawer_fps_monitor">FPS-Monitor</string>
+    <string name="session_drawer_fps_monitor_subtitle">Leistungsstatistiken in Echtzeit anzeigen</string>
+    <string name="session_drawer_dual_series_battery">Dual-Series-Akku</string>
+    <string name="settings_general_check_for_updates">Nach Updates suchen</string>
+    <string name="settings_general_check_for_updates_summary">Beim Start und regelmäßig automatisch nach neuen App-Versionen suchen.</string>
+    <string name="setup_wizard_containers">Container-Einrichtung</string>
+    <string name="google_cloud_auto_backup">Automatische Cloud-Sync-Sicherung</string>
+    <string name="google_cloud_auto_backup_summary">Spielstände bei jedem Beenden eines Spiels automatisch in Google Drive sichern.</string>
+    <string name="cloud_saves_title">Cloud-Speicherstände</string>
+    <string name="cloud_saves_backup">Cloud-Speicherstand sichern</string>
+    <string name="cloud_saves_restore">Cloud-Speicherstand wiederherstellen</string>
+    <string name="cloud_sync_title">Cloud-Synchronisierung</string>
+    <string name="cloud_sync_enabled_summary">Cloud-Speicherstände beim Start herunterladen und beim Beenden synchronisieren/sichern.</string>
+    <string name="cloud_sync_disabled_summary">Dieses Spiel ohne Cloud-Speicherstand-Download oder Synchronisierung beim Beenden starten.</string>
+    <string name="cloud_saves_backing_up">Cloud-Speicherstand wird gesichert…</string>
+    <string name="cloud_saves_restoring">Cloud-Speicherstand wird wiederhergestellt…</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -952,4 +952,36 @@ Ruta instalada:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Juego personalizado</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Gráficos</string>
+    <string name="container_backups_title">Copias de seguridad</string>
+    <string name="container_backups_prompt">Elige una acción para esta copia de seguridad del contenedor.</string>
+    <string name="container_backups_backing_up">Creando copia de seguridad del contenedor…</string>
+    <string name="container_backups_restoring">Restaurando contenedor…</string>
+    <string name="container_backups_checking">Comprobando copias de seguridad del contenedor…</string>
+    <string name="container_backups_select_title">Selecciona la copia para restaurar</string>
+    <string name="container_backups_no_files">No se encontraron copias de seguridad del contenedor en Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Asignación secundaria</string>
+    <string name="input_controls_editor_tap_to_switch">Toca para cambiar</string>
+    <string name="input_controls_editor_download_profile">Descargar perfil</string>
+    <string name="container_config_emulator_section">Emulador</string>
+    <string name="container_no_wine_installed">No hay Wine ni Proton instalados. Instala uno primero.</string>
+    <string name="session_drawer_fps_monitor">Monitor de FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Mostrar estadísticas de rendimiento en tiempo real</string>
+    <string name="session_drawer_dual_series_battery">Batería Dual Series</string>
+    <string name="settings_general_check_for_updates">Buscar actualizaciones</string>
+    <string name="settings_general_check_for_updates_summary">Buscar automáticamente nuevas versiones de la aplicación al iniciar y periódicamente.</string>
+    <string name="setup_wizard_containers">Configuración del contenedor</string>
+    <string name="google_cloud_auto_backup">Copia automática de Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Haz una copia automática de los guardados del juego en Google Drive cada vez que salgas de un juego.</string>
+    <string name="cloud_saves_title">Guardados en la nube</string>
+    <string name="cloud_saves_backup">Hacer copia del guardado en la nube</string>
+    <string name="cloud_saves_restore">Restaurar guardado en la nube</string>
+    <string name="cloud_sync_title">Sincronización en la nube</string>
+    <string name="cloud_sync_enabled_summary">Descarga los guardados en la nube al iniciar y sincronízalos o respáldalos al salir.</string>
+    <string name="cloud_sync_disabled_summary">Inicia este juego sin descarga de guardados en la nube ni sincronización al salir.</string>
+    <string name="cloud_saves_backing_up">Respaldando guardado en la nube…</string>
+    <string name="cloud_saves_restoring">Restaurando guardado en la nube…</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -952,4 +952,36 @@ Chemin installé :
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Jeu personnalisé</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Graphismes</string>
+    <string name="container_backups_title">Sauvegardes</string>
+    <string name="container_backups_prompt">Choisissez une action pour cette sauvegarde de conteneur.</string>
+    <string name="container_backups_backing_up">Sauvegarde du conteneur…</string>
+    <string name="container_backups_restoring">Restauration du conteneur…</string>
+    <string name="container_backups_checking">Vérification des sauvegardes du conteneur…</string>
+    <string name="container_backups_select_title">Sélectionner une sauvegarde à restaurer</string>
+    <string name="container_backups_no_files">Aucune sauvegarde de conteneur trouvée dans Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Affectation secondaire</string>
+    <string name="input_controls_editor_tap_to_switch">Touchez pour basculer</string>
+    <string name="input_controls_editor_download_profile">Télécharger le profil</string>
+    <string name="container_config_emulator_section">Émulateur</string>
+    <string name="container_no_wine_installed">Aucun Wine ou Proton installé. Installez-en un d\'abord.</string>
+    <string name="session_drawer_fps_monitor">Moniteur FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Afficher les statistiques de performance en temps réel</string>
+    <string name="session_drawer_dual_series_battery">Batterie Dual Series</string>
+    <string name="settings_general_check_for_updates">Rechercher des mises à jour</string>
+    <string name="settings_general_check_for_updates_summary">Rechercher automatiquement de nouvelles versions de l\'application au lancement et périodiquement.</string>
+    <string name="setup_wizard_containers">Configuration du conteneur</string>
+    <string name="google_cloud_auto_backup">Sauvegarde automatique Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Sauvegardez automatiquement les sauvegardes de jeu sur Google Drive chaque fois que vous quittez un jeu.</string>
+    <string name="cloud_saves_title">Sauvegardes cloud</string>
+    <string name="cloud_saves_backup">Sauvegarder la sauvegarde cloud</string>
+    <string name="cloud_saves_restore">Restaurer la sauvegarde cloud</string>
+    <string name="cloud_sync_title">Synchronisation cloud</string>
+    <string name="cloud_sync_enabled_summary">Téléchargez les sauvegardes cloud au lancement et synchronisez-les/sauvegardez-les à la fermeture.</string>
+    <string name="cloud_sync_disabled_summary">Lancez ce jeu sans téléchargement de sauvegarde cloud ni synchronisation à la fermeture.</string>
+    <string name="cloud_saves_backing_up">Sauvegarde cloud en cours…</string>
+    <string name="cloud_saves_restoring">Restauration de la sauvegarde cloud…</string>
+
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -952,4 +952,36 @@ Percorso installato:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Gioco personalizzato</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Grafica</string>
+    <string name="container_backups_title">Backup</string>
+    <string name="container_backups_prompt">Scegli un\'azione per questo backup del container.</string>
+    <string name="container_backups_backing_up">Backup del container in corso…</string>
+    <string name="container_backups_restoring">Ripristino del container in corso…</string>
+    <string name="container_backups_checking">Controllo dei backup del container…</string>
+    <string name="container_backups_select_title">Seleziona il backup da ripristinare</string>
+    <string name="container_backups_no_files">Nessun backup del container trovato in Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Associazione secondaria</string>
+    <string name="input_controls_editor_tap_to_switch">Tocca per cambiare</string>
+    <string name="input_controls_editor_download_profile">Scarica profilo</string>
+    <string name="container_config_emulator_section">Emulatore</string>
+    <string name="container_no_wine_installed">Nessun Wine o Proton installato. Installane uno prima.</string>
+    <string name="session_drawer_fps_monitor">Monitor FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Mostra statistiche prestazioni in tempo reale</string>
+    <string name="session_drawer_dual_series_battery">Batteria Dual Series</string>
+    <string name="settings_general_check_for_updates">Controlla aggiornamenti</string>
+    <string name="settings_general_check_for_updates_summary">Controlla automaticamente la presenza di nuove versioni dell\'app all\'avvio e periodicamente.</string>
+    <string name="setup_wizard_containers">Configurazione container</string>
+    <string name="google_cloud_auto_backup">Backup automatico Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Esegui automaticamente il backup dei salvataggi di gioco su Google Drive ogni volta che esci da un gioco.</string>
+    <string name="cloud_saves_title">Salvataggi cloud</string>
+    <string name="cloud_saves_backup">Backup salvataggio cloud</string>
+    <string name="cloud_saves_restore">Ripristina salvataggio cloud</string>
+    <string name="cloud_sync_title">Sincronizzazione cloud</string>
+    <string name="cloud_sync_enabled_summary">Scarica i salvataggi cloud all\'avvio e sincronizzali/esegui il backup all\'uscita.</string>
+    <string name="cloud_sync_disabled_summary">Avvia questo gioco senza scaricare i salvataggi cloud né sincronizzarli all\'uscita.</string>
+    <string name="cloud_saves_backing_up">Backup salvataggio cloud in corso…</string>
+    <string name="cloud_saves_restoring">Ripristino salvataggio cloud in corso…</string>
+
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -952,4 +952,36 @@
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">커스텀 게임</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">그래픽</string>
+    <string name="container_backups_title">백업</string>
+    <string name="container_backups_prompt">이 컨테이너 백업에 대해 수행할 작업을 선택하세요.</string>
+    <string name="container_backups_backing_up">컨테이너 백업 중…</string>
+    <string name="container_backups_restoring">컨테이너 복원 중…</string>
+    <string name="container_backups_checking">컨테이너 백업 확인 중…</string>
+    <string name="container_backups_select_title">복원할 백업 선택</string>
+    <string name="container_backups_no_files">Google Drive에서 컨테이너 백업을 찾지 못했습니다.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">보조 바인딩</string>
+    <string name="input_controls_editor_tap_to_switch">탭하여 전환</string>
+    <string name="input_controls_editor_download_profile">프로필 다운로드</string>
+    <string name="container_config_emulator_section">에뮬레이터</string>
+    <string name="container_no_wine_installed">Wine 또는 Proton이 설치되어 있지 않습니다. 먼저 하나를 설치하세요.</string>
+    <string name="session_drawer_fps_monitor">FPS 모니터</string>
+    <string name="session_drawer_fps_monitor_subtitle">실시간 성능 통계 표시</string>
+    <string name="session_drawer_dual_series_battery">듀얼 시리즈 배터리</string>
+    <string name="settings_general_check_for_updates">업데이트 확인</string>
+    <string name="settings_general_check_for_updates_summary">앱 실행 시와 주기적으로 새 버전을 자동으로 확인합니다.</string>
+    <string name="setup_wizard_containers">컨테이너 설정</string>
+    <string name="google_cloud_auto_backup">클라우드 동기화 자동 백업</string>
+    <string name="google_cloud_auto_backup_summary">게임을 종료할 때마다 게임 저장 데이터를 Google Drive에 자동으로 백업합니다.</string>
+    <string name="cloud_saves_title">클라우드 저장</string>
+    <string name="cloud_saves_backup">클라우드 저장 백업</string>
+    <string name="cloud_saves_restore">클라우드 저장 복원</string>
+    <string name="cloud_sync_title">클라우드 동기화</string>
+    <string name="cloud_sync_enabled_summary">실행 시 클라우드 저장을 다운로드하고 종료 시 동기화/백업합니다.</string>
+    <string name="cloud_sync_disabled_summary">클라우드 저장 다운로드나 종료 시 동기화 없이 이 게임을 실행합니다.</string>
+    <string name="cloud_saves_backing_up">클라우드 저장 백업 중…</string>
+    <string name="cloud_saves_restoring">클라우드 저장 복원 중…</string>
+
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -952,4 +952,36 @@ Zainstalowana ścieżka:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Gra niestandardowa</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Grafika</string>
+    <string name="container_backups_title">Kopie zapasowe</string>
+    <string name="container_backups_prompt">Wybierz działanie dla tej kopii zapasowej kontenera.</string>
+    <string name="container_backups_backing_up">Tworzenie kopii zapasowej kontenera…</string>
+    <string name="container_backups_restoring">Przywracanie kontenera…</string>
+    <string name="container_backups_checking">Sprawdzanie kopii zapasowych kontenera…</string>
+    <string name="container_backups_select_title">Wybierz kopię zapasową do przywrócenia</string>
+    <string name="container_backups_no_files">Nie znaleziono kopii zapasowych kontenera na Dysku Google.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Drugie przypisanie</string>
+    <string name="input_controls_editor_tap_to_switch">Dotknij, aby przełączyć</string>
+    <string name="input_controls_editor_download_profile">Pobierz profil</string>
+    <string name="container_config_emulator_section">Emulator</string>
+    <string name="container_no_wine_installed">Nie zainstalowano Wine ani Proton. Najpierw zainstaluj jeden z nich.</string>
+    <string name="session_drawer_fps_monitor">Monitor FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Pokaż statystyki wydajności w czasie rzeczywistym</string>
+    <string name="session_drawer_dual_series_battery">Bateria Dual Series</string>
+    <string name="settings_general_check_for_updates">Sprawdź aktualizacje</string>
+    <string name="settings_general_check_for_updates_summary">Automatycznie sprawdzaj nowe wersje aplikacji przy uruchomieniu i okresowo.</string>
+    <string name="setup_wizard_containers">Konfiguracja kontenera</string>
+    <string name="google_cloud_auto_backup">Automatyczna kopia Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Automatycznie twórz kopie zapasowe zapisów gry na Dysku Google przy każdym wyjściu z gry.</string>
+    <string name="cloud_saves_title">Zapisy w chmurze</string>
+    <string name="cloud_saves_backup">Utwórz kopię zapisu w chmurze</string>
+    <string name="cloud_saves_restore">Przywróć zapis w chmurze</string>
+    <string name="cloud_sync_title">Synchronizacja z chmurą</string>
+    <string name="cloud_sync_enabled_summary">Pobieraj zapisy z chmury przy uruchomieniu oraz synchronizuj/twórz ich kopie przy wyjściu.</string>
+    <string name="cloud_sync_disabled_summary">Uruchom tę grę bez pobierania zapisów z chmury i bez synchronizacji przy wyjściu.</string>
+    <string name="cloud_saves_backing_up">Tworzenie kopii zapisu w chmurze…</string>
+    <string name="cloud_saves_restoring">Przywracanie zapisu w chmurze…</string>
+
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -952,4 +952,36 @@ Caminho instalado:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Jogo personalizado</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Gráficos</string>
+    <string name="container_backups_title">Backups</string>
+    <string name="container_backups_prompt">Escolha uma ação para este backup do contêiner.</string>
+    <string name="container_backups_backing_up">Fazendo backup do contêiner…</string>
+    <string name="container_backups_restoring">Restaurando contêiner…</string>
+    <string name="container_backups_checking">Verificando backups do contêiner…</string>
+    <string name="container_backups_select_title">Selecione o backup para restaurar</string>
+    <string name="container_backups_no_files">Nenhum backup de contêiner foi encontrado no Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Vinculação secundária</string>
+    <string name="input_controls_editor_tap_to_switch">Toque para alternar</string>
+    <string name="input_controls_editor_download_profile">Baixar perfil</string>
+    <string name="container_config_emulator_section">Emulador</string>
+    <string name="container_no_wine_installed">Nenhum Wine ou Proton instalado. Instale um primeiro.</string>
+    <string name="session_drawer_fps_monitor">Monitor de FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Mostrar estatísticas de desempenho em tempo real</string>
+    <string name="session_drawer_dual_series_battery">Bateria Dual Series</string>
+    <string name="settings_general_check_for_updates">Verificar atualizações</string>
+    <string name="settings_general_check_for_updates_summary">Verifique automaticamente novas versões do app ao iniciar e periodicamente.</string>
+    <string name="setup_wizard_containers">Configuração do contêiner</string>
+    <string name="google_cloud_auto_backup">Backup automático do Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Faça backup automático dos salvamentos do jogo no Google Drive sempre que sair de um jogo.</string>
+    <string name="cloud_saves_title">Salvamentos na nuvem</string>
+    <string name="cloud_saves_backup">Fazer backup do salvamento na nuvem</string>
+    <string name="cloud_saves_restore">Restaurar salvamento na nuvem</string>
+    <string name="cloud_sync_title">Sincronização na nuvem</string>
+    <string name="cloud_sync_enabled_summary">Baixe os salvamentos na nuvem ao iniciar e sincronize/faça backup deles ao sair.</string>
+    <string name="cloud_sync_disabled_summary">Inicie este jogo sem baixar salvamentos na nuvem nem sincronizar ao sair.</string>
+    <string name="cloud_saves_backing_up">Fazendo backup do salvamento na nuvem…</string>
+    <string name="cloud_saves_restoring">Restaurando salvamento na nuvem…</string>
+
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -952,4 +952,36 @@ Cale instalata:
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Joc personalizat</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Grafică</string>
+    <string name="container_backups_title">Copii de rezervă</string>
+    <string name="container_backups_prompt">Alege o acțiune pentru această copie de rezervă a containerului.</string>
+    <string name="container_backups_backing_up">Se face copia de rezervă a containerului…</string>
+    <string name="container_backups_restoring">Se restaurează containerul…</string>
+    <string name="container_backups_checking">Se verifică copiile de rezervă ale containerului…</string>
+    <string name="container_backups_select_title">Selectează copia de rezervă de restaurat</string>
+    <string name="container_backups_no_files">Nu au fost găsite copii de rezervă ale containerului în Google Drive.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Asociere secundară</string>
+    <string name="input_controls_editor_tap_to_switch">Atinge pentru a schimba</string>
+    <string name="input_controls_editor_download_profile">Descarcă profilul</string>
+    <string name="container_config_emulator_section">Emulator</string>
+    <string name="container_no_wine_installed">Nu este instalat Wine sau Proton. Instalează unul mai întâi.</string>
+    <string name="session_drawer_fps_monitor">Monitor FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Afișează statisticile de performanță în timp real</string>
+    <string name="session_drawer_dual_series_battery">Baterie Dual Series</string>
+    <string name="settings_general_check_for_updates">Verifică actualizările</string>
+    <string name="settings_general_check_for_updates_summary">Verifică automat dacă există versiuni noi ale aplicației la pornire și periodic.</string>
+    <string name="setup_wizard_containers">Configurare container</string>
+    <string name="google_cloud_auto_backup">Backup automat Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Salvează automat copiile de rezervă ale jocurilor în Google Drive de fiecare dată când ieși dintr-un joc.</string>
+    <string name="cloud_saves_title">Salvări în cloud</string>
+    <string name="cloud_saves_backup">Fă backup salvării în cloud</string>
+    <string name="cloud_saves_restore">Restaurează salvarea în cloud</string>
+    <string name="cloud_sync_title">Sincronizare în cloud</string>
+    <string name="cloud_sync_enabled_summary">Descarcă salvările din cloud la pornire și sincronizează/fă backup la ieșire.</string>
+    <string name="cloud_sync_disabled_summary">Pornește acest joc fără descărcarea salvărilor din cloud sau sincronizare la ieșire.</string>
+    <string name="cloud_saves_backing_up">Se face backup salvării în cloud…</string>
+    <string name="cloud_saves_restoring">Se restaurează salvarea în cloud…</string>
+
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -952,4 +952,36 @@
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">Власна гра</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">Графіка</string>
+    <string name="container_backups_title">Резервні копії</string>
+    <string name="container_backups_prompt">Виберіть дію для цієї резервної копії контейнера.</string>
+    <string name="container_backups_backing_up">Створення резервної копії контейнера…</string>
+    <string name="container_backups_restoring">Відновлення контейнера…</string>
+    <string name="container_backups_checking">Перевірка резервних копій контейнера…</string>
+    <string name="container_backups_select_title">Виберіть резервну копію для відновлення</string>
+    <string name="container_backups_no_files">У Google Drive не знайдено резервних копій контейнера.</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">Вторинне призначення</string>
+    <string name="input_controls_editor_tap_to_switch">Торкніться, щоб перемкнути</string>
+    <string name="input_controls_editor_download_profile">Завантажити профіль</string>
+    <string name="container_config_emulator_section">Емулятор</string>
+    <string name="container_no_wine_installed">Wine або Proton не встановлено. Спочатку встановіть один із них.</string>
+    <string name="session_drawer_fps_monitor">Монітор FPS</string>
+    <string name="session_drawer_fps_monitor_subtitle">Показувати статистику продуктивності в реальному часі</string>
+    <string name="session_drawer_dual_series_battery">Батарея Dual Series</string>
+    <string name="settings_general_check_for_updates">Перевірити оновлення</string>
+    <string name="settings_general_check_for_updates_summary">Автоматично перевіряти нові версії застосунку під час запуску та періодично.</string>
+    <string name="setup_wizard_containers">Налаштування контейнера</string>
+    <string name="google_cloud_auto_backup">Автоматичне резервне копіювання Cloud Sync</string>
+    <string name="google_cloud_auto_backup_summary">Автоматично створювати резервні копії збережень гри в Google Drive щоразу після виходу з гри.</string>
+    <string name="cloud_saves_title">Хмарні збереження</string>
+    <string name="cloud_saves_backup">Створити резервну копію хмарного збереження</string>
+    <string name="cloud_saves_restore">Відновити хмарне збереження</string>
+    <string name="cloud_sync_title">Хмарна синхронізація</string>
+    <string name="cloud_sync_enabled_summary">Завантажувати хмарні збереження під час запуску та синхронізувати/резервувати їх під час виходу.</string>
+    <string name="cloud_sync_disabled_summary">Запустити цю гру без завантаження хмарних збережень і синхронізації при виході.</string>
+    <string name="cloud_saves_backing_up">Створення резервної копії хмарного збереження…</string>
+    <string name="cloud_saves_restoring">Відновлення хмарного збереження…</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -952,4 +952,36 @@
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">自定义游戏</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">图形</string>
+    <string name="container_backups_title">备份</string>
+    <string name="container_backups_prompt">选择对此容器备份执行的操作。</string>
+    <string name="container_backups_backing_up">正在备份容器…</string>
+    <string name="container_backups_restoring">正在恢复容器…</string>
+    <string name="container_backups_checking">正在检查容器备份…</string>
+    <string name="container_backups_select_title">选择要恢复的备份</string>
+    <string name="container_backups_no_files">未在 Google Drive 中找到容器备份。</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">次要绑定</string>
+    <string name="input_controls_editor_tap_to_switch">点按切换</string>
+    <string name="input_controls_editor_download_profile">下载配置文件</string>
+    <string name="container_config_emulator_section">模拟器</string>
+    <string name="container_no_wine_installed">未安装 Wine 或 Proton。请先安装一个。</string>
+    <string name="session_drawer_fps_monitor">FPS 监视器</string>
+    <string name="session_drawer_fps_monitor_subtitle">显示实时性能统计信息</string>
+    <string name="session_drawer_dual_series_battery">Dual Series 电量</string>
+    <string name="settings_general_check_for_updates">检查更新</string>
+    <string name="settings_general_check_for_updates_summary">在启动时和定期自动检查新版本。</string>
+    <string name="setup_wizard_containers">容器设置</string>
+    <string name="google_cloud_auto_backup">云同步自动备份</string>
+    <string name="google_cloud_auto_backup_summary">每次退出游戏时自动将游戏存档备份到 Google Drive。</string>
+    <string name="cloud_saves_title">云存档</string>
+    <string name="cloud_saves_backup">备份云存档</string>
+    <string name="cloud_saves_restore">恢复云存档</string>
+    <string name="cloud_sync_title">云同步</string>
+    <string name="cloud_sync_enabled_summary">启动时下载云存档，并在退出时同步/备份。</string>
+    <string name="cloud_sync_disabled_summary">启动此游戏时不下载云存档，也不在退出时同步。</string>
+    <string name="cloud_saves_backing_up">正在备份云存档…</string>
+    <string name="cloud_saves_restoring">正在恢复云存档…</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -952,4 +952,36 @@
     <string name="preloader_platform_gog">GOG</string>
     <string name="preloader_platform_custom">自訂遊戲</string>
 
+    <!-- Missing translations -->
+    <string name="common_ui_graphics">圖形</string>
+    <string name="container_backups_title">備份</string>
+    <string name="container_backups_prompt">選擇要對此容器備份執行的操作。</string>
+    <string name="container_backups_backing_up">正在備份容器…</string>
+    <string name="container_backups_restoring">正在還原容器…</string>
+    <string name="container_backups_checking">正在檢查容器備份…</string>
+    <string name="container_backups_select_title">選擇要還原的備份</string>
+    <string name="container_backups_no_files">未在 Google Drive 中找到容器備份。</string>
+    <string name="steam_section_title">Steam</string>
+    <string name="binding_secondary">次要綁定</string>
+    <string name="input_controls_editor_tap_to_switch">點按切換</string>
+    <string name="input_controls_editor_download_profile">下載設定檔</string>
+    <string name="container_config_emulator_section">模擬器</string>
+    <string name="container_no_wine_installed">尚未安裝 Wine 或 Proton。請先安裝其中一個。</string>
+    <string name="session_drawer_fps_monitor">FPS 監視器</string>
+    <string name="session_drawer_fps_monitor_subtitle">顯示即時效能統計資料</string>
+    <string name="session_drawer_dual_series_battery">Dual Series 電量</string>
+    <string name="settings_general_check_for_updates">檢查更新</string>
+    <string name="settings_general_check_for_updates_summary">啟動時及定期自動檢查新版本。</string>
+    <string name="setup_wizard_containers">容器設定</string>
+    <string name="google_cloud_auto_backup">雲端同步自動備份</string>
+    <string name="google_cloud_auto_backup_summary">每次退出遊戲時自動將遊戲存檔備份到 Google Drive。</string>
+    <string name="cloud_saves_title">雲端存檔</string>
+    <string name="cloud_saves_backup">備份雲端存檔</string>
+    <string name="cloud_saves_restore">還原雲端存檔</string>
+    <string name="cloud_sync_title">雲端同步</string>
+    <string name="cloud_sync_enabled_summary">啟動時下載雲端存檔，並在退出時同步/備份。</string>
+    <string name="cloud_sync_disabled_summary">啟動此遊戲時不下載雲端存檔，也不在退出時同步。</string>
+    <string name="cloud_saves_backing_up">正在備份雲端存檔…</string>
+    <string name="cloud_saves_restoring">正在還原雲端存檔…</string>
+
 </resources>


### PR DESCRIPTION
- added the 30 missing `strings.xml` entries from recent i18n/UI work to every non-English locale resource file
- updated `values-da`, `values-de`, `values-es`, `values-fr`, `values-it`, `values-ko`, `values-pl`, `values-pt-rBR`, `values-ro`, `values-uk`, `values-zh-rCN`, and `values-zh-rTW`
- kept the change limited to previously missing localized strings; no English source strings or plurals were modified
