### PR TITLE
Fix touchscreen and controller input regressions

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3654,6 +3654,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         touchpadView.setPointerButtonRightEnabled(false);
 
         inputControlsView.invalidate();
+        winHandler.sendGamepadState();
     }
 
     private void hideInputControls() {
@@ -3666,6 +3667,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         touchpadView.setPointerButtonRightEnabled(true);
 
         inputControlsView.invalidate();
+        winHandler.sendGamepadState();
     }
 
     private void extractGraphicsDriverFiles() {

--- a/app/src/main/runtime/input/controls/ExternalController.java
+++ b/app/src/main/runtime/input/controls/ExternalController.java
@@ -45,6 +45,8 @@ public class ExternalController {
   public final GamepadState remappedState = new GamepadState();
   private boolean triggerLPressedViaButton = false;
   private boolean triggerRPressedViaButton = false;
+  private float triggerLAnalogValue = 0.0f;
+  private float triggerRAnalogValue = 0.0f;
 
   // Configurable deadzone, sensitivity, and inversion settings
   private float deadzoneLeft = 0.1f;
@@ -153,6 +155,7 @@ public class ExternalController {
 
   public void setTriggerType(byte mode) {
     this.triggerType = mode;
+    updateTriggerState();
   }
 
   public void setContext(Context context) {
@@ -307,12 +310,9 @@ public class ExternalController {
     // DualSense uses AXIS_BRAKE(23)/AXIS_GAS(22) while Xbox uses
     // AXIS_LTRIGGER(17)/AXIS_RTRIGGER(18).
     // Some controllers report tiny noise on the unused axis, so comparing == 0.0f is unreliable.
-    float l = Math.max(event.getAxisValue(17), event.getAxisValue(23));
-    float r = Math.max(event.getAxisValue(18), event.getAxisValue(22));
-    this.state.triggerL = l;
-    this.state.triggerR = r;
-    this.state.setPressed(10, l > 0.9f);
-    this.state.setPressed(11, r > 0.9f);
+    triggerLAnalogValue = Math.max(event.getAxisValue(17), event.getAxisValue(23));
+    triggerRAnalogValue = Math.max(event.getAxisValue(18), event.getAxisValue(22));
+    updateTriggerState();
   }
 
   public boolean isXboxController() {
@@ -325,22 +325,9 @@ public class ExternalController {
   }
 
   private void processXboxTriggerButton(MotionEvent event) {
-    float l = Math.max(event.getAxisValue(17), event.getAxisValue(23));
-    float r = Math.max(event.getAxisValue(18), event.getAxisValue(22));
-    if (l > 0.0f) {
-      this.state.triggerL = 1.0f;
-      this.state.setPressed(10, true);
-    } else {
-      this.state.triggerL = 0.0f;
-      this.state.setPressed(10, false);
-    }
-    if (r > 0.0f) {
-      this.state.triggerR = 1.0f;
-      this.state.setPressed(11, true);
-    } else {
-      this.state.triggerR = 0.0f;
-      this.state.setPressed(11, false);
-    }
+    triggerLAnalogValue = Math.max(event.getAxisValue(17), event.getAxisValue(23));
+    triggerRAnalogValue = Math.max(event.getAxisValue(18), event.getAxisValue(22));
+    updateTriggerState();
   }
 
   public boolean updateStateFromMotionEvent(MotionEvent event) {
@@ -363,9 +350,13 @@ public class ExternalController {
     int buttonIdx = getButtonIdxByKeyCode(keyCode);
     if (buttonIdx != -1) {
       if (buttonIdx == 10 || buttonIdx == 11) {
-        // Trigger key events: don't call sendGamepadState to avoid
-        // overwriting analog trigger values from motion events
-        return false;
+        if (buttonIdx == 10) {
+          triggerLPressedViaButton = pressed;
+        } else {
+          triggerRPressedViaButton = pressed;
+        }
+        updateTriggerState();
+        return true;
       }
       this.state.setPressed(buttonIdx, pressed);
       return true;
@@ -549,6 +540,36 @@ public class ExternalController {
     float normalized = (Math.abs(value) - deadzone) / (1.0f - deadzone);
     normalized = Math.signum(value) * normalized;
     return normalized * sensitivity;
+  }
+
+  private void updateTriggerState() {
+    float buttonLValue = triggerLPressedViaButton ? 1.0f : 0.0f;
+    float buttonRValue = triggerRPressedViaButton ? 1.0f : 0.0f;
+
+    float finalL;
+    float finalR;
+    switch (triggerType) {
+      case TRIGGER_IS_BUTTON:
+        finalL = buttonLValue;
+        finalR = buttonRValue;
+        break;
+      case TRIGGER_IS_BOTH:
+        finalL = Math.max(triggerLAnalogValue, buttonLValue);
+        finalR = Math.max(triggerRAnalogValue, buttonRValue);
+        break;
+      case TRIGGER_IS_AXIS:
+      default:
+        // Preserve digital trigger presses for controllers that only emit key events,
+        // while still preferring analog data when it is available.
+        finalL = triggerLAnalogValue > 0.0f ? triggerLAnalogValue : buttonLValue;
+        finalR = triggerRAnalogValue > 0.0f ? triggerRAnalogValue : buttonRValue;
+        break;
+    }
+
+    state.triggerL = finalL;
+    state.triggerR = finalR;
+    state.setPressed(IDX_BUTTON_L2, triggerLPressedViaButton || finalL > 0.9f);
+    state.setPressed(IDX_BUTTON_R2, triggerRPressedViaButton || finalR > 0.9f);
   }
 
   public static boolean isJoystickDevice(MotionEvent event) {

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -646,6 +646,7 @@ public class InputControlsView extends View {
           {
             float x = event.getX(actionIndex);
             float y = event.getY(actionIndex);
+            boolean vibrated = false;
 
             touchpadView.setPointerButtonLeftEnabled(!hasMouseLeftButtonElement());
             for (ControlElement element : profile.getElements()) {
@@ -654,7 +655,7 @@ public class InputControlsView extends View {
                 activeTouchElements.put(pointerId, element);
 
                 // Trigger haptic feedback for input controls
-                if (hapticsEnabled) {
+                if (!vibrated && hapticsEnabled) {
                   Vibrator vibrator;
                   if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                     VibratorManager vibratorManager =
@@ -668,8 +669,8 @@ public class InputControlsView extends View {
                     vibrator.vibrate(
                         VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE));
                   }
+                  vibrated = true;
                 }
-                break;
               }
             }
             if (!handled) touchpadView.onTouchEvent(event);
@@ -681,38 +682,25 @@ public class InputControlsView extends View {
               int movePointerId = event.getPointerId(i);
               float x = event.getX(i);
               float y = event.getY(i);
-
-              ControlElement activeElement = activeTouchElements.get(movePointerId);
-              handled = activeElement != null && activeElement.handleTouchMove(movePointerId, x, y);
-
-              if (!handled && activeElement == null) {
-                for (ControlElement element : profile.getElements()) {
-                  if (element.handleTouchMove(movePointerId, x, y)) {
-                    activeTouchElements.put(movePointerId, element);
-                    handled = true;
-                    break;
-                  }
+              boolean handledMove = false;
+              for (ControlElement element : profile.getElements()) {
+                if (element.handleTouchMove(movePointerId, x, y)) {
+                  handledMove = true;
                 }
               }
-              if (!handled) touchpadView.onTouchEvent(event);
+              if (!handledMove) touchpadView.onTouchEvent(event);
             }
             break;
           }
         case MotionEvent.ACTION_UP:
         case MotionEvent.ACTION_POINTER_UP:
           {
-            ControlElement activeElement = activeTouchElements.get(pointerId);
-            if (activeElement != null) {
-              handled = activeElement.handleTouchUp(pointerId);
-              activeTouchElements.remove(pointerId);
-            } else {
-              for (ControlElement element : profile.getElements()) {
-                if (element.handleTouchUp(pointerId)) {
-                  handled = true;
-                  break;
-                }
+            for (ControlElement element : profile.getElements()) {
+              if (element.handleTouchUp(pointerId)) {
+                handled = true;
               }
             }
+            activeTouchElements.remove(pointerId);
             if (!handled) touchpadView.onTouchEvent(event);
             break;
           }
@@ -722,6 +710,12 @@ public class InputControlsView extends View {
               int activePointerId = activeTouchElements.keyAt(i);
               ControlElement activeElement = activeTouchElements.valueAt(i);
               if (activeElement != null) activeElement.handleTouchUp(activePointerId);
+            }
+            for (byte i = 0, count = (byte) event.getPointerCount(); i < count; i++) {
+              int canceledPointerId = event.getPointerId(i);
+              for (ControlElement element : profile.getElements()) {
+                element.handleTouchUp(canceledPointerId);
+              }
             }
             activeTouchElements.clear();
             touchpadView.onTouchEvent(event);

--- a/app/src/main/runtime/input/ui/TouchpadView.kt
+++ b/app/src/main/runtime/input/ui/TouchpadView.kt
@@ -340,6 +340,9 @@ class TouchpadView(
             MotionEvent.ACTION_CANCEL -> {
                 longPressHandler.removeCallbacks(longPressRunnable)
                 longPressActive = false
+                // NOTE: This matches Ludashi, but it only clears tracked fingers.
+                // If touchpad-mode stuck buttons or clicks show up later, revisit this
+                // path and explicitly release any state that would normally flow through handleFingerUp().
                 for (i in 0 until MAX_FINGERS.toInt()) fingers[i] = null
                 numFingers = 0
             }


### PR DESCRIPTION
## Summary
This fixes a set of input-runtime regressions affecting touchscreen overlays and external controllers.

## What changed
- restored immediate virtual gamepad sync when touchscreen controls are shown or hidden
- aligned touchscreen overlay move/up/cancel handling with the more reliable Ludashi event routing path
- fixed external controller trigger handling so L2/R2 key-based, axis-based, and mixed trigger devices all update runtime state correctly
- documented the touchpad cancel-path follow-up point for future stuck-input investigation

## Root cause
The current branch had drifted in a few input paths:
- touch overlay handling relied on a newer per-pointer cache path that could miss some button events on Samsung touchscreens
- virtual touch gamepad state was not pushed immediately when controls were shown or hidden
- trigger mode settings existed, but L2/R2 button events were not fully wired into runtime controller state updates

## Impact
- touchscreen buttons register more reliably during multi-touch use
- showing or hiding touchscreen controls no longer leaves stale virtual controller state behind
- physical controllers that report triggers as buttons, axes, or both register L2/R2 correctly

## Validation
- `./gradlew :app:compileStandardDebugJavaWithJavac`
- `./gradlew :app:compileLudashiDebugJavaWithJavac`
