### PR TITLE
fix: stabilize startup transitions and settings fade

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,15 @@
         <!-- Setup Wizard (first launch entry point) -->
         <activity
             android:name="com.winlator.cmod.SetupWizardActivity"
-            android:theme="@style/AppThemeFullscreen.Dark"
+            android:theme="@style/AppThemeFullscreenDarkNoAnimation"
+            android:screenOrientation="sensorLandscape"
+            android:exported="false"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation" />
+
+        <!-- Unified Activity -->
+        <activity
+            android:name="com.winlator.cmod.UnifiedActivity"
+            android:theme="@style/AppThemeUnifiedDarkNoAnimation"
             android:screenOrientation="sensorLandscape"
             android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation">
@@ -52,14 +60,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-
-        <!-- Unified Activity -->
-        <activity
-            android:name="com.winlator.cmod.UnifiedActivity"
-            android:theme="@style/AppThemeFullscreen.Dark"
-            android:screenOrientation="sensorLandscape"
-            android:exported="false"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation" />
 
         <activity
             android:name="com.winlator.cmod.steam.SteamLoginActivity"

--- a/app/src/main/java/com/winlator/cmod/SetupWizardActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/SetupWizardActivity.kt
@@ -1331,9 +1331,12 @@ class SetupWizardActivity : FragmentActivity() {
     }
 
     private fun launchApp() {
-        startActivity(Intent(this, UnifiedActivity::class.java))
+        startActivity(
+            Intent(this, UnifiedActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        )
         @Suppress("DEPRECATION")
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+        overridePendingTransition(0, 0)
         finish()
     }
 

--- a/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
+++ b/app/src/main/java/com/winlator/cmod/UnifiedActivity.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.togetherWith
@@ -162,6 +164,7 @@ import com.winlator.cmod.gog.service.GOGConstants
 import com.winlator.cmod.gog.service.GOGService
 import com.winlator.cmod.gog.ui.auth.GOGOAuthActivity
 import com.winlator.cmod.utils.ControllerHelper
+import com.winlator.cmod.xenvironment.ImageFs
 import com.winlator.cmod.ui.FourByTwoGridView
 import com.winlator.cmod.ui.CarouselView
 import com.winlator.cmod.ui.ListView
@@ -616,6 +619,18 @@ class UnifiedActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         instance = this
         super.onCreate(savedInstanceState)
+
+        if (!SetupWizardActivity.isSetupComplete(this) || !ImageFs.find(this).isValid) {
+            startActivity(
+                Intent(this, SetupWizardActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+            )
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+            finish()
+            return
+        }
+
         supportFragmentManager.registerFragmentLifecycleCallbacks(inputControlsFragmentTracker, true)
         db = PluviaDatabase.getInstance(this)
         EpicAuthManager.updateLoginStatus(this)
@@ -682,14 +697,62 @@ class UnifiedActivity : AppCompatActivity() {
                     startDestination = initialSettingsNavigation?.let {
                         buildSettingsRoute(it.item, it.profileId, it.editContainerId)
                     } ?: "hub",
-                    modifier = Modifier.navigationBarsPadding(),
+                    modifier = Modifier.fillMaxSize(),
                     enterTransition = {
-                        fadeIn(tween(300, easing = androidx.compose.animation.core.FastOutSlowInEasing))
+                        val fromRoute = initialState.destination.route
+                        val toRoute = targetState.destination.route
+                        if (
+                            (
+                                (fromRoute == "hub" && toRoute?.startsWith("settings") == true) ||
+                                    (fromRoute?.startsWith("settings") == true && toRoute == "hub")
+                                )
+                        ) {
+                            fadeIn(tween(220, easing = FastOutSlowInEasing))
+                        } else {
+                            EnterTransition.None
+                        }
                     },
-                    exitTransition = { fadeOut(tween(300, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
-                    popEnterTransition = { fadeIn(tween(300, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+                    exitTransition = {
+                        val fromRoute = initialState.destination.route
+                        val toRoute = targetState.destination.route
+                        if (
+                            (
+                                (fromRoute == "hub" && toRoute?.startsWith("settings") == true) ||
+                                    (fromRoute?.startsWith("settings") == true && toRoute == "hub")
+                                )
+                        ) {
+                            fadeOut(tween(220, easing = FastOutSlowInEasing))
+                        } else {
+                            ExitTransition.None
+                        }
+                    },
+                    popEnterTransition = {
+                        val fromRoute = initialState.destination.route
+                        val toRoute = targetState.destination.route
+                        if (
+                            (
+                                (fromRoute == "hub" && toRoute?.startsWith("settings") == true) ||
+                                    (fromRoute?.startsWith("settings") == true && toRoute == "hub")
+                                )
+                        ) {
+                            fadeIn(tween(220, easing = FastOutSlowInEasing))
+                        } else {
+                            EnterTransition.None
+                        }
+                    },
                     popExitTransition = {
-                        fadeOut(tween(300, easing = androidx.compose.animation.core.FastOutSlowInEasing))
+                        val fromRoute = initialState.destination.route
+                        val toRoute = targetState.destination.route
+                        if (
+                            (
+                                (fromRoute == "hub" && toRoute?.startsWith("settings") == true) ||
+                                    (fromRoute?.startsWith("settings") == true && toRoute == "hub")
+                                )
+                        ) {
+                            fadeOut(tween(220, easing = FastOutSlowInEasing))
+                        } else {
+                            ExitTransition.None
+                        }
                     }
                 ) {
                     composable("hub") {
@@ -712,7 +775,7 @@ class UnifiedActivity : AppCompatActivity() {
                         val editContainerId = backStackEntry.arguments?.getInt("editContainerId") ?: 0
 
                         // Idempotent pop: the first Back press pops, any further presses during
-                        // the 300ms exit animation are absorbed here so NavHost state stays
+                        // the 220ms exit animation are absorbed here so NavHost state stays
                         // consistent (see isPoppingSettings field for full context).
                         val popSettingsOnce: () -> Unit = {
                             if (!isPoppingSettings) {
@@ -1036,6 +1099,7 @@ class UnifiedActivity : AppCompatActivity() {
         Box(Modifier.fillMaxSize().background(BgDark)) {
             Scaffold(
                 containerColor = BgDark,
+                contentWindowInsets = WindowInsets(0, 0, 0, 0),
                 topBar = { TopBar(tabs, selectedIdx, { selectedIdx = it }, persona, context, scope, isControllerConnected, isPS, isLibraryTab, searchQueryTfv, { searchQueryTfv = it }, onFilterClicked = { scope.launch { drawerState.open() } }) {
                     if (selectedLibrarySource == "GOG") {
                         globalSettingsGogGame = gogApps.find { it.id == selectedGogGameId }
@@ -1271,10 +1335,9 @@ class UnifiedActivity : AppCompatActivity() {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .statusBarsPadding()
                 .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
+                .padding(start = 8.dp, end = 8.dp, top = 8.dp)
                 .height(64.dp)
-                .padding(horizontal = 8.dp)
         ) {
             // Center Block: Tabs (absolutely centered, unaffected by left/right content)
             Row(

--- a/app/src/main/res/anim/no_animation.xml
+++ b/app/src/main/res/anim/no_animation.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="0"
+    android:fromAlpha="1.0"
+    android:toAlpha="1.0" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -55,6 +55,34 @@
         <item name="android:windowTranslucentNavigation">true</item>
     </style>
 
+    <style name="AppWindowAnimationNoAnimation">
+        <item name="android:activityOpenEnterAnimation">@anim/no_animation</item>
+        <item name="android:activityOpenExitAnimation">@anim/no_animation</item>
+        <item name="android:activityCloseEnterAnimation">@anim/no_animation</item>
+        <item name="android:activityCloseExitAnimation">@anim/no_animation</item>
+        <item name="android:taskOpenEnterAnimation">@anim/no_animation</item>
+        <item name="android:taskOpenExitAnimation">@anim/no_animation</item>
+        <item name="android:taskCloseEnterAnimation">@anim/no_animation</item>
+        <item name="android:taskCloseExitAnimation">@anim/no_animation</item>
+        <item name="android:taskToFrontEnterAnimation">@anim/no_animation</item>
+        <item name="android:taskToFrontExitAnimation">@anim/no_animation</item>
+        <item name="android:taskToBackEnterAnimation">@anim/no_animation</item>
+        <item name="android:taskToBackExitAnimation">@anim/no_animation</item>
+    </style>
+
+    <style name="AppThemeFullscreenDarkNoAnimation" parent="@style/AppThemeFullscreen.Dark">
+        <item name="android:windowAnimationStyle">@style/AppWindowAnimationNoAnimation</item>
+    </style>
+
+    <style name="AppThemeUnifiedDarkNoAnimation" parent="@style/AppTheme.Dark">
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowBackground">#000000</item>
+        <item name="android:colorBackground">#000000</item>
+        <item name="android:statusBarColor">#141B24</item>
+        <item name="android:navigationBarColor">#141B24</item>
+        <item name="android:windowAnimationStyle">@style/AppWindowAnimationNoAnimation</item>
+    </style>
+
     <!-- Base ComboBox Styles -->
     <style name="ComboBox">
         <item name="android:layout_width">192dp</item>


### PR DESCRIPTION
- routes normal app launches directly into `UnifiedActivity` and only redirects to `SetupWizardActivity` when setup is incomplete
- adds a no-animation window style and removes launch-time inset and status-bar adjustments that were causing the hub UI to jump on open
- restores a short Compose fade only for `hub` to `settings` navigation so settings transitions feel smoother without reintroducing launch animations
- fixes startup jank caused by the launcher activity hop plus late-applied window and inset changes during first render