### PR TITLE
Fix JNI AppUtils lookup

### DIFF
--- a/app/src/main/cpp/winlator/vulkan.c
+++ b/app/src/main/cpp/winlator/vulkan.c
@@ -31,7 +31,7 @@ static char *get_native_library_dir(JNIEnv *env, jobject context) {
     return NULL;
 
   jclass class_ =
-      (*env)->FindClass(env, "com/winlator/cmod/runtime/wine/AppUtils");
+      (*env)->FindClass(env, "com/winlator/cmod/shared/android/AppUtils");
   if (class_ == NULL) {
     (*env)->ExceptionClear(env);
     return NULL;


### PR DESCRIPTION
## Summary
- fix the native Vulkan JNI lookup for `AppUtils`
- point `vulkan.c` at `com.winlator.cmod.shared.android.AppUtils` instead of the old `runtime.wine` package

## Root Cause
The app package refactor moved `AppUtils` into `com.winlator.cmod.shared.android`, but the native Vulkan code still used the old JNI class path. That made the JNI lookup fail in the driver probing path.

## Impact
This keeps the native Vulkan helper aligned with the current Java package layout so the lookup resolves correctly.

## Validation
- `./gradlew.bat :app:assembleStandardDebug`
