### PR TITLE
Fix automatic DXVK FPS cap from refresh rate

### DIFF
--- a/app/src/main/feature/settings/drivers/DXVKConfigUtils.java
+++ b/app/src/main/feature/settings/drivers/DXVKConfigUtils.java
@@ -19,26 +19,14 @@ public final class DXVKConfigUtils {
     }
 
     public static void setEnvVars(Context context, KeyValueSet config, EnvVars envVars) {
-        setEnvVars(context, config, envVars, 0);
-    }
-
-    public static void setEnvVars(Context context, KeyValueSet config, EnvVars envVars, int refreshRateOverride) {
         String content = "";
 
-        if (refreshRateOverride > 0) {
-            String rateStr = String.valueOf(refreshRateOverride);
-            content += "dxgi.syncInterval = 0; ";
-            content += "dxgi.maxFrameRate = " + rateStr + "; ";
-            content += "d3d9.maxFrameRate = " + rateStr;
-            envVars.put("DXVK_FRAME_RATE", rateStr);
-        } else {
-            String framerate = config.get("framerate");
+        String framerate = config.get("framerate");
 
-            if (!framerate.isEmpty() && !framerate.equals("0")) {
-                content += "dxgi.maxFrameRate = " + framerate + "; ";
-                content += "d3d9.maxFrameRate = " + framerate;
-                envVars.put("DXVK_FRAME_RATE", framerate);
-            }
+        if (!framerate.isEmpty() && !framerate.equals("0")) {
+            content += "dxgi.maxFrameRate = " + framerate + "; ";
+            content += "d3d9.maxFrameRate = " + framerate;
+            envVars.put("DXVK_FRAME_RATE", framerate);
         }
 
         String async = config.get("async");

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -382,39 +382,6 @@ public class XServerDisplayActivity extends AppCompatActivity {
         return Math.max(0, preferences.getInt("refresh_rate_override", 0));
     }
 
-    private boolean hasPerGameDxvkFrameRateOverride() {
-        if (shortcut == null || shortcutUsesContainerDefaults()) return false;
-
-        String shortcutDxwrapperConfig = shortcut.getExtra("dxwrapperConfig");
-        if (shortcutDxwrapperConfig.isEmpty()) return false;
-
-        KeyValueSet perGameConfig = DXVKConfigUtils.parseConfig(shortcutDxwrapperConfig);
-        return parsePositiveInt(perGameConfig.get("framerate")) > 0;
-    }
-
-    /**
-     * Per-game settings always win over the global refresh rate when determining DXVK frame limit.
-     * Returns 0 (no override) when no explicit user preference is set, matching Ludashi behavior.
-     * The old code fell back to the device's max refresh rate which always injected
-     * dxgi.syncInterval=0 and DXVK_FRAME_RATE, interfering with VKD3D frame pacing
-     * and causing significant FPS drops in DX12 games.
-     */
-    private int getDxvkFrameRateOverride() {
-        int perGameRate = getPerGameRefreshRateOverride();
-        if (perGameRate > 0) {
-            return perGameRate;
-        }
-        if (hasPerGameDxvkFrameRateOverride()) {
-            return 0;
-        }
-
-        int globalRate = getGlobalRefreshRateOverride();
-        if (globalRate > 0) {
-            return globalRate;
-        }
-        return 0;
-    }
-
     private int parsePositiveInt(String value) {
         if (value == null || value.isEmpty()) return 0;
         try {
@@ -3690,8 +3657,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         File rootDir = imageFs.getRootDir();
 
         if (dxwrapper.contains("dxvk")) {
-            int refreshRateOverride = getDxvkFrameRateOverride();
-            DXVKConfigUtils.setEnvVars(this, dxwrapperConfig, envVars, refreshRateOverride);
+            DXVKConfigUtils.setEnvVars(this, dxwrapperConfig, envVars);
             String version = dxwrapperConfig.get("version");
             if (version.equals("1.11.1-sarek")) {
                 Log.d("GraphicsDriverExtraction", "Disabling Wrapper PATCH_OPCONSTCOMP SPIR-V pass");


### PR DESCRIPTION
## Summary
This change removes the automatic DXVK frame limit that was being derived from the selected refresh rate.

## What changed
- Stop passing the refresh rate override into DXVK environment setup.
- Remove the helper logic in `XServerDisplayActivity` that converted refresh rate preferences into a DXVK frame cap.
- Keep explicit DXVK `framerate` settings working as before.

## Why
Some games were being capped to the selected display refresh rate even when no manual DXVK framerate limit had been configured. In practice this could force titles that initially reported very high frame rates down to 60 FPS when a 60 Hz refresh override was selected.

## Impact
Refresh rate selection still controls the preferred display mode, but it no longer automatically injects `DXVK_FRAME_RATE`, `dxgi.maxFrameRate`, `d3d9.maxFrameRate`, or `dxgi.syncInterval` unless the user explicitly sets a DXVK framerate limit.

## Validation
- Verified the change is limited to the DXVK frame-limit injection path.
- Local Gradle compilation could not be run in this environment because `java`/`JAVA_HOME` is not configured.