### PR TITLE
Polish compose settings screens and unified hub UI

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -220,6 +220,20 @@ private val StatusOnline = Color(0xFF3FB950)
 private val StatusAway = Color(0xFFF0C040)
 private val StatusOffline = Color(0xFF6E7681)
 
+private val TabScreenHorizontalPadding = 16.dp
+private val TabScreenBottomPadding = 8.dp
+private val TabListContentPadding = PaddingValues(top = 8.dp, bottom = 12.dp)
+private val TabGridContentPadding = PaddingValues(top = 12.dp, bottom = 16.dp)
+private val TabGridTopPadding = 12.dp
+private val TabCarouselTopPadding = 20.dp
+private val TabCarouselBottomPadding = 20.dp
+private val DownloadsHeaderTopPadding = 4.dp
+
+private fun Modifier.tabScreenPadding(
+    top: Dp = 0.dp,
+    bottom: Dp = TabScreenBottomPadding,
+): Modifier = padding(start = TabScreenHorizontalPadding, top = top, end = TabScreenHorizontalPadding, bottom = bottom)
+
 private val LIBRARY_NAME_SANITIZE_REGEX = "[^A-Za-z0-9 _-]".toRegex()
 
 enum class LibraryLayoutMode {
@@ -2104,9 +2118,9 @@ class UnifiedActivity :
             LibraryLayoutMode.GRID_4 -> {
                 FourByTwoGridView(
                     items = displayedApps,
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+                    modifier = Modifier.tabScreenPadding(),
                     gridState = gridState,
-                    contentPadding = PaddingValues(vertical = 16.dp),
+                    contentPadding = TabGridContentPadding,
                     clipContent = false,
                 ) { app, index, rowHeight ->
                     GameCapsule(
@@ -2140,7 +2154,7 @@ class UnifiedActivity :
             LibraryLayoutMode.CAROUSEL -> {
                 CarouselView(
                     items = displayedApps,
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 20.dp),
+                    modifier = Modifier.tabScreenPadding(top = TabCarouselTopPadding, bottom = TabCarouselBottomPadding),
                     listState = carouselState,
                     selectedIndex = focusIndex,
                     onCenteredIndexChanged = { centeredIndex ->
@@ -2189,9 +2203,9 @@ class UnifiedActivity :
                 val listViewState = rememberLazyListState()
                 ListView(
                     items = displayedApps,
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+                    modifier = Modifier.tabScreenPadding(),
                     listState = listViewState,
-                    contentPadding = PaddingValues(vertical = 12.dp),
+                    contentPadding = TabListContentPadding,
                     selectedIndex = focusIndex,
                     onSelectedIndexChanged = { newIdx ->
                         activity?.libraryFocusIndex?.value = newIdx
@@ -4919,9 +4933,9 @@ class UnifiedActivity :
             JoystickListScroll(listViewState, activity?.rightStickScrollState)
             ListView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
-                contentPadding = PaddingValues(vertical = 12.dp),
+                contentPadding = TabListContentPadding,
             ) { app, _, _ ->
                 EpicStoreCapsule(app, listMode = true, isControllerActive = ControllerHelper.isControllerConnected()) {
                     selectedAppId.value =
@@ -4946,7 +4960,7 @@ class UnifiedActivity :
             JoystickGridScroll(gridState, activity?.rightStickScrollState)
             FourByTwoGridView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
             ) { app, index, rowHeight ->
                 Box(
@@ -5586,9 +5600,9 @@ class UnifiedActivity :
             val listViewState = rememberLazyListState()
             ListView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
-                contentPadding = PaddingValues(vertical = 12.dp),
+                contentPadding = TabListContentPadding,
             ) { app, _, _ ->
                 val isInstalled = app.isInstalled && java.io.File(app.installPath).exists()
                 Row(
@@ -5658,7 +5672,7 @@ class UnifiedActivity :
             }
             FourByTwoGridView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
             ) { app, index, rowHeight ->
                 val isInstalled = app.isInstalled && java.io.File(app.installPath).exists()
@@ -5935,9 +5949,9 @@ class UnifiedActivity :
             JoystickListScroll(listViewState, activity?.rightStickScrollState, minSpeed = 2.5f, maxSpeed = 16f, quadratic = true)
             ListView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
-                contentPadding = PaddingValues(vertical = 12.dp),
+                contentPadding = TabListContentPadding,
             ) { app, _, _ ->
                 SteamStoreCapsule(app, listMode = true, isControllerActive = ControllerHelper.isControllerConnected(), onClick = {
                     selectedAppForDialog =
@@ -5965,7 +5979,7 @@ class UnifiedActivity :
             JoystickGridScroll(gridState, activity?.leftStickScrollState, deadZone = 0.15f, minSpeed = 0.3125f, maxSpeed = 2f)
             FourByTwoGridView(
                 items = displayedApps,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
             ) { app, index, rowHeight ->
                 Box(
@@ -6204,7 +6218,7 @@ class UnifiedActivity :
             Modifier
                 .fillMaxSize()
                 .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom))
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .tabScreenPadding(top = DownloadsHeaderTopPadding),
         ) {
             val isController = ControllerHelper.isControllerConnected()
             val isPS = ControllerHelper.isPlayStationController()

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -108,6 +108,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -219,15 +220,17 @@ private val DangerRed = Color(0xFFFF6B6B)
 private val StatusOnline = Color(0xFF3FB950)
 private val StatusAway = Color(0xFFF0C040)
 private val StatusOffline = Color(0xFF6E7681)
-
 private val TabScreenHorizontalPadding = 16.dp
 private val TabScreenBottomPadding = 8.dp
-private val TabListContentPadding = PaddingValues(top = 8.dp, bottom = 12.dp)
-private val TabGridContentPadding = PaddingValues(top = 12.dp, bottom = 16.dp)
-private val TabGridTopPadding = 12.dp
-private val TabCarouselTopPadding = 20.dp
+private val UnifiedTopBarHorizontalPadding = 8.dp
+private val UnifiedTopBarTopPadding = 4.dp
+private val UnifiedTopBarHeight = 56.dp
+private val TabListContentPadding = PaddingValues(top = 4.dp, bottom = 12.dp)
+private val TabGridContentPadding = PaddingValues(top = 8.dp, bottom = 16.dp)
+private val TabGridTopPadding = 8.dp
+private val TabCarouselTopPadding = 12.dp
 private val TabCarouselBottomPadding = 20.dp
-private val DownloadsHeaderTopPadding = 4.dp
+private val DownloadsHeaderTopPadding = 2.dp
 
 private fun Modifier.tabScreenPadding(
     top: Dp = 0.dp,
@@ -1347,17 +1350,29 @@ class UnifiedActivity :
                             }
                         }
 
+                        val configuration = LocalConfiguration.current
+                        val libraryFabBase = minOf(configuration.screenWidthDp, configuration.screenHeightDp)
+                        val addGameFabSize = (libraryFabBase * 0.125f).dp.coerceIn(56.dp, 64.dp)
+                        val addGameFabMargin = (libraryFabBase * 0.035f).dp.coerceIn(12.dp, 20.dp)
+                        val addGameFabIconSize = (libraryFabBase * 0.055f).dp.coerceIn(24.dp, 28.dp)
+
                         // Bottom-right Add Custom Game button
                         if (key == "library") {
                             Box(
                                 modifier =
                                     Modifier
                                         .align(Alignment.BottomEnd)
-                                        .padding(16.dp)
-                                        .size(52.dp)
+                                        .windowInsetsPadding(
+                                            WindowInsets.navigationBars.only(
+                                                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                                            ),
+                                        )
+                                        .padding(end = addGameFabMargin, bottom = addGameFabMargin)
+                                        .size(addGameFabSize)
                                         .shadow(10.dp, CircleShape, spotColor = Accent.copy(alpha = 0.4f))
                                         .clip(CircleShape)
-                                        .background(Accent)
+                                        .background(SurfaceDark.copy(alpha = 0.96f), CircleShape)
+                                        .border(1.5.dp, Accent.copy(alpha = 0.55f), CircleShape)
                                         .focusProperties { canFocus = false } // No specific button for this, handle via long press or touch
                                         .clickable { showAddCustomGame = true },
                                 contentAlignment = Alignment.Center,
@@ -1366,7 +1381,7 @@ class UnifiedActivity :
                                     Icons.Outlined.Add,
                                     contentDescription = "Add Custom Game",
                                     tint = Color.White,
-                                    modifier = Modifier.size(28.dp),
+                                    modifier = Modifier.size(addGameFabIconSize),
                                 )
                             }
                         }
@@ -1513,8 +1528,12 @@ class UnifiedActivity :
                     Modifier
                         .fillMaxWidth()
                         .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
-                        .padding(start = 8.dp, end = 8.dp, top = 8.dp)
-                        .height(64.dp),
+                        .padding(
+                            start = UnifiedTopBarHorizontalPadding,
+                            end = UnifiedTopBarHorizontalPadding,
+                            top = UnifiedTopBarTopPadding,
+                        )
+                        .height(UnifiedTopBarHeight),
             ) {
                 // Center Block: Tabs (absolutely centered, unaffected by left/right content)
                 Row(

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -2275,6 +2275,7 @@ private fun EnvVarRow(
                         color = TextPrimary,
                         fontSize = 13.sp
                     ),
+                    cursorBrush = SolidColor(AccentBlue),
                     singleLine = true,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/feature/settings/containers/ContainersScreen.kt
+++ b/app/src/main/feature/settings/containers/ContainersScreen.kt
@@ -7,13 +7,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
@@ -49,6 +55,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -133,12 +140,22 @@ fun ContainersScreen(
     onClearCacheDialog: (Container) -> Unit,
     onBackupSelectionChosen: (Int) -> Unit,
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
+
     Column(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(ContainersBg)
-                .padding(start = 16.dp, top = 16.dp, end = 26.dp, bottom = 16.dp),
+                .padding(
+                    start = 16.dp + navBarStartPadding,
+                    top = 16.dp,
+                    end = 16.dp + navBarEndPadding,
+                ),
     ) {
         SectionLabel(text = stringResource(R.string.common_ui_containers))
         if (state.containers.isEmpty()) {
@@ -159,6 +176,7 @@ fun ContainersScreen(
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
             modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 4.dp + navBarBottomPadding),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {

--- a/app/src/main/feature/settings/contents/ComponentsScreen.kt
+++ b/app/src/main/feature/settings/contents/ComponentsScreen.kt
@@ -16,15 +16,22 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -54,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -136,6 +144,11 @@ fun ComponentsScreen(
     onToggleAutoCreateContainer: (Boolean) -> Unit,
 ) {
     var itemPendingRemoval by remember { mutableStateOf<ComponentItem?>(null) }
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     itemPendingRemoval?.let { item ->
         ConfirmDialog(
@@ -160,7 +173,13 @@ fun ComponentsScreen(
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "hero_header") {
@@ -180,56 +199,49 @@ fun ComponentsScreen(
             )
         }
 
-        item(key = "type_content") {
-            AnimatedContent(
-                targetState = state,
-                transitionSpec = {
-                    (
-                        fadeIn(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
-                            togetherWith
-                            fadeOut(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
-                    ).using(
-                        SizeTransform(clip = false) { _, _ ->
-                            tween(durationMillis = 140, easing = FastOutSlowInEasing)
-                        },
-                    )
-                },
-                contentKey = { it.currentType },
-                label = "componentsTypeContent",
-            ) { snapshot ->
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (snapshot.installed.isEmpty() && snapshot.available.isEmpty()) {
-                        EmptyState()
-                    }
+        if (state.installed.isEmpty() && state.available.isEmpty()) {
+            item(key = "empty_${state.currentType.name}") {
+                EmptyState()
+            }
+        }
 
-                    if (snapshot.installed.isNotEmpty()) {
-                        SectionLabel(
-                            text = stringResource(R.string.common_ui_installed),
-                            modifier = Modifier.padding(top = 8.dp),
-                        )
-                        snapshot.installed.forEach { item ->
-                            ComponentItemCard(
-                                item = item,
-                                onDownload = { onDownloadItem(item) },
-                                onRemove = { itemPendingRemoval = item },
-                            )
-                        }
-                    }
+        if (state.installed.isNotEmpty()) {
+            item(key = "installed_section_${state.currentType.name}") {
+                SectionLabel(
+                    text = stringResource(R.string.common_ui_installed),
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            items(
+                items = state.installed,
+                key = { item -> "installed_${state.currentType.name}_${item.key}" },
+                contentType = { "installedComponentCard" },
+            ) { item ->
+                ComponentItemCard(
+                    item = item,
+                    onDownload = { onDownloadItem(item) },
+                    onRemove = { itemPendingRemoval = item },
+                )
+            }
+        }
 
-                    if (snapshot.available.isNotEmpty()) {
-                        SectionLabel(
-                            text = stringResource(R.string.common_ui_available),
-                            modifier = Modifier.padding(top = 8.dp),
-                        )
-                        snapshot.available.forEach { item ->
-                            ComponentItemCard(
-                                item = item,
-                                onDownload = { onDownloadItem(item) },
-                                onRemove = { itemPendingRemoval = item },
-                            )
-                        }
-                    }
-                }
+        if (state.available.isNotEmpty()) {
+            item(key = "available_section_${state.currentType.name}") {
+                SectionLabel(
+                    text = stringResource(R.string.common_ui_available),
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            items(
+                items = state.available,
+                key = { item -> "available_${state.currentType.name}_${item.key}" },
+                contentType = { "availableComponentCard" },
+            ) { item ->
+                ComponentItemCard(
+                    item = item,
+                    onDownload = { onDownloadItem(item) },
+                    onRemove = { itemPendingRemoval = item },
+                )
             }
         }
 
@@ -251,7 +263,7 @@ private fun HeroHeader(
     onInstallFromFile: () -> Unit,
     onToggleAutoCreateContainer: (Boolean) -> Unit,
 ) {
-    Box(
+    BoxWithConstraints(
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -260,53 +272,115 @@ private fun HeroHeader(
                 .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
                 .padding(horizontal = 14.dp, vertical = 11.dp),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .size(34.dp)
-                        .clip(RoundedCornerShape(9.dp))
-                        .background(IconBoxBg),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Extension,
-                    contentDescription = null,
-                    tint = Accent,
-                    modifier = Modifier.size(17.dp),
-                )
-            }
-            Spacer(Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.settings_content_components),
-                    color = TextPrimary,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Spacer(Modifier.height(2.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
-                    Spacer(Modifier.width(6.dp))
-                    CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
+        val stackActionsBelowCounts = maxWidth < 620.dp
+
+        if (stackActionsBelowCounts) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(34.dp)
+                                .clip(RoundedCornerShape(9.dp))
+                                .background(IconBoxBg),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Extension,
+                            contentDescription = null,
+                            tint = Accent,
+                            modifier = Modifier.size(17.dp),
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.settings_content_components),
+                            color = TextPrimary,
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
+                            Spacer(Modifier.width(6.dp))
+                            CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(10.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ToggleChip(
+                        label = stringResource(R.string.settings_content_auto_create_container),
+                        enabled = autoCreateContainer,
+                        onToggle = { onToggleAutoCreateContainer(!autoCreateContainer) },
+                    )
+                    SmallPillButton(
+                        label = stringResource(R.string.settings_content_install),
+                        icon = Icons.Outlined.Upload,
+                        tint = Accent,
+                        onClick = onInstallFromFile,
+                    )
                 }
             }
-            Spacer(Modifier.width(10.dp))
-            ToggleChip(
-                label = stringResource(R.string.settings_content_auto_create_container),
-                enabled = autoCreateContainer,
-                onToggle = { onToggleAutoCreateContainer(!autoCreateContainer) },
-            )
-            Spacer(Modifier.width(8.dp))
-            SmallPillButton(
-                label = stringResource(R.string.settings_content_install),
-                icon = Icons.Outlined.Upload,
-                tint = Accent,
-                onClick = onInstallFromFile,
-            )
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(34.dp)
+                            .clip(RoundedCornerShape(9.dp))
+                            .background(IconBoxBg),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Extension,
+                        contentDescription = null,
+                        tint = Accent,
+                        modifier = Modifier.size(17.dp),
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.settings_content_components),
+                        color = TextPrimary,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
+                        Spacer(Modifier.width(6.dp))
+                        CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
+                    }
+                }
+                Spacer(Modifier.width(10.dp))
+                ToggleChip(
+                    label = stringResource(R.string.settings_content_auto_create_container),
+                    enabled = autoCreateContainer,
+                    onToggle = { onToggleAutoCreateContainer(!autoCreateContainer) },
+                )
+                Spacer(Modifier.width(8.dp))
+                SmallPillButton(
+                    label = stringResource(R.string.settings_content_install),
+                    icon = Icons.Outlined.Upload,
+                    tint = Accent,
+                    onClick = onInstallFromFile,
+                )
+            }
         }
     }
 }
@@ -373,6 +447,8 @@ private fun CountPill(
             color = TextSecondary,
             fontSize = 10.sp,
             fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/app/src/main/feature/settings/contents/ComponentsScreen.kt
+++ b/app/src/main/feature/settings/contents/ComponentsScreen.kt
@@ -1,5 +1,5 @@
 /* Settings > Components screen — Jetpack Compose / Material3.
- * Scrolling delegated to a View-level ScrollView in ContentsFragment. */
+ * Uses a LazyColumn for the main content. */
 package com.winlator.cmod.feature.settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
@@ -15,18 +15,20 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -153,80 +155,87 @@ fun ComponentsScreen(
         DownloadProgressDialog(progress = progress)
     }
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        HeroHeader(
-            installedCount = state.installed.size,
-            availableCount = state.available.size,
-            autoCreateContainer = state.autoCreateContainer,
-            onInstallFromFile = onInstallFromFile,
-            onToggleAutoCreateContainer = onToggleAutoCreateContainer,
-        )
+        item(key = "hero_header") {
+            HeroHeader(
+                installedCount = state.installed.size,
+                availableCount = state.available.size,
+                autoCreateContainer = state.autoCreateContainer,
+                onInstallFromFile = onInstallFromFile,
+                onToggleAutoCreateContainer = onToggleAutoCreateContainer,
+            )
+        }
 
-        TypeTabsCard(
-            currentType = state.currentType,
-            onTypeSelected = onTypeSelected,
-        )
+        item(key = "type_tabs") {
+            TypeTabsCard(
+                currentType = state.currentType,
+                onTypeSelected = onTypeSelected,
+            )
+        }
 
-        AnimatedContent(
-            targetState = state,
-            transitionSpec = {
-                (
-                    fadeIn(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
-                        togetherWith
-                        fadeOut(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
-                ).using(
-                    SizeTransform(clip = false) { _, _ ->
-                        tween(durationMillis = 140, easing = FastOutSlowInEasing)
-                    },
-                )
-            },
-            contentKey = { it.currentType },
-            label = "componentsTypeContent",
-        ) { snapshot ->
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (snapshot.installed.isEmpty() && snapshot.available.isEmpty()) {
-                    EmptyState()
-                }
-
-                if (snapshot.installed.isNotEmpty()) {
-                    SectionLabel(
-                        text = stringResource(R.string.common_ui_installed),
-                        modifier = Modifier.padding(top = 8.dp),
+        item(key = "type_content") {
+            AnimatedContent(
+                targetState = state,
+                transitionSpec = {
+                    (
+                        fadeIn(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
+                            togetherWith
+                            fadeOut(animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing))
+                    ).using(
+                        SizeTransform(clip = false) { _, _ ->
+                            tween(durationMillis = 140, easing = FastOutSlowInEasing)
+                        },
                     )
-                    snapshot.installed.forEach { item ->
-                        ComponentItemCard(
-                            item = item,
-                            onDownload = { onDownloadItem(item) },
-                            onRemove = { itemPendingRemoval = item },
-                        )
+                },
+                contentKey = { it.currentType },
+                label = "componentsTypeContent",
+            ) { snapshot ->
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (snapshot.installed.isEmpty() && snapshot.available.isEmpty()) {
+                        EmptyState()
                     }
-                }
 
-                if (snapshot.available.isNotEmpty()) {
-                    SectionLabel(
-                        text = stringResource(R.string.common_ui_available),
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                    snapshot.available.forEach { item ->
-                        ComponentItemCard(
-                            item = item,
-                            onDownload = { onDownloadItem(item) },
-                            onRemove = { itemPendingRemoval = item },
+                    if (snapshot.installed.isNotEmpty()) {
+                        SectionLabel(
+                            text = stringResource(R.string.common_ui_installed),
+                            modifier = Modifier.padding(top = 8.dp),
                         )
+                        snapshot.installed.forEach { item ->
+                            ComponentItemCard(
+                                item = item,
+                                onDownload = { onDownloadItem(item) },
+                                onRemove = { itemPendingRemoval = item },
+                            )
+                        }
+                    }
+
+                    if (snapshot.available.isNotEmpty()) {
+                        SectionLabel(
+                            text = stringResource(R.string.common_ui_available),
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                        snapshot.available.forEach { item ->
+                            ComponentItemCard(
+                                item = item,
+                                onDownload = { onDownloadItem(item) },
+                                onRemove = { itemPendingRemoval = item },
+                            )
+                        }
                     }
                 }
             }
         }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/contents/ContentsFragment.kt
+++ b/app/src/main/feature/settings/contents/ContentsFragment.kt
@@ -1,16 +1,12 @@
 /* Components screen — Jetpack Compose host.
  * Hosts ComponentsScreen; orchestrates install / download / remove flows. */
 package com.winlator.cmod.feature.settings
-import android.graphics.drawable.GradientDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
@@ -95,79 +91,39 @@ class ContentsFragment : Fragment() {
         val ctx = requireContext()
         publishState()
 
-        val composeView =
-            ComposeView(ctx).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        ComponentsScreen(
-                            state = componentsState,
-                            onTypeSelected = { type -> selectContentType(type) },
-                            onInstallFromFile = { promptInstallFromFile() },
-                            onDownloadItem = { item ->
-                                profilesByKey[item.key]?.let { downloadRemoteContent(it) }
-                            },
-                            onRemoveItem = { item ->
-                                profilesByKey[item.key]?.let { onRemoveRequested(it) }
-                            },
-                            onToggleAutoCreateContainer = { enabled ->
-                                autoCreateContainer = enabled
-                                PreferenceManager
-                                    .getDefaultSharedPreferences(requireContext())
-                                    .edit()
-                                    .putBoolean(PREF_AUTO_CREATE_CONTAINER, enabled)
-                                    .apply()
-                                publishState()
-                            },
-                        )
-                    }
-                }
-            }
-
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(ctx).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+        return ComposeView(ctx).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    ComponentsScreen(
+                        state = componentsState,
+                        onTypeSelected = { type -> selectContentType(type) },
+                        onInstallFromFile = { promptInstallFromFile() },
+                        onDownloadItem = { item ->
+                            profilesByKey[item.key]?.let { downloadRemoteContent(it) }
+                        },
+                        onRemoveItem = { item ->
+                            profilesByKey[item.key]?.let { onRemoveRequested(it) }
+                        },
+                        onToggleAutoCreateContainer = { enabled ->
+                            autoCreateContainer = enabled
+                            PreferenceManager
+                                .getDefaultSharedPreferences(requireContext())
+                                .edit()
+                                .putBoolean(PREF_AUTO_CREATE_CONTAINER, enabled)
+                                .apply()
+                            publishState()
                         },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-
-        return FrameLayout(ctx).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#18181D"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/debug/DebugFragment.kt
+++ b/app/src/main/feature/settings/debug/DebugFragment.kt
@@ -2,16 +2,12 @@
 package com.winlator.cmod.feature.settings
 import android.content.Intent
 import android.content.SharedPreferences
-import android.graphics.drawable.GradientDrawable
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.getValue
@@ -51,139 +47,97 @@ class DebugFragment : Fragment() {
         wineChannelOptions = loadWineChannelOptions(ctx)
         refresh()
 
-        val composeView =
-            ComposeView(ctx).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        DebugScreen(
-                            state = debugState,
-                            wineChannelOptions = wineChannelOptions,
-                            onAppDebugChanged = { checked ->
-                                preferences.edit { putBoolean("enable_app_debug", checked) }
-                                if (checked) {
-                                    com.winlator.cmod.runtime.system.LogManager
-                                        .startAppLogging(ctx)
-                                } else {
-                                    com.winlator.cmod.runtime.system.LogManager
-                                        .stopAppLogging()
-                                    com.winlator.cmod.runtime.system.LogManager
-                                        .updateLoggingState(ctx)
-                                }
-                                refresh()
-                            },
-                            onWineDebugChanged = { checked ->
-                                preferences.edit { putBoolean("enable_wine_debug", checked) }
+        return ComposeView(ctx).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    DebugScreen(
+                        state = debugState,
+                        wineChannelOptions = wineChannelOptions,
+                        onAppDebugChanged = { checked ->
+                            preferences.edit { putBoolean("enable_app_debug", checked) }
+                            if (checked) {
+                                com.winlator.cmod.runtime.system.LogManager
+                                    .startAppLogging(ctx)
+                            } else {
+                                com.winlator.cmod.runtime.system.LogManager
+                                    .stopAppLogging()
                                 com.winlator.cmod.runtime.system.LogManager
                                     .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onWineChannelsChanged = { channels ->
-                                preferences.edit { putString("wine_debug_channels", channels.joinToString(",")) }
-                                refresh()
-                            },
-                            onResetWineChannels = {
-                                val defaults =
-                                    SettingsConfig.DEFAULT_WINE_DEBUG_CHANNELS
-                                        .split(",")
-                                        .filter { it.isNotBlank() }
-                                preferences.edit { putString("wine_debug_channels", defaults.joinToString(",")) }
-                                refresh()
-                            },
-                            onRemoveWineChannel = { channel ->
-                                val remaining = debugState.wineChannels.filterNot { it == channel }
-                                preferences.edit { putString("wine_debug_channels", remaining.joinToString(",")) }
-                                refresh()
-                            },
-                            onBox64LogsChanged = { checked ->
-                                preferences.edit { putBoolean("enable_box64_logs", checked) }
-                                com.winlator.cmod.runtime.system.LogManager
-                                    .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onFexcoreLogsChanged = { checked ->
-                                preferences.edit { putBoolean("enable_fexcore_logs", checked) }
-                                com.winlator.cmod.runtime.system.LogManager
-                                    .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onSteamLogsChanged = { checked ->
-                                com.winlator.cmod.feature.stores.steam.utils.PrefManager.enableSteamLogs = checked
-                                if (checked &&
-                                    timber.log.Timber
-                                        .forest()
-                                        .isEmpty()
-                                ) {
-                                    timber.log.Timber.plant(timber.log.Timber.DebugTree())
-                                }
-                                com.winlator.cmod.runtime.system.LogManager
-                                    .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onInputLogsChanged = { checked ->
-                                preferences.edit { putBoolean("enable_input_logs", checked) }
-                                com.winlator.cmod.runtime.system.LogManager
-                                    .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onDownloadLogsChanged = { checked ->
-                                preferences.edit { putBoolean("enable_download_logs", checked) }
-                                com.winlator.cmod.runtime.system.LogManager
-                                    .updateLoggingState(ctx)
-                                refresh()
-                            },
-                            onShareLogs = { shareLogs() },
-                        )
-                    }
-                }
-            }
-
-        // View-level ScrollView gives Compose a bounded height, mirroring StoresFragment.
-        // Do NOT add fillMaxSize/verticalScroll inside DebugScreen while this is here.
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(ctx).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+                            }
+                            refresh()
                         },
+                        onWineDebugChanged = { checked ->
+                            preferences.edit { putBoolean("enable_wine_debug", checked) }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onWineChannelsChanged = { channels ->
+                            preferences.edit { putString("wine_debug_channels", channels.joinToString(",")) }
+                            refresh()
+                        },
+                        onResetWineChannels = {
+                            val defaults =
+                                SettingsConfig.DEFAULT_WINE_DEBUG_CHANNELS
+                                    .split(",")
+                                    .filter { it.isNotBlank() }
+                            preferences.edit { putString("wine_debug_channels", defaults.joinToString(",")) }
+                            refresh()
+                        },
+                        onRemoveWineChannel = { channel ->
+                            val remaining = debugState.wineChannels.filterNot { it == channel }
+                            preferences.edit { putString("wine_debug_channels", remaining.joinToString(",")) }
+                            refresh()
+                        },
+                        onBox64LogsChanged = { checked ->
+                            preferences.edit { putBoolean("enable_box64_logs", checked) }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onFexcoreLogsChanged = { checked ->
+                            preferences.edit { putBoolean("enable_fexcore_logs", checked) }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onSteamLogsChanged = { checked ->
+                            com.winlator.cmod.feature.stores.steam.utils.PrefManager.enableSteamLogs = checked
+                            if (checked &&
+                                timber.log.Timber
+                                    .forest()
+                                    .isEmpty()
+                            ) {
+                                timber.log.Timber.plant(timber.log.Timber.DebugTree())
+                            }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onInputLogsChanged = { checked ->
+                            preferences.edit { putBoolean("enable_input_logs", checked) }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onDownloadLogsChanged = { checked ->
+                            preferences.edit { putBoolean("enable_download_logs", checked) }
+                            com.winlator.cmod.runtime.system.LogManager
+                                .updateLoggingState(ctx)
+                            refresh()
+                        },
+                        onShareLogs = { shareLogs() },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-
-        return FrameLayout(ctx).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#0F0F12"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/debug/DebugScreen.kt
+++ b/app/src/main/feature/settings/debug/DebugScreen.kt
@@ -1,5 +1,5 @@
 /* Settings > Debug screen — Jetpack Compose / Material3.
- * Scrolling delegated to a View-level ScrollView in DebugFragment, matching StoresFragment. */
+ * Uses a LazyColumn for the main content. */
 package com.winlator.cmod.feature.settings
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -8,11 +8,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -27,7 +29,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -123,91 +124,118 @@ fun DebugScreen(
         )
     }
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        SectionLabel(stringResource(R.string.common_ui_application))
+        item(key = "application_section") {
+            SectionLabel(stringResource(R.string.common_ui_application))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.common_ui_application),
-            subtitle = stringResource(R.string.settings_debug_log_to_file_desc),
-            icon = Icons.Outlined.BugReport,
-            accentColor = Warning,
-            checked = state.appDebug,
-            onCheckedChange = onAppDebugChanged,
-        )
+        item(key = "app_debug_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.common_ui_application),
+                subtitle = stringResource(R.string.settings_debug_log_to_file_desc),
+                icon = Icons.Outlined.BugReport,
+                accentColor = Warning,
+                checked = state.appDebug,
+                onCheckedChange = onAppDebugChanged,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_debug_section_emulation), modifier = Modifier.padding(top = 8.dp))
+        item(key = "emulation_section") {
+            SectionLabel(stringResource(R.string.settings_debug_section_emulation), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_wine_logs_title),
-            subtitle = stringResource(R.string.settings_debug_wine_logs_subtitle),
-            icon = Icons.Outlined.Terminal,
-            checked = state.wineDebug,
-            onCheckedChange = onWineDebugChanged,
-        )
+        item(key = "wine_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_wine_logs_title),
+                subtitle = stringResource(R.string.settings_debug_wine_logs_subtitle),
+                icon = Icons.Outlined.Terminal,
+                checked = state.wineDebug,
+                onCheckedChange = onWineDebugChanged,
+            )
+        }
 
-        WineChannelsCard(
-            channels = state.wineChannels,
-            enabled = state.wineDebug,
-            onEdit = { showChannelsDialog = true },
-            onReset = onResetWineChannels,
-            onRemoveChannel = onRemoveWineChannel,
-        )
+        item(key = "wine_channels_card") {
+            WineChannelsCard(
+                channels = state.wineChannels,
+                enabled = state.wineDebug,
+                onEdit = { showChannelsDialog = true },
+                onReset = onResetWineChannels,
+                onRemoveChannel = onRemoveWineChannel,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_box_logs_title),
-            subtitle = stringResource(R.string.settings_debug_box_logs_subtitle),
-            icon = Icons.Outlined.Memory,
-            checked = state.box64Logs,
-            onCheckedChange = onBox64LogsChanged,
-        )
+        item(key = "box64_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_box_logs_title),
+                subtitle = stringResource(R.string.settings_debug_box_logs_subtitle),
+                icon = Icons.Outlined.Memory,
+                checked = state.box64Logs,
+                onCheckedChange = onBox64LogsChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_fex_logs_title),
-            subtitle = stringResource(R.string.settings_debug_fex_logs_subtitle),
-            icon = Icons.Outlined.Memory,
-            checked = state.fexcoreLogs,
-            onCheckedChange = onFexcoreLogsChanged,
-        )
+        item(key = "fexcore_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_fex_logs_title),
+                subtitle = stringResource(R.string.settings_debug_fex_logs_subtitle),
+                icon = Icons.Outlined.Memory,
+                checked = state.fexcoreLogs,
+                onCheckedChange = onFexcoreLogsChanged,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_debug_section_subsystems), modifier = Modifier.padding(top = 8.dp))
+        item(key = "subsystems_section") {
+            SectionLabel(stringResource(R.string.settings_debug_section_subsystems), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_steam_logs_title),
-            subtitle = stringResource(R.string.settings_debug_steam_logs_subtitle),
-            icon = Icons.Outlined.SportsEsports,
-            checked = state.steamLogs,
-            onCheckedChange = onSteamLogsChanged,
-        )
+        item(key = "steam_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_steam_logs_title),
+                subtitle = stringResource(R.string.settings_debug_steam_logs_subtitle),
+                icon = Icons.Outlined.SportsEsports,
+                checked = state.steamLogs,
+                onCheckedChange = onSteamLogsChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_input_logs),
-            subtitle = stringResource(R.string.settings_debug_input_logs_description),
-            icon = Icons.Outlined.Gamepad,
-            checked = state.inputLogs,
-            onCheckedChange = onInputLogsChanged,
-        )
+        item(key = "input_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_input_logs),
+                subtitle = stringResource(R.string.settings_debug_input_logs_description),
+                icon = Icons.Outlined.Gamepad,
+                checked = state.inputLogs,
+                onCheckedChange = onInputLogsChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_debug_download_logs),
-            subtitle = stringResource(R.string.settings_debug_download_logs_description),
-            icon = Icons.Outlined.CloudDownload,
-            checked = state.downloadLogs,
-            onCheckedChange = onDownloadLogsChanged,
-        )
+        item(key = "download_logs_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_download_logs),
+                subtitle = stringResource(R.string.settings_debug_download_logs_description),
+                icon = Icons.Outlined.CloudDownload,
+                checked = state.downloadLogs,
+                onCheckedChange = onDownloadLogsChanged,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_debug_section_tools), modifier = Modifier.padding(top = 8.dp))
+        item(key = "tools_section") {
+            SectionLabel(stringResource(R.string.settings_debug_section_tools), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        ShareLogsButton(onClick = onShareLogs)
+        item(key = "share_logs_button") {
+            ShareLogsButton(onClick = onShareLogs)
+        }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/debug/DebugScreen.kt
+++ b/app/src/main/feature/settings/debug/DebugScreen.kt
@@ -18,11 +18,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
@@ -61,6 +65,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -111,6 +116,11 @@ fun DebugScreen(
     onShareLogs: () -> Unit,
 ) {
     var showChannelsDialog by remember { mutableStateOf(false) }
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     if (showChannelsDialog) {
         WineChannelsDialog(
@@ -129,7 +139,13 @@ fun DebugScreen(
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "application_section") {

--- a/app/src/main/feature/settings/drivers/DriversFragment.kt
+++ b/app/src/main/feature/settings/drivers/DriversFragment.kt
@@ -1,14 +1,10 @@
 package com.winlator.cmod.feature.settings
 import android.content.SharedPreferences
-import android.graphics.drawable.GradientDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
@@ -84,102 +80,62 @@ class DriversFragment : Fragment() {
         refreshInstalledDrivers()
         publishState()
 
-        val composeView =
-            ComposeView(ctx).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        DriversScreen(
-                            state = driversState,
-                            onInstallFromFile = {
-                                driverPicker.launch(arrayOf("*/*"))
-                            },
-                            onSourceTapped = { source -> onSourceSelected(source) },
-                            onReleaseTapped = { release ->
-                                expandedReleaseId = if (expandedReleaseId == release.id) null else release.id
-                                publishState()
-                            },
-                            onDownloadAsset = { asset -> downloadReleaseAsset(asset) },
-                            onRemoveDriver = { driver ->
-                                adrenotoolsManager.removeDriver(driver.id)
-                                refreshInstalledDrivers()
-                                publishState()
-                            },
-                            onRepoAdded = { name, apiUrl ->
+        return ComposeView(ctx).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    DriversScreen(
+                        state = driversState,
+                        onInstallFromFile = {
+                            driverPicker.launch(arrayOf("*/*"))
+                        },
+                        onSourceTapped = { source -> onSourceSelected(source) },
+                        onReleaseTapped = { release ->
+                            expandedReleaseId = if (expandedReleaseId == release.id) null else release.id
+                            publishState()
+                        },
+                        onDownloadAsset = { asset -> downloadReleaseAsset(asset) },
+                        onRemoveDriver = { driver ->
+                            adrenotoolsManager.removeDriver(driver.id)
+                            refreshInstalledDrivers()
+                            publishState()
+                        },
+                        onRepoAdded = { name, apiUrl ->
+                            val normalized = normalizeRepoInput(name, apiUrl)
+                            sources.add(normalized)
+                            saveRepos()
+                            publishState()
+                        },
+                        onRepoUpdated = { index, name, apiUrl ->
+                            if (index in sources.indices) {
                                 val normalized = normalizeRepoInput(name, apiUrl)
-                                sources.add(normalized)
+                                sources[index] = normalized
+                                releasesBySource.remove(sources[index].apiUrl)
                                 saveRepos()
                                 publishState()
-                            },
-                            onRepoUpdated = { index, name, apiUrl ->
-                                if (index in sources.indices) {
-                                    val normalized = normalizeRepoInput(name, apiUrl)
-                                    sources[index] = normalized
-                                    releasesBySource.remove(sources[index].apiUrl)
-                                    saveRepos()
-                                    publishState()
-                                }
-                            },
-                            onRepoDeleted = { index ->
-                                if (index in sources.indices) {
-                                    val removed = sources.removeAt(index)
-                                    releasesBySource.remove(removed.apiUrl)
-                                    if (expandedSourceApiUrl == removed.apiUrl) expandedSourceApiUrl = null
-                                    if (loadingSourceApiUrl == removed.apiUrl) loadingSourceApiUrl = null
-                                    saveRepos()
-                                    publishState()
-                                }
-                            },
-                            onRestoreDefaultRepos = { restoreDefaultRepos() },
-                        )
-                    }
-                }
-            }
-
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(ctx).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+                            }
                         },
+                        onRepoDeleted = { index ->
+                            if (index in sources.indices) {
+                                val removed = sources.removeAt(index)
+                                releasesBySource.remove(removed.apiUrl)
+                                if (expandedSourceApiUrl == removed.apiUrl) expandedSourceApiUrl = null
+                                if (loadingSourceApiUrl == removed.apiUrl) loadingSourceApiUrl = null
+                                saveRepos()
+                                publishState()
+                            }
+                        },
+                        onRestoreDefaultRepos = { restoreDefaultRepos() },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-
-        return FrameLayout(ctx).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#18181D"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/drivers/DriversScreen.kt
+++ b/app/src/main/feature/settings/drivers/DriversScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -21,11 +23,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.safeDrawing
@@ -72,6 +78,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -183,6 +190,11 @@ fun DriversScreen(
     var editingRepo by remember { mutableStateOf<Pair<Int, DriverRepo>?>(null) }
     var driverPendingRemoval by remember { mutableStateOf<InstalledDriverItem?>(null) }
     var repoPendingRemoval by remember { mutableStateOf<Pair<Int, DriverRepo>?>(null) }
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     if (showAddRepoDialog || editingRepo != null) {
         val editing = editingRepo
@@ -241,7 +253,13 @@ fun DriversScreen(
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "hero_header") {
@@ -260,25 +278,22 @@ fun DriversScreen(
             }
         }
 
-        item(key = "installed_section") {
-            if (state.installedDrivers.isNotEmpty()) {
+        if (state.installedDrivers.isNotEmpty()) {
+            item(key = "installed_section") {
                 SectionLabel(
                     text = stringResource(R.string.common_ui_installed),
                     modifier = Modifier.padding(top = 8.dp),
                 )
             }
-        }
-
-        item(key = "installed_drivers") {
-            if (state.installedDrivers.isNotEmpty()) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    state.installedDrivers.forEach { driver ->
-                        InstalledDriverCard(
-                            driver = driver,
-                            onRemove = { driverPendingRemoval = driver },
-                        )
-                    }
-                }
+            items(
+                items = state.installedDrivers,
+                key = { driver -> driver.id },
+                contentType = { "installedDriverCard" },
+            ) { driver ->
+                InstalledDriverCard(
+                    driver = driver,
+                    onRemove = { driverPendingRemoval = driver },
+                )
             }
         }
 
@@ -305,30 +320,32 @@ fun DriversScreen(
             }
         }
 
-        item(key = "repos_content") {
-            if (state.sources.isEmpty()) {
+        if (state.sources.isEmpty()) {
+            item(key = "repos_empty") {
                 EmptyRepoCard()
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    state.sources.forEachIndexed { index, source ->
-                        val releases = state.releasesBySource[source.apiUrl].orEmpty()
-                        val isExpanded = state.expandedSourceApiUrl == source.apiUrl
-                        val isLoading = state.loadingSourceApiUrl == source.apiUrl
-                        RepoCard(
-                            source = source,
-                            isExpanded = isExpanded,
-                            isLoading = isLoading,
-                            releases = releases,
-                            expandedReleaseId = state.expandedReleaseId,
-                            installedAssetNames = state.installedAssetNames,
-                            onTap = { onSourceTapped(source) },
-                            onReleaseTap = onReleaseTapped,
-                            onDownloadAsset = onDownloadAsset,
-                            onEdit = { editingRepo = index to source },
-                            onDelete = { repoPendingRemoval = index to source },
-                        )
-                    }
-                }
+            }
+        } else {
+            itemsIndexed(
+                items = state.sources,
+                key = { _, source -> source.apiUrl },
+                contentType = { _, _ -> "repoCard" },
+            ) { index, source ->
+                val releases = state.releasesBySource[source.apiUrl].orEmpty()
+                val isExpanded = state.expandedSourceApiUrl == source.apiUrl
+                val isLoading = state.loadingSourceApiUrl == source.apiUrl
+                RepoCard(
+                    source = source,
+                    isExpanded = isExpanded,
+                    isLoading = isLoading,
+                    releases = releases,
+                    expandedReleaseId = state.expandedReleaseId,
+                    installedAssetNames = state.installedAssetNames,
+                    onTap = { onSourceTapped(source) },
+                    onReleaseTap = onReleaseTapped,
+                    onDownloadAsset = onDownloadAsset,
+                    onEdit = { editingRepo = index to source },
+                    onDelete = { repoPendingRemoval = index to source },
+                )
             }
         }
 

--- a/app/src/main/feature/settings/drivers/DriversScreen.kt
+++ b/app/src/main/feature/settings/drivers/DriversScreen.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -234,85 +236,105 @@ fun DriversScreen(
         DownloadProgressDialog(progress = progress)
     }
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        HeroHeader(
-            installedCount = state.installedDrivers.size,
-            repoCount = state.sources.size,
-            isBusy = state.loadingSourceApiUrl != null,
-            onInstall = onInstallFromFile,
-            onAddRepo = { showAddRepoDialog = true },
-        )
-
-        if (state.installedDrivers.isEmpty() && state.sources.isEmpty()) {
-            EmptyState()
+        item(key = "hero_header") {
+            HeroHeader(
+                installedCount = state.installedDrivers.size,
+                repoCount = state.sources.size,
+                isBusy = state.loadingSourceApiUrl != null,
+                onInstall = onInstallFromFile,
+                onAddRepo = { showAddRepoDialog = true },
+            )
         }
 
-        if (state.installedDrivers.isNotEmpty()) {
-            SectionLabel(
-                text = stringResource(R.string.common_ui_installed),
-                modifier = Modifier.padding(top = 8.dp),
-            )
-            state.installedDrivers.forEach { driver ->
-                InstalledDriverCard(
-                    driver = driver,
-                    onRemove = { driverPendingRemoval = driver },
+        item(key = "empty_state") {
+            if (state.installedDrivers.isEmpty() && state.sources.isEmpty()) {
+                EmptyState()
+            }
+        }
+
+        item(key = "installed_section") {
+            if (state.installedDrivers.isNotEmpty()) {
+                SectionLabel(
+                    text = stringResource(R.string.common_ui_installed),
+                    modifier = Modifier.padding(top = 8.dp),
                 )
             }
         }
 
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-            verticalAlignment = Alignment.Bottom,
-        ) {
-            SectionLabel(
-                text = stringResource(R.string.settings_drivers_github_repos),
-                modifier = Modifier.weight(1f),
-            )
-            if (state.hasMissingDefaults) {
-                SmallPillButton(
-                    label = "Restore defaults",
-                    icon = Icons.Outlined.Restore,
-                    tint = Accent,
-                    onClick = onRestoreDefaultRepos,
-                )
+        item(key = "installed_drivers") {
+            if (state.installedDrivers.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    state.installedDrivers.forEach { driver ->
+                        InstalledDriverCard(
+                            driver = driver,
+                            onRemove = { driverPendingRemoval = driver },
+                        )
+                    }
+                }
             }
         }
 
-        if (state.sources.isEmpty()) {
-            EmptyRepoCard()
+        item(key = "repos_header") {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                SectionLabel(
+                    text = stringResource(R.string.settings_drivers_github_repos),
+                    modifier = Modifier.weight(1f),
+                )
+                if (state.hasMissingDefaults) {
+                    SmallPillButton(
+                        label = "Restore defaults",
+                        icon = Icons.Outlined.Restore,
+                        tint = Accent,
+                        onClick = onRestoreDefaultRepos,
+                    )
+                }
+            }
         }
 
-        state.sources.forEachIndexed { index, source ->
-            val releases = state.releasesBySource[source.apiUrl].orEmpty()
-            val isExpanded = state.expandedSourceApiUrl == source.apiUrl
-            val isLoading = state.loadingSourceApiUrl == source.apiUrl
-            RepoCard(
-                source = source,
-                isExpanded = isExpanded,
-                isLoading = isLoading,
-                releases = releases,
-                expandedReleaseId = state.expandedReleaseId,
-                installedAssetNames = state.installedAssetNames,
-                onTap = { onSourceTapped(source) },
-                onReleaseTap = onReleaseTapped,
-                onDownloadAsset = onDownloadAsset,
-                onEdit = { editingRepo = index to source },
-                onDelete = { repoPendingRemoval = index to source },
-            )
+        item(key = "repos_content") {
+            if (state.sources.isEmpty()) {
+                EmptyRepoCard()
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    state.sources.forEachIndexed { index, source ->
+                        val releases = state.releasesBySource[source.apiUrl].orEmpty()
+                        val isExpanded = state.expandedSourceApiUrl == source.apiUrl
+                        val isLoading = state.loadingSourceApiUrl == source.apiUrl
+                        RepoCard(
+                            source = source,
+                            isExpanded = isExpanded,
+                            isLoading = isLoading,
+                            releases = releases,
+                            expandedReleaseId = state.expandedReleaseId,
+                            installedAssetNames = state.installedAssetNames,
+                            onTap = { onSourceTapped(source) },
+                            onReleaseTap = onReleaseTapped,
+                            onDownloadAsset = onDownloadAsset,
+                            onEdit = { editingRepo = index to source },
+                            onDelete = { repoPendingRemoval = index to source },
+                        )
+                    }
+                }
+            }
         }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -70,6 +72,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -218,7 +221,11 @@ fun InputControlsScreen(
     state: InputControlsScreenState,
     actions: InputControlsScreenActions,
 ) {
-    val navBarBottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     Box(
         modifier =
@@ -230,14 +237,13 @@ fun InputControlsScreen(
             modifier = Modifier.fillMaxSize(),
             contentPadding =
                 PaddingValues(
-                    start = 16.dp,
+                    start = 16.dp + navBarStartPadding,
                     top = 16.dp,
-                    end = 26.dp,
-                    bottom = 16.dp + navBarBottomPadding,
+                    end = 16.dp + navBarEndPadding,
+                    bottom = 20.dp + navBarBottomPadding,
                 ),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            item("profile-label") { SectionLabel(stringResource(R.string.common_ui_profile)) }
             item("profile-card") { ProfileCard(state, actions) }
             item("overlay-label") { SectionLabel(stringResource(R.string.input_controls_editor_overlay_opacity)) }
             item("overlay-card") { OverlayOpacityCard(state, actions) }
@@ -1197,102 +1203,132 @@ private fun ProfileCard(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(
-                            Color(
-                                red = InputField.red,
-                                green = InputField.green,
-                                blue = InputField.blue,
-                                alpha = 0.28f + (0.34f * selectorTint),
-                            ),
-                        ).border(
-                            1.dp,
-                            Color(
-                                red = InputOutline.red + ((InputAccent.red - InputOutline.red) * selectorTint * 0.45f),
-                                green = InputOutline.green + ((InputAccent.green - InputOutline.green) * selectorTint * 0.45f),
-                                blue = InputOutline.blue + ((InputAccent.blue - InputOutline.blue) * selectorTint * 0.45f),
-                                alpha = 0.8f + (0.15f * selectorTint),
-                            ),
-                            RoundedCornerShape(12.dp),
-                        ).clickable(
-                            interactionSource = selectionInteraction,
-                            indication = null,
-                            onClick = actions.onSelectProfile,
-                        ).padding(horizontal = 12.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                ProfileSelectorIconBox(if (selectorPressed) InputTextPrimary else InputAccent)
-                Spacer(Modifier.width(14.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text =
-                            state.selectedProfileName
-                                ?: stringResource(R.string.input_controls_editor_select_profile),
-                        color = InputTextPrimary,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        text =
-                            if (state.selectedProfileName != null) {
-                                stringResource(R.string.common_ui_elements_count, state.selectedProfileElementCount)
-                            } else {
-                                stringResource(R.string.input_controls_editor_no_profile_selected)
-                            },
-                        color = InputTextSecondary,
-                        fontSize = 12.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Spacer(Modifier.width(12.dp))
-                Text(
-                    text = stringResource(R.string.input_controls_editor_tap_to_switch),
-                    color = if (selectorPressed) InputTextPrimary else InputAccent,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                )
-            }
+            ProfileSelectorRow(
+                state = state,
+                selectionInteraction = selectionInteraction,
+                selectorTint = selectorTint,
+                selectorPressed = selectorPressed,
+                onClick = actions.onSelectProfile,
+                modifier = Modifier.weight(1f),
+            )
             Spacer(Modifier.width(10.dp))
-            IconActionButton(
-                image = Icons.Outlined.SportsEsports,
-                contentDescription = stringResource(R.string.input_controls_editor_title),
-                onClick = actions.onOpenEditor,
+            ProfileActionRow(actions = actions)
+        }
+    }
+}
+
+@Composable
+private fun ProfileSelectorRow(
+    state: InputControlsScreenState,
+    selectionInteraction: MutableInteractionSource,
+    selectorTint: Float,
+    selectorPressed: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(
+                    Color(
+                        red = InputField.red,
+                        green = InputField.green,
+                        blue = InputField.blue,
+                        alpha = 0.28f + (0.34f * selectorTint),
+                    ),
+                ).border(
+                    1.dp,
+                    Color(
+                        red = InputOutline.red + ((InputAccent.red - InputOutline.red) * selectorTint * 0.45f),
+                        green = InputOutline.green + ((InputAccent.green - InputOutline.green) * selectorTint * 0.45f),
+                        blue = InputOutline.blue + ((InputAccent.blue - InputOutline.blue) * selectorTint * 0.45f),
+                        alpha = 0.8f + (0.15f * selectorTint),
+                    ),
+                    RoundedCornerShape(12.dp),
+                )
+                .clickable(
+                    interactionSource = selectionInteraction,
+                    indication = null,
+                    onClick = onClick,
+                )
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ProfileSelectorIconBox(if (selectorPressed) InputTextPrimary else InputAccent)
+        Spacer(Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text =
+                    state.selectedProfileName
+                        ?: stringResource(R.string.input_controls_editor_select_profile),
+                color = InputTextPrimary,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
-            Spacer(Modifier.width(6.dp))
-            IconActionButton(
-                image = Icons.Outlined.Add,
-                contentDescription = stringResource(R.string.common_ui_add),
-                onClick = actions.onAddProfile,
-            )
-            Spacer(Modifier.width(6.dp))
-            IconActionButton(
-                image = Icons.Outlined.Edit,
-                contentDescription = stringResource(R.string.common_ui_edit),
-                onClick = actions.onEditProfile,
-            )
-            Spacer(Modifier.width(6.dp))
-            IconActionButton(
-                image = Icons.Outlined.ContentCopy,
-                contentDescription = stringResource(R.string.common_ui_duplicate),
-                onClick = actions.onDuplicateProfile,
-            )
-            Spacer(Modifier.width(6.dp))
-            IconActionButton(
-                image = Icons.Outlined.Delete,
-                contentDescription = stringResource(R.string.common_ui_remove),
-                tint = InputDanger,
-                onClick = actions.onRemoveProfile,
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text =
+                    if (state.selectedProfileName != null) {
+                        stringResource(R.string.common_ui_elements_count, state.selectedProfileElementCount)
+                    } else {
+                        stringResource(R.string.input_controls_editor_no_profile_selected)
+                    },
+                color = InputTextSecondary,
+                fontSize = 12.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
+        Spacer(Modifier.width(10.dp))
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+            contentDescription = null,
+            tint =
+                if (selectorPressed) {
+                    InputTextPrimary
+                } else {
+                    InputAccent.copy(alpha = 0.9f)
+                },
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+@Composable
+private fun ProfileActionRow(actions: InputControlsScreenActions) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.End),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconActionButton(
+            image = Icons.Outlined.SportsEsports,
+            contentDescription = stringResource(R.string.input_controls_editor_title),
+            onClick = actions.onOpenEditor,
+        )
+        IconActionButton(
+            image = Icons.Outlined.Add,
+            contentDescription = stringResource(R.string.common_ui_add),
+            onClick = actions.onAddProfile,
+        )
+        IconActionButton(
+            image = Icons.Outlined.Edit,
+            contentDescription = stringResource(R.string.common_ui_edit),
+            onClick = actions.onEditProfile,
+        )
+        IconActionButton(
+            image = Icons.Outlined.ContentCopy,
+            contentDescription = stringResource(R.string.common_ui_duplicate),
+            onClick = actions.onDuplicateProfile,
+        )
+        IconActionButton(
+            image = Icons.Outlined.Delete,
+            contentDescription = stringResource(R.string.common_ui_remove),
+            tint = InputDanger,
+            onClick = actions.onRemoveProfile,
+        )
     }
 }
 

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.safeDrawingPadding
@@ -215,6 +218,8 @@ fun InputControlsScreen(
     state: InputControlsScreenState,
     actions: InputControlsScreenActions,
 ) {
+    val navBarBottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
     Box(
         modifier =
             Modifier
@@ -223,7 +228,13 @@ fun InputControlsScreen(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 26.dp, bottom = 16.dp),
+            contentPadding =
+                PaddingValues(
+                    start = 16.dp,
+                    top = 16.dp,
+                    end = 26.dp,
+                    bottom = 16.dp + navBarBottomPadding,
+                ),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             item("profile-label") { SectionLabel(stringResource(R.string.common_ui_profile)) }

--- a/app/src/main/feature/settings/nav/SettingsNavGraph.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavGraph.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -42,7 +41,6 @@ fun SettingsHost(
         modifier =
             Modifier
                 .fillMaxSize()
-                .graphicsLayer { compositingStrategy = androidx.compose.ui.graphics.CompositingStrategy.Offscreen }
                 .background(SettingsBg),
     ) {
         SettingsNavSidebar(

--- a/app/src/main/feature/settings/nav/SettingsNavGraph.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation.compose.NavHost
@@ -37,74 +39,81 @@ fun SettingsHost(
     val settingsNavController = rememberNavController()
     var currentItem by rememberSaveable { mutableStateOf(startItem) }
 
-    Row(
+    Box(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(SettingsBg),
     ) {
-        SettingsNavSidebar(
-            selectedItem = currentItem,
-            onItemSelected = { item ->
-                if (item != currentItem) {
-                    currentItem = item
-                    settingsNavController.navigate(SettingsRoutes.fromNavItem(item)) {
-                        popUpTo(SettingsRoutes.fromNavItem(startItem)) {
-                            inclusive = false
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                }
-            },
-            onBackPressed = onBack,
-            bordersPaused = bordersPaused,
-        )
-
-        NavHost(
-            navController = settingsNavController,
-            startDestination = SettingsRoutes.fromNavItem(startItem),
-            enterTransition = { fadeIn(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
-            exitTransition = { fadeOut(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
-            popEnterTransition = { fadeIn(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
-            popExitTransition = { fadeOut(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+        Row(
             modifier =
                 Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
+                    .fillMaxSize(),
         ) {
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.CONTAINERS)) {
-                AndroidFragment<ContainersFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.INPUT_CONTROLS)) {
-                AndroidFragment<InputControlsFragment>(
-                    arguments =
-                        Bundle().apply {
-                            putInt("selectedProfileId", selectedProfileId)
-                        },
-                )
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.COMPONENTS)) {
-                AndroidFragment<ContentsFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.DRIVERS)) {
-                AndroidFragment<DriversFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.STORES)) {
-                AndroidFragment<StoresFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.DEBUG)) {
-                AndroidFragment<DebugFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.GOOGLE)) {
-                AndroidFragment<GoogleFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.PRESETS)) {
-                AndroidFragment<PresetsFragment>()
-            }
-            composable(SettingsRoutes.fromNavItem(SettingsNavItem.OTHER)) {
-                AndroidFragment<OtherSettingsFragment>()
+            SettingsNavSidebar(
+                selectedItem = currentItem,
+                onItemSelected = { item ->
+                    if (item != currentItem) {
+                        currentItem = item
+                        settingsNavController.navigate(SettingsRoutes.fromNavItem(item)) {
+                            popUpTo(SettingsRoutes.fromNavItem(startItem)) {
+                                inclusive = false
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                onBackPressed = onBack,
+                bordersPaused = bordersPaused,
+            )
+
+            NavHost(
+                navController = settingsNavController,
+                startDestination = SettingsRoutes.fromNavItem(startItem),
+                enterTransition = { fadeIn(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+                exitTransition = { fadeOut(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+                popEnterTransition = { fadeIn(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+                popExitTransition = { fadeOut(tween(250, easing = androidx.compose.animation.core.FastOutSlowInEasing)) },
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .graphicsLayer(),
+            ) {
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.CONTAINERS)) {
+                    AndroidFragment<ContainersFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.INPUT_CONTROLS)) {
+                    AndroidFragment<InputControlsFragment>(
+                        arguments =
+                            Bundle().apply {
+                                putInt("selectedProfileId", selectedProfileId)
+                            },
+                    )
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.COMPONENTS)) {
+                    AndroidFragment<ContentsFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.DRIVERS)) {
+                    AndroidFragment<DriversFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.STORES)) {
+                    AndroidFragment<StoresFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.DEBUG)) {
+                    AndroidFragment<DebugFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.GOOGLE)) {
+                    AndroidFragment<GoogleFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.PRESETS)) {
+                    AndroidFragment<PresetsFragment>()
+                }
+                composable(SettingsRoutes.fromNavItem(SettingsNavItem.OTHER)) {
+                    AndroidFragment<OtherSettingsFragment>()
+                }
             }
         }
     }

--- a/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
@@ -8,16 +8,20 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -41,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -63,6 +68,7 @@ import com.winlator.cmod.shared.ui.widget.chasingBorder
 private val SidebarBgTop = Color(0xFF171E2E)
 private val SidebarBgBot = Color(0xFF11161F)
 private val SectionLabelClr = Color(0xFF3D4F65)
+private val HeaderTextClr = Color(0xFF58708C)
 private val TextNormal = Color(0xFF7A8FA8)
 private val TextSelected = Color(0xFFF0F4FF)
 private val IconMuted = Color(0xFF4A7A8F)
@@ -70,6 +76,7 @@ private val SelectedBg = Color(0xFF131D2F)
 private val DividerColor = Color(0xFF212C3F)
 
 private val AccentSelected = Color(0xFF4FC3F7)
+private val AccentPressed = Color(0xFF8BDEFF)
 
 private val InterFamily = FontFamily(Font(R.font.inter_medium, FontWeight.Medium))
 
@@ -115,14 +122,20 @@ fun SettingsNavSidebar(
     onBackPressed: () -> Unit,
     bordersPaused: Boolean = false,
 ) {
-    Row(modifier = Modifier.fillMaxHeight()) {
+    val navBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxHeight()
+                .graphicsLayer(),
+    ) {
         Column(
             modifier =
                 Modifier
                     .width(220.dp)
                     .fillMaxHeight()
-                    .background(Brush.verticalGradient(listOf(SidebarBgTop, SidebarBgBot)))
-                    .navigationBarsPadding(),
+                    .background(Brush.verticalGradient(listOf(SidebarBgTop, SidebarBgBot))),
         ) {
             // Header
             SidebarHeader(onBackPressed)
@@ -132,7 +145,8 @@ fun SettingsNavSidebar(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .padding(start = 8.dp, end = 8.dp, top = 2.dp, bottom = 16.dp),
+                        .padding(start = 8.dp, end = 8.dp, top = 2.dp),
+                contentPadding = PaddingValues(bottom = 24.dp + navBottomInset),
             ) {
                 NavSection.entries.forEachIndexed { index, section ->
                     if (index > 0) {
@@ -180,13 +194,21 @@ fun SettingsNavSidebar(
 
 @Composable
 private fun SidebarHeader(onBackPressed: () -> Unit) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val arrowTint by animateColorAsState(
+        targetValue = if (isPressed) AccentPressed else AccentSelected,
+        animationSpec = tween(120),
+        label = "sidebarHeaderArrowTint",
+    )
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier =
             Modifier
                 .fillMaxWidth()
                 .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = interactionSource,
                     indication = null,
                     onClick = onBackPressed,
                 ).padding(start = 14.dp, end = 14.dp, top = 18.dp, bottom = 6.dp),
@@ -194,13 +216,13 @@ private fun SidebarHeader(onBackPressed: () -> Unit) {
         Icon(
             imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
             contentDescription = stringResource(R.string.common_ui_back),
-            tint = AccentSelected,
+            tint = arrowTint,
             modifier = Modifier.size(22.dp),
         )
 
         Text(
             text = stringResource(R.string.common_ui_settings).uppercase(),
-            color = SectionLabelClr,
+            color = HeaderTextClr,
             fontSize = 13.sp,
             fontWeight = FontWeight.Bold,
             fontFamily = InterFamily,

--- a/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,9 +21,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.AccountCircle
@@ -128,17 +128,32 @@ fun SettingsNavSidebar(
             SidebarHeader(onBackPressed)
 
             // Scrollable nav items
-            Column(
+            LazyColumn(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .verticalScroll(rememberScrollState())
                         .padding(start = 8.dp, end = 8.dp, top = 2.dp, bottom = 16.dp),
             ) {
                 NavSection.entries.forEachIndexed { index, section ->
-                    if (index > 0) Spacer(Modifier.height(4.dp))
-                    SectionHeader(section.name)
-                    sectionedNavItems[section]?.forEach { item ->
+                    if (index > 0) {
+                        item(
+                            key = "spacer_${section.name}",
+                            contentType = "sectionSpacer",
+                        ) {
+                            Spacer(Modifier.height(4.dp))
+                        }
+                    }
+                    item(
+                        key = "header_${section.name}",
+                        contentType = "sectionHeader",
+                    ) {
+                        SectionHeader(section.name)
+                    }
+                    items(
+                        items = sectionedNavItems[section].orEmpty(),
+                        key = { it.name },
+                        contentType = { "navItem" },
+                    ) { item ->
                         NavItemRow(
                             item = item,
                             isSelected = item == selectedItem,

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -32,6 +32,7 @@ import androidx.preference.PreferenceManager
 import com.winlator.cmod.R
 import com.winlator.cmod.app.config.SettingsConfig
 import com.winlator.cmod.app.update.UpdateChecker
+import com.winlator.cmod.feature.setup.SetupWizardActivity
 import com.winlator.cmod.runtime.audio.midi.MidiManager
 import com.winlator.cmod.runtime.display.environment.ImageFsInstaller
 import com.winlator.cmod.shared.android.AppUtils
@@ -190,6 +191,9 @@ class OtherSettingsFragment : Fragment() {
                             onShareClipboardChanged = { checked ->
                                 preferences.edit { putBoolean("share_android_clipboard", checked) }
                                 refresh()
+                            },
+                            onRunSetupWizard = {
+                                startActivity(SetupWizardActivity.createManualRerunIntent(ctx))
                             },
                             onReinstallImagefs = { startImagefsReinstall() },
                         )

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -1,21 +1,16 @@
-/* Settings > Other fragment — hosts OtherSettingsScreen via ComposeView.
- * Mirrors the ScrollView wrapper used in StoresFragment / DebugFragment. */
+/* Settings > Other fragment — hosts OtherSettingsScreen via ComposeView. */
 package com.winlator.cmod.feature.settings
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.graphics.drawable.GradientDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
@@ -94,152 +89,110 @@ class OtherSettingsFragment : Fragment() {
         preferences = PreferenceManager.getDefaultSharedPreferences(ctx)
         refresh()
 
-        val composeView =
-            ComposeView(ctx).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        OtherSettingsScreen(
-                            state = uiState,
-                            onCheckForUpdatesChanged = { checked ->
-                                preferences.edit { putBoolean("check_for_updates", checked) }
-                                if (checked) {
-                                    UpdateChecker.startBackgroundLoop(ctx)
-                                } else {
-                                    UpdateChecker.stopBackgroundLoop()
-                                }
-                                refresh()
-                            },
-                            onCheckForUpdatesNow = {
-                                val started = UpdateChecker.checkForUpdateManual(ctx)
-                                if (started) {
-                                    AppUtils.showToast(ctx, R.string.settings_other_checking_for_updates)
-                                } else {
-                                    val seconds = UpdateChecker.manualCheckCooldownSeconds()
-                                    AppUtils.showToast(
-                                        ctx,
-                                        getString(R.string.settings_other_update_check_cooldown, seconds),
-                                    )
-                                }
-                            },
-                            onLanguageSelected = { index ->
-                                val currentIndex =
-                                    LocaleHelper.indexForTag(
-                                        LocaleHelper.getAppliedLanguageTag(),
-                                    )
-                                if (index != currentIndex) {
-                                    LocaleHelper.applyLanguageTag(LocaleHelper.tagForIndex(index))
-                                    // AppCompatDelegate recreates attached activities automatically.
-                                }
-                            },
-                            onRefreshRateSelected = { index ->
-                                val hz =
-                                    RefreshRateUtils.parseRefreshRateLabel(
-                                        uiState.refreshRateLabels.getOrNull(index),
-                                    )
-                                preferences.edit { putInt("refresh_rate_override", hz) }
-                                if (isAdded) RefreshRateUtils.applyPreferredRefreshRate(requireActivity())
-                                refresh()
-                            },
-                            onSoundFontSelected = { index ->
-                                // Selection is display-only; no persistence in legacy code.
-                                uiState = uiState.copy(soundFontIndex = index)
-                            },
-                            onInstallSoundFont = {
-                                val intent =
-                                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                        addCategory(Intent.CATEGORY_OPENABLE)
-                                        type = "*/*"
-                                    }
-                                installSoundFontLauncher.launch(intent)
-                            },
-                            onRemoveSoundFont = { removeSelectedSoundFont() },
-                            onPickWinlatorPath = { winlatorPathLauncher.launch(null) },
-                            onPickShortcutExportPath = { shortcutExportPathLauncher.launch(null) },
-                            onCursorSpeedChanged = { percent ->
-                                preferences.edit { putFloat("cursor_speed", percent / 100f) }
-                                refresh()
-                            },
-                            onUseDRI3Changed = { checked ->
-                                preferences.edit { putBoolean("use_dri3", checked) }
-                                refresh()
-                            },
-                            onCursorLockChanged = { checked ->
-                                preferences.edit { putBoolean("cursor_lock", checked) }
-                                refresh()
-                            },
-                            onXinputDisabledChanged = { checked ->
-                                preferences.edit { putBoolean("xinput_toggle", checked) }
-                                refresh()
-                            },
-                            onEnableFileProviderChanged = { checked ->
-                                preferences.edit { putBoolean("enable_file_provider", checked) }
-                                AppUtils.showToast(ctx, R.string.settings_general_take_effect_next_startup)
-                                refresh()
-                            },
-                            onOpenInBrowserChanged = { checked ->
-                                preferences.edit { putBoolean("open_with_android_browser", checked) }
-                                refresh()
-                            },
-                            onShareClipboardChanged = { checked ->
-                                preferences.edit { putBoolean("share_android_clipboard", checked) }
-                                refresh()
-                            },
-                            onRunSetupWizard = {
-                                startActivity(SetupWizardActivity.createManualRerunIntent(ctx))
-                            },
-                            onReinstallImagefs = { startImagefsReinstall() },
-                        )
-                    }
-                }
-            }
-
-        // View-level ScrollView gives Compose a bounded height, mirroring StoresFragment.
-        // Do NOT add fillMaxSize/verticalScroll inside OtherSettingsScreen while this is here.
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(ctx).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+        return ComposeView(ctx).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    OtherSettingsScreen(
+                        state = uiState,
+                        onCheckForUpdatesChanged = { checked ->
+                            preferences.edit { putBoolean("check_for_updates", checked) }
+                            if (checked) {
+                                UpdateChecker.startBackgroundLoop(ctx)
+                            } else {
+                                UpdateChecker.stopBackgroundLoop()
+                            }
+                            refresh()
                         },
+                        onCheckForUpdatesNow = {
+                            val started = UpdateChecker.checkForUpdateManual(ctx)
+                            if (started) {
+                                AppUtils.showToast(ctx, R.string.settings_other_checking_for_updates)
+                            } else {
+                                val seconds = UpdateChecker.manualCheckCooldownSeconds()
+                                AppUtils.showToast(
+                                    ctx,
+                                    getString(R.string.settings_other_update_check_cooldown, seconds),
+                                )
+                            }
+                        },
+                        onLanguageSelected = { index ->
+                            val currentIndex =
+                                LocaleHelper.indexForTag(
+                                    LocaleHelper.getAppliedLanguageTag(),
+                                )
+                            if (index != currentIndex) {
+                                LocaleHelper.applyLanguageTag(LocaleHelper.tagForIndex(index))
+                                // AppCompatDelegate recreates attached activities automatically.
+                            }
+                        },
+                        onRefreshRateSelected = { index ->
+                            val hz =
+                                RefreshRateUtils.parseRefreshRateLabel(
+                                    uiState.refreshRateLabels.getOrNull(index),
+                                )
+                            preferences.edit { putInt("refresh_rate_override", hz) }
+                            if (isAdded) RefreshRateUtils.applyPreferredRefreshRate(requireActivity())
+                            refresh()
+                        },
+                        onSoundFontSelected = { index ->
+                            // Selection is display-only; no persistence in legacy code.
+                            uiState = uiState.copy(soundFontIndex = index)
+                        },
+                        onInstallSoundFont = {
+                            val intent =
+                                Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "*/*"
+                                }
+                            installSoundFontLauncher.launch(intent)
+                        },
+                        onRemoveSoundFont = { removeSelectedSoundFont() },
+                        onPickWinlatorPath = { winlatorPathLauncher.launch(null) },
+                        onPickShortcutExportPath = { shortcutExportPathLauncher.launch(null) },
+                        onCursorSpeedChanged = { percent ->
+                            preferences.edit { putFloat("cursor_speed", percent / 100f) }
+                            refresh()
+                        },
+                        onUseDRI3Changed = { checked ->
+                            preferences.edit { putBoolean("use_dri3", checked) }
+                            refresh()
+                        },
+                        onCursorLockChanged = { checked ->
+                            preferences.edit { putBoolean("cursor_lock", checked) }
+                            refresh()
+                        },
+                        onXinputDisabledChanged = { checked ->
+                            preferences.edit { putBoolean("xinput_toggle", checked) }
+                            refresh()
+                        },
+                        onEnableFileProviderChanged = { checked ->
+                            preferences.edit { putBoolean("enable_file_provider", checked) }
+                            AppUtils.showToast(ctx, R.string.settings_general_take_effect_next_startup)
+                            refresh()
+                        },
+                        onOpenInBrowserChanged = { checked ->
+                            preferences.edit { putBoolean("open_with_android_browser", checked) }
+                            refresh()
+                        },
+                        onShareClipboardChanged = { checked ->
+                            preferences.edit { putBoolean("share_android_clipboard", checked) }
+                            refresh()
+                        },
+                        onRunSetupWizard = {
+                            startActivity(SetupWizardActivity.createManualRerunIntent(ctx))
+                        },
+                        onReinstallImagefs = { startImagefsReinstall() },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-
-        return FrameLayout(ctx).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#0F0F12"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.outlined.Monitor
 import androidx.compose.material.icons.outlined.Mouse
 import androidx.compose.material.icons.outlined.OpenInBrowser
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.SystemUpdate
@@ -126,6 +127,7 @@ fun OtherSettingsScreen(
     onEnableFileProviderChanged: (Boolean) -> Unit,
     onOpenInBrowserChanged: (Boolean) -> Unit,
     onShareClipboardChanged: (Boolean) -> Unit,
+    onRunSetupWizard: () -> Unit,
     onReinstallImagefs: () -> Unit,
 ) {
     var showReinstallDialog by remember { mutableStateOf(false) }
@@ -264,6 +266,7 @@ fun OtherSettingsScreen(
         SectionLabel(stringResource(R.string.settings_general_imagefs), modifier = Modifier.padding(top = 8.dp))
 
         ReinstallImagefsCard(onClick = { showReinstallDialog = true })
+        SetupWizardCard(onClick = onRunSetupWizard)
 
         Spacer(Modifier.height(24.dp))
     }
@@ -1001,6 +1004,34 @@ private fun ImagefsInstallProgressDialog(percent: Int) {
 // Reinstall imagefs card with centered action button
 @Composable
 private fun ReinstallImagefsCard(onClick: () -> Unit) {
+    SettingsActionCard(
+        title = stringResource(R.string.settings_general_reinstall_imagefs),
+        subtitle = stringResource(R.string.settings_general_imagefs_summary),
+        icon = Icons.Outlined.Autorenew,
+        buttonLabel = stringResource(R.string.common_ui_reinstall),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun SetupWizardCard(onClick: () -> Unit) {
+    SettingsActionCard(
+        title = stringResource(R.string.settings_other_setup_wizard_title),
+        subtitle = stringResource(R.string.settings_other_setup_wizard_summary),
+        icon = Icons.Outlined.Settings,
+        buttonLabel = stringResource(R.string.common_ui_open),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun SettingsActionCard(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    buttonLabel: String,
+    onClick: () -> Unit,
+) {
     Box(
         modifier =
             Modifier
@@ -1009,90 +1040,47 @@ private fun ReinstallImagefsCard(onClick: () -> Unit) {
                 .background(CardDark)
                 .border(1.dp, CardBorder, RoundedCornerShape(12.dp)),
     ) {
-        Column(
+        Row(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(34.dp)
-                            .clip(RoundedCornerShape(9.dp))
-                            .background(IconBoxBg),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Autorenew,
-                        contentDescription = null,
-                        tint = Accent,
-                        modifier = Modifier.size(17.dp),
-                    )
-                }
-                Spacer(Modifier.width(13.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.settings_general_reinstall_imagefs),
-                        color = TextPrimary,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_general_imagefs_summary),
-                        color = TextSecondary,
-                        fontSize = 11.sp,
-                    )
-                }
+            Box(
+                modifier =
+                    Modifier
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(9.dp))
+                        .background(IconBoxBg),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = Accent,
+                    modifier = Modifier.size(17.dp),
+                )
             }
-            Spacer(Modifier.height(10.dp))
-            ReinstallButton(onClick = onClick)
-        }
-    }
-}
-
-@Composable
-private fun ReinstallButton(onClick: () -> Unit) {
-    var isPressed by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(stiffness = Spring.StiffnessHigh),
-        label = "reinstallScale",
-    )
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .scale(scale)
-                .clip(RoundedCornerShape(10.dp))
-                .background(Accent.copy(alpha = 0.12f))
-                .border(1.dp, Accent.copy(alpha = 0.35f), RoundedCornerShape(10.dp))
-                .pointerInput(onClick) {
-                    detectTapGestures(
-                        onPress = {
-                            isPressed = true
-                            tryAwaitRelease()
-                            isPressed = false
-                        },
-                        onTap = { onClick() },
-                    )
-                }.padding(vertical = 12.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.Outlined.Refresh,
-                contentDescription = null,
-                tint = Accent,
-                modifier = Modifier.size(16.dp),
-            )
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = stringResource(R.string.settings_general_reinstall_imagefs),
-                color = Accent,
-                fontSize = 13.sp,
-                fontWeight = FontWeight.SemiBold,
+            Spacer(Modifier.width(13.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    color = TextPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = subtitle,
+                    color = TextSecondary,
+                    fontSize = 11.sp,
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            SmallActionButton(
+                label = buttonLabel,
+                textColor = Accent,
+                onClick = onClick,
             )
         }
     }
@@ -1115,6 +1103,7 @@ private fun SmallActionButton(
         modifier =
             Modifier
                 .scale(scale)
+                .width(104.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(Color(0xFF222232))
                 .border(1.dp, textColor.copy(alpha = 0.30f), RoundedCornerShape(8.dp))

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -1,6 +1,5 @@
 /* Settings > Other screen — Jetpack Compose / Material3.
- * Scrolling delegated to a View-level ScrollView in OtherSettingsFragment,
- * matching StoresFragment and DebugFragment. */
+ * Uses a LazyColumn for the main content so the screen scrolls natively in Compose. */
 package com.winlator.cmod.feature.settings
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
@@ -12,11 +11,14 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -24,7 +26,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -146,129 +147,176 @@ fun OtherSettingsScreen(
         ImagefsInstallProgressDialog(percent = percent)
     }
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        SectionLabel(stringResource(R.string.common_ui_application))
+        item(key = "application_section") {
+            SectionLabel(stringResource(R.string.common_ui_application))
+        }
 
-        UpdatesCard(
-            checked = state.checkForUpdates,
-            onCheckedChange = onCheckForUpdatesChanged,
-            onCheckNow = onCheckForUpdatesNow,
-        )
+        item(key = "updates_card") {
+            UpdatesCard(
+                checked = state.checkForUpdates,
+                onCheckedChange = onCheckForUpdatesChanged,
+                onCheckNow = onCheckForUpdatesNow,
+            )
+        }
 
-        SettingsDropdownCard(
-            title = stringResource(R.string.settings_other_language_title),
-            subtitle = stringResource(R.string.settings_other_language_summary),
-            icon = Icons.Outlined.Language,
-            options = state.languageLabels,
-            selectedIndex = state.languageIndex,
-            onOptionSelected = onLanguageSelected,
-        )
+        item(key = "language_card") {
+            SettingsDropdownCard(
+                title = stringResource(R.string.settings_other_language_title),
+                subtitle = stringResource(R.string.settings_other_language_summary),
+                icon = Icons.Outlined.Language,
+                options = state.languageLabels,
+                selectedIndex = state.languageIndex,
+                onOptionSelected = onLanguageSelected,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.session_display_title), modifier = Modifier.padding(top = 8.dp))
+        item(key = "display_section") {
+            SectionLabel(stringResource(R.string.session_display_title), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsDropdownCard(
-            title = stringResource(R.string.settings_general_refresh_rate),
-            subtitle = stringResource(R.string.settings_general_refresh_rate_summary),
-            icon = Icons.Outlined.Monitor,
-            options = state.refreshRateLabels,
-            selectedIndex = state.refreshRateIndex,
-            onOptionSelected = onRefreshRateSelected,
-        )
+        item(key = "refresh_rate_card") {
+            SettingsDropdownCard(
+                title = stringResource(R.string.settings_general_refresh_rate),
+                subtitle = stringResource(R.string.settings_general_refresh_rate_summary),
+                icon = Icons.Outlined.Monitor,
+                options = state.refreshRateLabels,
+                selectedIndex = state.refreshRateIndex,
+                onOptionSelected = onRefreshRateSelected,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_audio_sound), modifier = Modifier.padding(top = 8.dp))
+        item(key = "audio_section") {
+            SectionLabel(stringResource(R.string.settings_audio_sound), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SoundFontCard(
-            files = state.soundFontFiles,
-            selectedIndex = state.soundFontIndex,
-            onSelected = onSoundFontSelected,
-            onInstall = onInstallSoundFont,
-            onRemove = onRemoveSoundFont,
-        )
+        item(key = "sound_font_card") {
+            SoundFontCard(
+                files = state.soundFontFiles,
+                selectedIndex = state.soundFontIndex,
+                onSelected = onSoundFontSelected,
+                onInstall = onInstallSoundFont,
+                onRemove = onRemoveSoundFont,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_general_paths_title), modifier = Modifier.padding(top = 8.dp))
+        item(key = "paths_section") {
+            SectionLabel(stringResource(R.string.settings_general_paths_title), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        FolderPathCard(
-            label = stringResource(R.string.settings_general_winlator_path_title),
-            path = state.winlatorPath,
-            onBrowse = onPickWinlatorPath,
-        )
-        FolderPathCard(
-            label = stringResource(R.string.settings_general_shortcut_export_path_title),
-            path = state.shortcutExportPath,
-            onBrowse = onPickShortcutExportPath,
-        )
+        item(key = "winlator_path_card") {
+            FolderPathCard(
+                label = stringResource(R.string.settings_general_winlator_path_title),
+                path = state.winlatorPath,
+                onBrowse = onPickWinlatorPath,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.session_xserver_title), modifier = Modifier.padding(top = 8.dp))
+        item(key = "shortcut_export_path_card") {
+            FolderPathCard(
+                label = stringResource(R.string.settings_general_shortcut_export_path_title),
+                path = state.shortcutExportPath,
+                onBrowse = onPickShortcutExportPath,
+            )
+        }
 
-        CursorSpeedCard(
-            percent = state.cursorSpeedPercent,
-            onPercentChanged = onCursorSpeedChanged,
-        )
+        item(key = "xserver_section") {
+            SectionLabel(stringResource(R.string.session_xserver_title), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.session_xserver_use_dri3_extension),
-            subtitle = stringResource(R.string.session_xserver_use_dri3_description),
-            icon = Icons.Outlined.Visibility,
-            checked = state.useDRI3,
-            onCheckedChange = onUseDRI3Changed,
-        )
+        item(key = "cursor_speed_card") {
+            CursorSpeedCard(
+                percent = state.cursorSpeedPercent,
+                onPercentChanged = onCursorSpeedChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_general_cursor_lock_title),
-            subtitle = stringResource(R.string.settings_general_cursor_lock_summary),
-            icon = Icons.Outlined.Mouse,
-            checked = state.cursorLock,
-            onCheckedChange = onCursorLockChanged,
-        )
+        item(key = "use_dri3_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.session_xserver_use_dri3_extension),
+                subtitle = stringResource(R.string.session_xserver_use_dri3_description),
+                icon = Icons.Outlined.Visibility,
+                checked = state.useDRI3,
+                onCheckedChange = onUseDRI3Changed,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_general_xinput_toggle_title),
-            subtitle = stringResource(R.string.settings_general_xinput_toggle_summary),
-            icon = Icons.Outlined.SportsEsports,
-            checked = state.xinputDisabled,
-            onCheckedChange = onXinputDisabledChanged,
-        )
+        item(key = "cursor_lock_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_general_cursor_lock_title),
+                subtitle = stringResource(R.string.settings_general_cursor_lock_summary),
+                icon = Icons.Outlined.Mouse,
+                checked = state.cursorLock,
+                onCheckedChange = onCursorLockChanged,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_other_section_integration), modifier = Modifier.padding(top = 8.dp))
+        item(key = "xinput_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_general_xinput_toggle_title),
+                subtitle = stringResource(R.string.settings_general_xinput_toggle_summary),
+                icon = Icons.Outlined.SportsEsports,
+                checked = state.xinputDisabled,
+                onCheckedChange = onXinputDisabledChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_general_enable_file_provider),
-            subtitle = stringResource(R.string.settings_general_file_provider_summary),
-            icon = Icons.Outlined.Folder,
-            checked = state.enableFileProvider,
-            onCheckedChange = onEnableFileProviderChanged,
-        )
+        item(key = "integration_section") {
+            SectionLabel(stringResource(R.string.settings_other_section_integration), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_general_open_with_android_browser),
-            subtitle = stringResource(R.string.settings_general_open_browser_summary),
-            icon = Icons.Outlined.OpenInBrowser,
-            checked = state.openInBrowser,
-            onCheckedChange = onOpenInBrowserChanged,
-        )
+        item(key = "file_provider_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_general_enable_file_provider),
+                subtitle = stringResource(R.string.settings_general_file_provider_summary),
+                icon = Icons.Outlined.Folder,
+                checked = state.enableFileProvider,
+                onCheckedChange = onEnableFileProviderChanged,
+            )
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.settings_general_share_android_clipboard),
-            subtitle = stringResource(R.string.settings_general_clipboard_summary),
-            icon = Icons.Outlined.ContentCopy,
-            checked = state.shareClipboard,
-            onCheckedChange = onShareClipboardChanged,
-        )
+        item(key = "browser_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_general_open_with_android_browser),
+                subtitle = stringResource(R.string.settings_general_open_browser_summary),
+                icon = Icons.Outlined.OpenInBrowser,
+                checked = state.openInBrowser,
+                onCheckedChange = onOpenInBrowserChanged,
+            )
+        }
 
-        SectionLabel(stringResource(R.string.settings_general_imagefs), modifier = Modifier.padding(top = 8.dp))
+        item(key = "clipboard_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_general_share_android_clipboard),
+                subtitle = stringResource(R.string.settings_general_clipboard_summary),
+                icon = Icons.Outlined.ContentCopy,
+                checked = state.shareClipboard,
+                onCheckedChange = onShareClipboardChanged,
+            )
+        }
 
-        ReinstallImagefsCard(onClick = { showReinstallDialog = true })
-        SetupWizardCard(onClick = onRunSetupWizard)
+        item(key = "imagefs_section") {
+            SectionLabel(stringResource(R.string.settings_general_imagefs), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "reinstall_imagefs_card") {
+            ReinstallImagefsCard(onClick = { showReinstallDialog = true })
+        }
+
+        item(key = "setup_wizard_card") {
+            SetupWizardCard(onClick = onRunSetupWizard)
+        }
+
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -18,10 +18,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -67,6 +72,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -132,6 +138,11 @@ fun OtherSettingsScreen(
     onReinstallImagefs: () -> Unit,
 ) {
     var showReinstallDialog by remember { mutableStateOf(false) }
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     if (showReinstallDialog) {
         ReinstallImagefsConfirmDialog(
@@ -152,7 +163,13 @@ fun OtherSettingsScreen(
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "application_section") {

--- a/app/src/main/feature/settings/presets/PresetsFragment.kt
+++ b/app/src/main/feature/settings/presets/PresetsFragment.kt
@@ -1,14 +1,10 @@
 // Settings > Presets fragment — hosts PresetsScreen via ComposeView.
 package com.winlator.cmod.feature.settings
 import android.content.SharedPreferences
-import android.graphics.drawable.GradientDrawable
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
@@ -114,182 +110,138 @@ class PresetsFragment : Fragment() {
         val ctx = requireContext()
         refresh()
 
-        val composeView =
-            ComposeView(ctx).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        PresetsScreen(
-                            state = presetsState,
-                            onEngineSelected = { engine ->
-                                if (engine != currentEngine) {
-                                    currentEngine = engine
-                                    refresh()
-                                }
-                            },
-                            onPresetSelected = { presetId ->
-                                setSelectedPreset(currentEngine, presetId)
+        return ComposeView(ctx).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    PresetsScreen(
+                        state = presetsState,
+                        onEngineSelected = { engine ->
+                            if (engine != currentEngine) {
+                                currentEngine = engine
                                 refresh()
-                            },
-                            onEnvVarValueChanged = { name, value ->
-                                onEnvVarValueChanged(name, value)
-                            },
-                            onCreatePreset = { rawName ->
-                                val sanitized = sanitizePresetName(rawName)
-                                if (sanitized.isEmpty()) return@PresetsScreen
-                                savePreset(
-                                    engine = currentEngine,
-                                    presetId = null,
-                                    presetName = sanitized,
-                                    envVars = buildEnvVarsFromMap(currentEngine, buildDefaultValueMap(currentEngine)),
-                                )
-                                refresh(selectLatestPreset = true)
-                            },
-                            onRenamePreset = { rawName ->
-                                val selected = selectedPresetOption() ?: return@PresetsScreen
-                                if (!selected.isCustom) {
-                                    AppUtils.showToast(requireContext(), R.string.container_presets_cannot_rename)
-                                    return@PresetsScreen
-                                }
-                                val sanitized = sanitizePresetName(rawName)
-                                if (sanitized.isEmpty()) return@PresetsScreen
-                                savePreset(
-                                    engine = currentEngine,
-                                    presetId = selected.id,
-                                    presetName = sanitized,
-                                    envVars =
-                                        buildEnvVarsFromMap(
-                                            currentEngine,
-                                            currentValues[currentEngine] ?: linkedMapOf(),
-                                        ),
-                                )
-                                refresh()
-                            },
-                            onDuplicatePreset = {
-                                val selected = selectedPresetOption() ?: return@PresetsScreen
-                                when (currentEngine) {
-                                    PresetEngine.BOX64 -> {
-                                        Box64PresetManager.duplicatePreset(
-                                            "box64",
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-
-                                    PresetEngine.FEXCORE -> {
-                                        FEXCorePresetManager.duplicatePreset(
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-                                }
-                                refresh(selectLatestPreset = true)
-                            },
-                            onExportPreset = {
-                                val selected = selectedPresetOption() ?: return@PresetsScreen
-                                if (!selected.isCustom) {
-                                    AppUtils.showToast(requireContext(), R.string.container_presets_cannot_export)
-                                    return@PresetsScreen
-                                }
-                                when (currentEngine) {
-                                    PresetEngine.BOX64 -> {
-                                        Box64PresetManager.exportPreset(
-                                            "box64",
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-
-                                    PresetEngine.FEXCORE -> {
-                                        FEXCorePresetManager.exportPreset(
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-                                }
-                            },
-                            onImportPreset = {
-                                pendingImportEngine = currentEngine
-                                importPresetPicker.launch(arrayOf("*/*"))
-                            },
-                            onRemovePreset = {
-                                val selected = selectedPresetOption() ?: return@PresetsScreen
-                                if (!selected.isCustom) {
-                                    AppUtils.showToast(requireContext(), R.string.container_presets_cannot_remove)
-                                    return@PresetsScreen
-                                }
-                                when (currentEngine) {
-                                    PresetEngine.BOX64 -> {
-                                        Box64PresetManager.removePreset(
-                                            "box64",
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-
-                                    PresetEngine.FEXCORE -> {
-                                        FEXCorePresetManager.removePreset(
-                                            requireContext(),
-                                            selected.id,
-                                        )
-                                    }
-                                }
-                                refresh()
-                            },
-                            suggestedNewPresetName = { buildDefaultPresetName(currentEngine) },
-                        )
-                    }
-                }
-            }
-
-        // Match the DriversFragment / DebugFragment pattern: outer ScrollView gives
-        // Compose a bounded height so the screen scrolls predictably across every
-        // display size. Don't add verticalScroll inside PresetsScreen while this
-        // ScrollView is the parent.
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(ctx).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+                            }
                         },
+                        onPresetSelected = { presetId ->
+                            setSelectedPreset(currentEngine, presetId)
+                            refresh()
+                        },
+                        onEnvVarValueChanged = { name, value ->
+                            onEnvVarValueChanged(name, value)
+                        },
+                        onCreatePreset = { rawName ->
+                            val sanitized = sanitizePresetName(rawName)
+                            if (sanitized.isEmpty()) return@PresetsScreen
+                            savePreset(
+                                engine = currentEngine,
+                                presetId = null,
+                                presetName = sanitized,
+                                envVars = buildEnvVarsFromMap(currentEngine, buildDefaultValueMap(currentEngine)),
+                            )
+                            refresh(selectLatestPreset = true)
+                        },
+                        onRenamePreset = { rawName ->
+                            val selected = selectedPresetOption() ?: return@PresetsScreen
+                            if (!selected.isCustom) {
+                                AppUtils.showToast(requireContext(), R.string.container_presets_cannot_rename)
+                                return@PresetsScreen
+                            }
+                            val sanitized = sanitizePresetName(rawName)
+                            if (sanitized.isEmpty()) return@PresetsScreen
+                            savePreset(
+                                engine = currentEngine,
+                                presetId = selected.id,
+                                presetName = sanitized,
+                                envVars =
+                                    buildEnvVarsFromMap(
+                                        currentEngine,
+                                        currentValues[currentEngine] ?: linkedMapOf(),
+                                    ),
+                            )
+                            refresh()
+                        },
+                        onDuplicatePreset = {
+                            val selected = selectedPresetOption() ?: return@PresetsScreen
+                            when (currentEngine) {
+                                PresetEngine.BOX64 -> {
+                                    Box64PresetManager.duplicatePreset(
+                                        "box64",
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+
+                                PresetEngine.FEXCORE -> {
+                                    FEXCorePresetManager.duplicatePreset(
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+                            }
+                            refresh(selectLatestPreset = true)
+                        },
+                        onExportPreset = {
+                            val selected = selectedPresetOption() ?: return@PresetsScreen
+                            if (!selected.isCustom) {
+                                AppUtils.showToast(requireContext(), R.string.container_presets_cannot_export)
+                                return@PresetsScreen
+                            }
+                            when (currentEngine) {
+                                PresetEngine.BOX64 -> {
+                                    Box64PresetManager.exportPreset(
+                                        "box64",
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+
+                                PresetEngine.FEXCORE -> {
+                                    FEXCorePresetManager.exportPreset(
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+                            }
+                        },
+                        onImportPreset = {
+                            pendingImportEngine = currentEngine
+                            importPresetPicker.launch(arrayOf("*/*"))
+                        },
+                        onRemovePreset = {
+                            val selected = selectedPresetOption() ?: return@PresetsScreen
+                            if (!selected.isCustom) {
+                                AppUtils.showToast(requireContext(), R.string.container_presets_cannot_remove)
+                                return@PresetsScreen
+                            }
+                            when (currentEngine) {
+                                PresetEngine.BOX64 -> {
+                                    Box64PresetManager.removePreset(
+                                        "box64",
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+
+                                PresetEngine.FEXCORE -> {
+                                    FEXCorePresetManager.removePreset(
+                                        requireContext(),
+                                        selected.id,
+                                    )
+                                }
+                            }
+                            refresh()
+                        },
+                        suggestedNewPresetName = { buildDefaultPresetName(currentEngine) },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-
-        return FrameLayout(ctx).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#18181D"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/presets/PresetsScreen.kt
+++ b/app/src/main/feature/settings/presets/PresetsScreen.kt
@@ -1,5 +1,5 @@
 /* Settings > Presets screen — Jetpack Compose / Material3.
- * Scrolling delegated to a View-level ScrollView in PresetsFragment, matching DriversFragment. */
+ * Uses a LazyColumn for the main content. */
 package com.winlator.cmod.feature.settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
@@ -17,11 +17,13 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -252,68 +254,77 @@ fun PresetsScreen(
 
     val currentData = state.current
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        PresetHeroHeader(
-            engine = state.currentEngine,
-            presetCount = currentData.presets.size,
-            customCount = currentData.presets.count { it.isCustom },
-            onCreatePreset = { showNewDialog = true },
-            onImportPreset = onImportPreset,
-        )
+        item(key = "hero_header") {
+            PresetHeroHeader(
+                engine = state.currentEngine,
+                presetCount = currentData.presets.size,
+                customCount = currentData.presets.count { it.isCustom },
+                onCreatePreset = { showNewDialog = true },
+                onImportPreset = onImportPreset,
+            )
+        }
 
-        // Combined engine-tabs + preset selector card. The tabs themselves stay
-        // static; only the preset dropdown / badge / menu / hint and env-var grid
-        // are inside the AnimatedContent below, so tapping a tab doesn't make the
-        // tab itself flicker.
-        PresetSelectorCard(
-            engine = state.currentEngine,
-            state = state,
-            onEngineSelected = onEngineSelected,
-            onPresetSelected = onPresetSelected,
-            onRename = { showRenameDialog = true },
-            onDuplicate = { showDuplicateConfirm = true },
-            onExport = onExportPreset,
-            onImport = onImportPreset,
-            onRemove = { showRemoveConfirm = true },
-        )
+        item(key = "selector_card") {
+            // Combined engine-tabs + preset selector card. The tabs themselves stay
+            // static; only the preset dropdown / badge / menu / hint and env-var grid
+            // are inside the AnimatedContent below, so tapping a tab doesn't make the
+            // tab itself flicker.
+            PresetSelectorCard(
+                engine = state.currentEngine,
+                state = state,
+                onEngineSelected = onEngineSelected,
+                onPresetSelected = onPresetSelected,
+                onRename = { showRenameDialog = true },
+                onDuplicate = { showDuplicateConfirm = true },
+                onExport = onExportPreset,
+                onImport = onImportPreset,
+                onRemove = { showRemoveConfirm = true },
+            )
+        }
 
-        SectionLabel(
-            text = stringResource(R.string.container_config_env_vars),
-            modifier = Modifier.padding(top = 6.dp),
-        )
+        item(key = "env_vars_section") {
+            SectionLabel(
+                text = stringResource(R.string.container_config_env_vars),
+                modifier = Modifier.padding(top = 6.dp),
+            )
+        }
 
-        // Env var grid crossfades + slides when switching engines. Keyed on the
-        // engine enum so AnimatedContent can gracefully interrupt rapid taps:
-        // mid-animation state changes swap to the new target from current progress
-        // instead of completing the old animation first.
-        AnimatedContent(
-            targetState = state.currentEngine,
-            transitionSpec = { engineSwapTransition() },
-            contentKey = { it },
-            label = "presetEnvVarGrid",
-        ) { frameEngine ->
-            val data = state.engines[frameEngine] ?: PresetEngineData()
-            if (data.envVarDefinitions.isEmpty()) {
-                EmptyEnvVarsCard()
-            } else {
-                EnvVarGrid(
-                    definitions = data.envVarDefinitions,
-                    values = data.currentValues,
-                    editable = data.editable,
-                    onValueChanged = onEnvVarValueChanged,
-                )
+        item(key = "env_var_grid") {
+            // Env var grid crossfades + slides when switching engines. Keyed on the
+            // engine enum so AnimatedContent can gracefully interrupt rapid taps:
+            // mid-animation state changes swap to the new target from current progress
+            // instead of completing the old animation first.
+            AnimatedContent(
+                targetState = state.currentEngine,
+                transitionSpec = { engineSwapTransition() },
+                contentKey = { it },
+                label = "presetEnvVarGrid",
+            ) { frameEngine ->
+                val data = state.engines[frameEngine] ?: PresetEngineData()
+                if (data.envVarDefinitions.isEmpty()) {
+                    EmptyEnvVarsCard()
+                } else {
+                    EnvVarGrid(
+                        definitions = data.envVarDefinitions,
+                        values = data.currentValues,
+                        editable = data.editable,
+                        onValueChanged = onEnvVarValueChanged,
+                    )
+                }
             }
         }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/presets/PresetsScreen.kt
+++ b/app/src/main/feature/settings/presets/PresetsScreen.kt
@@ -27,11 +27,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.safeDrawing
@@ -76,6 +80,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -194,6 +199,11 @@ fun PresetsScreen(
     var showRenameDialog by remember { mutableStateOf(false) }
     var showRemoveConfirm by remember { mutableStateOf(false) }
     var showDuplicateConfirm by remember { mutableStateOf(false) }
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     if (showNewDialog) {
         val defaultName = remember { suggestedNewPresetName() }
@@ -259,7 +269,13 @@ fun PresetsScreen(
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "hero_header") {

--- a/app/src/main/feature/settings/stores/StoresFragment.kt
+++ b/app/src/main/feature/settings/stores/StoresFragment.kt
@@ -1,15 +1,11 @@
 // Settings > Stores fragment — hosts StoresScreen via ComposeView.
 package com.winlator.cmod.feature.settings
 import android.content.Intent
-import android.graphics.drawable.GradientDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
@@ -148,103 +144,57 @@ class StoresFragment : Fragment() {
         serverOptions = loadServerOptions()
         refresh()
 
-        val composeView =
-            ComposeView(requireContext()).apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    MaterialTheme(
-                        colorScheme =
-                            darkColorScheme(
-                                primary = Color(0xFF1A9FFF),
-                                background = Color(0xFF141B24),
-                                surface = Color(0xFF1E252E),
-                            ),
-                    ) {
-                        StoresScreen(
-                            state = storeState,
-                            serverOptions = serverOptions,
-                            onSteamSignIn = { steamLoginLauncher.launch(Intent(requireContext(), SteamLoginActivity::class.java)) },
-                            onSteamSignOut = {
-                                SteamService.logOut()
-                                refresh()
-                            },
-                            onEpicSignIn = { epicLoginLauncher.launch(Intent(requireContext(), EpicOAuthActivity::class.java)) },
-                            onEpicSignOut = {
-                                EpicAuthManager.logoutSync(requireContext())
-                                refresh()
-                            },
-                            onGogSignIn = { gogLoginLauncher.launch(Intent(requireContext(), GOGOAuthActivity::class.java)) },
-                            onGogSignOut = {
-                                CoroutineScope(Dispatchers.Main).launch {
-                                    GOGService.logout(requireContext())
-                                    refresh()
-                                }
-                            },
-                            onSharedFolderChanged = {
-                                PrefManager.useSingleDownloadFolder = it
-                                refresh()
-                            },
-                            onDownloadSpeedChanged = {
-                                PrefManager.downloadSpeed = it
-                                refresh()
-                            },
-                            onDownloadServerChanged = { cellId ->
-                                PrefManager.cellId = cellId
-                                PrefManager.cellIdManuallySet = cellId != 0
-                                refresh()
-                            },
-                            onPickDefaultFolder = { defaultFolderLauncher.launch(null) },
-                            onPickSteamFolder = { steamFolderLauncher.launch(null) },
-                            onPickEpicFolder = { epicFolderLauncher.launch(null) },
-                            onPickGogFolder = { gogFolderLauncher.launch(null) },
-                        )
-                    }
-                }
-            }
-
-        // View level ScrollView gives Compose a bounded height required because ComposeView
-        // sits inside a weighted LinearLayout that passes unbounded constraints to its children.
-        // WARNING: Do NOT add verticalScroll/fillMaxSize to StoresScreen while this is here;
-        // fillMaxSize inside an unbounded container crashes at runtime.
-        // TODO: Remove this block and use Compose native scrolling once fully migrated off Fragments.
-        val density = resources.displayMetrics.density
-        val scrollView =
-            ScrollView(requireContext()).apply {
-                isFillViewport = true
-                scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                scrollBarSize = (3 * density).toInt()
-                isScrollbarFadingEnabled = true
-                scrollBarDefaultDelayBeforeFade = 400
-                scrollBarFadeDuration = 250
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    setVerticalScrollbarThumbDrawable(
-                        GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            setColor(android.graphics.Color.argb(100, 26, 159, 255))
-                            cornerRadius = 4 * density
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme(
+                    colorScheme =
+                        darkColorScheme(
+                            primary = Color(0xFF1A9FFF),
+                            background = Color(0xFF141B24),
+                            surface = Color(0xFF1E252E),
+                        ),
+                ) {
+                    StoresScreen(
+                        state = storeState,
+                        serverOptions = serverOptions,
+                        onSteamSignIn = { steamLoginLauncher.launch(Intent(requireContext(), SteamLoginActivity::class.java)) },
+                        onSteamSignOut = {
+                            SteamService.logOut()
+                            refresh()
                         },
+                        onEpicSignIn = { epicLoginLauncher.launch(Intent(requireContext(), EpicOAuthActivity::class.java)) },
+                        onEpicSignOut = {
+                            EpicAuthManager.logoutSync(requireContext())
+                            refresh()
+                        },
+                        onGogSignIn = { gogLoginLauncher.launch(Intent(requireContext(), GOGOAuthActivity::class.java)) },
+                        onGogSignOut = {
+                            CoroutineScope(Dispatchers.Main).launch {
+                                GOGService.logout(requireContext())
+                                refresh()
+                            }
+                        },
+                        onSharedFolderChanged = {
+                            PrefManager.useSingleDownloadFolder = it
+                            refresh()
+                        },
+                        onDownloadSpeedChanged = {
+                            PrefManager.downloadSpeed = it
+                            refresh()
+                        },
+                        onDownloadServerChanged = { cellId ->
+                            PrefManager.cellId = cellId
+                            PrefManager.cellIdManuallySet = cellId != 0
+                            refresh()
+                        },
+                        onPickDefaultFolder = { defaultFolderLauncher.launch(null) },
+                        onPickSteamFolder = { steamFolderLauncher.launch(null) },
+                        onPickEpicFolder = { epicFolderLauncher.launch(null) },
+                        onPickGogFolder = { gogFolderLauncher.launch(null) },
                     )
                 }
-                addView(
-                    composeView,
-                    ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ),
-                )
             }
-        // Outer FrameLayout with right margin so the scrollbar never touches the screen edge.
-        // Background matches the content area so the gap is invisible.
-        return FrameLayout(requireContext()).apply {
-            setBackgroundColor(android.graphics.Color.parseColor("#0F0F12"))
-            addView(
-                scrollView,
-                FrameLayout
-                    .LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    ).apply { marginEnd = (10 * density).toInt() },
-            )
         }
     }
 

--- a/app/src/main/feature/settings/stores/StoresScreen.kt
+++ b/app/src/main/feature/settings/stores/StoresScreen.kt
@@ -1,5 +1,5 @@
 /* Settings > Stores screen — Jetpack Compose / Material3.
- * Scrolling delegated to a View-level ScrollView in StoresFragment. */
+ * Uses a LazyColumn for the main content. */
 package com.winlator.cmod.feature.settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
@@ -19,11 +19,14 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -31,7 +34,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -128,103 +130,124 @@ fun StoresScreen(
     onPickEpicFolder: () -> Unit,
     onPickGogFolder: () -> Unit,
 ) {
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        SectionLabel("Connected Stores")
+        item(key = "stores_section") {
+            SectionLabel("Connected Stores")
+        }
 
-        StoreCard(
-            name = "Steam",
-            icon = Icons.Outlined.Gamepad,
-            accentColor = Color(0xFF66C0F4),
-            isLoggedIn = state.isSteamLoggedIn,
-            onSignIn = onSteamSignIn,
-            onSignOut = onSteamSignOut,
-        )
-        StoreCard(
-            name = "Epic Games",
-            icon = Icons.Outlined.Gamepad,
-            accentColor = Color(0xFF8BAFD4),
-            isLoggedIn = state.isEpicLoggedIn,
-            onSignIn = onEpicSignIn,
-            onSignOut = onEpicSignOut,
-        )
-        StoreCard(
-            name = "GOG",
-            icon = Icons.Outlined.Gamepad,
-            accentColor = Color(0xFFA855F7),
-            isLoggedIn = state.isGogLoggedIn,
-            onSignIn = onGogSignIn,
-            onSignOut = onGogSignOut,
-        )
+        item(key = "steam_card") {
+            StoreCard(
+                name = "Steam",
+                icon = Icons.Outlined.Gamepad,
+                accentColor = Color(0xFF66C0F4),
+                isLoggedIn = state.isSteamLoggedIn,
+                onSignIn = onSteamSignIn,
+                onSignOut = onSteamSignOut,
+            )
+        }
+        item(key = "epic_card") {
+            StoreCard(
+                name = "Epic Games",
+                icon = Icons.Outlined.Gamepad,
+                accentColor = Color(0xFF8BAFD4),
+                isLoggedIn = state.isEpicLoggedIn,
+                onSignIn = onEpicSignIn,
+                onSignOut = onEpicSignOut,
+            )
+        }
+        item(key = "gog_card") {
+            StoreCard(
+                name = "GOG",
+                icon = Icons.Outlined.Gamepad,
+                accentColor = Color(0xFFA855F7),
+                isLoggedIn = state.isGogLoggedIn,
+                onSignIn = onGogSignIn,
+                onSignOut = onGogSignOut,
+            )
+        }
 
-        SectionLabel("Download Settings", modifier = Modifier.padding(top = 8.dp))
+        item(key = "download_section") {
+            SectionLabel("Download Settings", modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsToggleCard(
-            title = stringResource(R.string.stores_accounts_shared_downloads_folder),
-            subtitle = stringResource(R.string.stores_accounts_shared_downloads_subtitle),
-            icon = Icons.Outlined.FolderShared,
-            checked = state.sharedFolder,
-            onCheckedChange = onSharedFolderChanged,
-        )
+        item(key = "shared_folder_toggle") {
+            SettingsToggleCard(
+                title = stringResource(R.string.stores_accounts_shared_downloads_folder),
+                subtitle = stringResource(R.string.stores_accounts_shared_downloads_subtitle),
+                icon = Icons.Outlined.FolderShared,
+                checked = state.sharedFolder,
+                onCheckedChange = onSharedFolderChanged,
+            )
+        }
 
-        AnimatedContent(
-            targetState = state.sharedFolder,
-            transitionSpec = {
-                fadeIn(tween(220)) togetherWith fadeOut(tween(160)) using
-                    SizeTransform(clip = true, sizeAnimationSpec = { _, _ -> tween(240) })
-            },
-            label = "folderPaths",
-        ) { shared ->
-            if (shared) {
-                FolderPathCard(
-                    label = "Default Downloads Folder",
-                    path = state.defaultFolder,
-                    onBrowse = onPickDefaultFolder,
-                )
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    FolderPathCard("Steam Downloads", state.steamFolder, onPickSteamFolder)
-                    FolderPathCard("Epic Downloads", state.epicFolder, onPickEpicFolder)
-                    FolderPathCard("GOG Downloads", state.gogFolder, onPickGogFolder)
+        item(key = "folder_paths") {
+            AnimatedContent(
+                targetState = state.sharedFolder,
+                transitionSpec = {
+                    fadeIn(tween(220)) togetherWith fadeOut(tween(160)) using
+                        SizeTransform(clip = true, sizeAnimationSpec = { _, _ -> tween(240) })
+                },
+                label = "folderPaths",
+            ) { shared ->
+                if (shared) {
+                    FolderPathCard(
+                        label = "Default Downloads Folder",
+                        path = state.defaultFolder,
+                        onBrowse = onPickDefaultFolder,
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        FolderPathCard("Steam Downloads", state.steamFolder, onPickSteamFolder)
+                        FolderPathCard("Epic Downloads", state.epicFolder, onPickEpicFolder)
+                        FolderPathCard("GOG Downloads", state.gogFolder, onPickGogFolder)
+                    }
                 }
             }
         }
 
-        SectionLabel("Steam", modifier = Modifier.padding(top = 8.dp))
+        item(key = "steam_section") {
+            SectionLabel("Steam", modifier = Modifier.padding(top = 8.dp))
+        }
 
-        SettingsDropdownCard(
-            title = stringResource(R.string.stores_accounts_download_speed),
-            subtitle = stringResource(R.string.stores_accounts_download_speed_subtitle),
-            icon = Icons.Outlined.Speed,
-            selectedValue = state.downloadSpeed,
-            options = downloadSpeedOptions,
-            onOptionSelected = onDownloadSpeedChanged,
-            highlightMaxValue = true,
-        )
-        val serverSubtitle =
-            if (!state.downloadServerManuallySet && state.downloadServer != 0) {
-                val name = serverOptions.firstOrNull { it.first == state.downloadServer }?.second ?: ""
-                "Auto-detected: $name"
-            } else {
-                "Steam CDN region for game downloads"
-            }
-        SettingsDropdownCard(
-            title = stringResource(R.string.stores_accounts_download_server),
-            subtitle = serverSubtitle,
-            icon = Icons.Outlined.Public,
-            selectedValue = state.downloadServer,
-            options = serverOptions,
-            onOptionSelected = onDownloadServerChanged,
-        )
+        item(key = "download_speed") {
+            SettingsDropdownCard(
+                title = stringResource(R.string.stores_accounts_download_speed),
+                subtitle = stringResource(R.string.stores_accounts_download_speed_subtitle),
+                icon = Icons.Outlined.Speed,
+                selectedValue = state.downloadSpeed,
+                options = downloadSpeedOptions,
+                onOptionSelected = onDownloadSpeedChanged,
+                highlightMaxValue = true,
+            )
+        }
+        item(key = "download_server") {
+            val serverSubtitle =
+                if (!state.downloadServerManuallySet && state.downloadServer != 0) {
+                    val name = serverOptions.firstOrNull { it.first == state.downloadServer }?.second ?: ""
+                    "Auto-detected: $name"
+                } else {
+                    "Steam CDN region for game downloads"
+                }
+            SettingsDropdownCard(
+                title = stringResource(R.string.stores_accounts_download_server),
+                subtitle = serverSubtitle,
+                icon = Icons.Outlined.Public,
+                selectedValue = state.downloadServer,
+                options = serverOptions,
+                onOptionSelected = onDownloadServerChanged,
+            )
+        }
 
-        Spacer(Modifier.height(24.dp))
+        item(key = "bottom_spacer") {
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 

--- a/app/src/main/feature/settings/stores/StoresScreen.kt
+++ b/app/src/main/feature/settings/stores/StoresScreen.kt
@@ -26,10 +26,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -66,6 +71,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -130,12 +136,24 @@ fun StoresScreen(
     onPickEpicFolder: () -> Unit,
     onPickGogFolder: () -> Unit,
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
+
     LazyColumn(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(BgDark),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp + navBarStartPadding,
+                end = 16.dp + navBarEndPadding,
+                top = 16.dp,
+                bottom = 4.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item(key = "stores_section") {

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -142,6 +142,8 @@ private data class TabInfo(
 class SetupWizardActivity : FragmentActivity() {
     companion object {
         private const val PREFS_NAME = "winnative_setup"
+        private const val EXTRA_FORCE_SHOW = "force_show"
+        private const val EXTRA_RETURN_TO_CALLER = "return_to_caller"
         private const val KEY_SETUP_COMPLETE = "setup_complete"
         private const val KEY_RECOMMENDED_COMPONENTS_DONE = "recommended_components_done"
         private const val KEY_DRIVERS_VISITED = "drivers_visited"
@@ -162,6 +164,12 @@ class SetupWizardActivity : FragmentActivity() {
         fun markSetupComplete(context: Context) {
             prefs(context).edit().putBoolean(KEY_SETUP_COMPLETE, true).apply()
         }
+
+        @JvmStatic
+        fun createManualRerunIntent(context: Context): Intent =
+            Intent(context, SetupWizardActivity::class.java)
+                .putExtra(EXTRA_FORCE_SHOW, true)
+                .putExtra(EXTRA_RETURN_TO_CALLER, true)
 
         @JvmStatic
         fun getPreferredGameContainer(
@@ -483,6 +491,7 @@ class SetupWizardActivity : FragmentActivity() {
     private val advancedInstalledSet = mutableStateListOf<String>()
     private val advancedContainerNames = mutableStateListOf<String>()
 
+    private var returnToCaller = false
     private var pendingContainerSettingsType: String? = null
     private var recommendedPackageRefreshInFlight = false
 
@@ -529,6 +538,8 @@ class SetupWizardActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        returnToCaller = intent?.getBooleanExtra(EXTRA_RETURN_TO_CALLER, false) == true
+        val forceShow = intent?.getBooleanExtra(EXTRA_FORCE_SHOW, false) == true
 
         supportFragmentManager.setFragmentResultListener(
             SetupWizardDriversDialogFragment.RESULT_KEY,
@@ -538,7 +549,7 @@ class SetupWizardActivity : FragmentActivity() {
             refreshWizardState()
         }
 
-        if (isSetupComplete(this) && ImageFs.find(this).isValid) {
+        if (!forceShow && isSetupComplete(this) && ImageFs.find(this).isValid) {
             launchApp()
             return
         }
@@ -1420,7 +1431,11 @@ class SetupWizardActivity : FragmentActivity() {
 
     private fun finishWizard() {
         markSetupComplete(this)
-        launchApp()
+        if (returnToCaller) {
+            finish()
+        } else {
+            launchApp()
+        }
     }
 
     private fun clearRootDir(rootDir: File) {

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -112,6 +112,7 @@ import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.io.TarCompressorUtils
 import com.winlator.cmod.shared.io.TarCompressorUtils.Type
+import com.winlator.cmod.shared.ui.widget.chasingBorder
 import com.winlator.cmod.shared.util.OnExtractFileListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -2236,6 +2237,10 @@ class SetupWizardActivity : FragmentActivity() {
                                 val allRecommendedInstalled =
                                     isRecommendedTab &&
                                         tabProfiles.all { it.verName in advancedInstalledSet }
+                                val highlightInstallAll =
+                                    isRecommendedTab &&
+                                        transferState.value == null &&
+                                        !allRecommendedInstalled
 
                                 LazyColumn(
                                     modifier = Modifier.fillMaxSize(),
@@ -2243,46 +2248,52 @@ class SetupWizardActivity : FragmentActivity() {
                                 ) {
                                     if (isRecommendedTab) {
                                         item {
+                                            val installAllEnabled = transferState.value == null && !allRecommendedInstalled
+                                            val installAllShape = RoundedCornerShape(8.dp)
                                             Box(
                                                 modifier = Modifier.fillMaxWidth(),
                                                 contentAlignment = Alignment.CenterEnd,
                                             ) {
-                                                OutlinedButton(
-                                                    onClick = { installAllRecommended() },
-                                                    enabled = transferState.value == null && !allRecommendedInstalled,
-                                                    shape = RoundedCornerShape(8.dp),
-                                                    border =
-                                                        BorderStroke(
-                                                            1.dp,
-                                                            if (allRecommendedInstalled) {
-                                                                Color(0xFF23436F)
-                                                            } else if (transferState.value != null) {
-                                                                Color(0xFF222D3D)
-                                                            } else {
-                                                                Color(0xFF306679)
-                                                            },
-                                                        ),
-                                                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp),
-                                                    modifier = Modifier.height(30.dp),
-                                                    colors =
-                                                        ButtonDefaults.outlinedButtonColors(
-                                                            contentColor =
-                                                                if (allRecommendedInstalled) {
-                                                                    Color(
-                                                                        0xFF3B82F6,
+                                                Box(
+                                                    modifier =
+                                                        Modifier
+                                                            .background(
+                                                                color =
+                                                                    if (highlightInstallAll) {
+                                                                        Color(0xFF131D2F)
+                                                                    } else {
+                                                                        Color.Transparent
+                                                                    },
+                                                                shape = installAllShape,
+                                                            ).then(
+                                                                if (highlightInstallAll) {
+                                                                    Modifier.chasingBorder(
+                                                                        isFocused = true,
+                                                                        cornerRadius = 8.dp,
+                                                                        borderWidth = 1.5.dp,
+                                                                        animationDurationMs = 8200,
                                                                     )
                                                                 } else {
-                                                                    Color(0xFF8BB8C5)
-                                                                },
-                                                            disabledContentColor =
-                                                                if (allRecommendedInstalled) {
-                                                                    Color(
-                                                                        0xFF3B82F6,
+                                                                    Modifier.border(
+                                                                        width = 1.dp,
+                                                                        color =
+                                                                            if (allRecommendedInstalled) {
+                                                                                Color(0xFF23436F)
+                                                                            } else if (!installAllEnabled) {
+                                                                                Color(0xFF222D3D)
+                                                                            } else {
+                                                                                Color(0xFF306679)
+                                                                            },
+                                                                        shape = installAllShape,
                                                                     )
-                                                                } else {
-                                                                    Color(0xFF4A5260)
                                                                 },
-                                                        ),
+                                                            ).clickable(
+                                                                enabled = installAllEnabled,
+                                                                interactionSource = remember { MutableInteractionSource() },
+                                                                indication = null,
+                                                            ) { installAllRecommended() }
+                                                            .padding(horizontal = 14.dp, vertical = 8.dp),
+                                                    contentAlignment = Alignment.Center,
                                                 ) {
                                                     Text(
                                                         text =
@@ -2296,6 +2307,16 @@ class SetupWizardActivity : FragmentActivity() {
                                                         fontFamily = InterFont,
                                                         fontWeight = FontWeight.SemiBold,
                                                         fontSize = 11.sp,
+                                                        color =
+                                                            if (highlightInstallAll) {
+                                                                Color(0xFFF0F4FF)
+                                                            } else if (allRecommendedInstalled) {
+                                                                Color(0xFF3B82F6)
+                                                            } else if (!installAllEnabled) {
+                                                                Color(0xFF4A5260)
+                                                            } else {
+                                                                Color(0xFF8BB8C5)
+                                                            },
                                                     )
                                                 }
                                             }

--- a/app/src/main/feature/sync/google/GoogleFragment.kt
+++ b/app/src/main/feature/sync/google/GoogleFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ScrollView
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 
 class GoogleFragment : Fragment() {
@@ -14,25 +13,13 @@ class GoogleFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        val scrollView =
-            ScrollView(requireContext()).apply {
-                layoutParams =
-                    FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    )
-                isFillViewport = true
+    ): View =
+        ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                GoogleScreen()
             }
-        val composeView =
-            ComposeView(requireContext()).apply {
-                setContent {
-                    GoogleScreen()
-                }
-            }
-        scrollView.addView(composeView)
-        return scrollView
-    }
+        }
 
     fun onSavedGamesPermissionResult(
         resultCode: Int,

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -15,17 +15,22 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -78,6 +83,7 @@ fun GoogleScreen() {
     val context = LocalContext.current
     val activity = context as? Activity
     val scope = rememberCoroutineScope()
+    val navBarBottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     var googleSignedIn by remember { mutableStateOf(false) }
     var syncState by remember { mutableStateOf(CloudSyncManager.StoreLoginSyncState()) }
@@ -107,109 +113,126 @@ fun GoogleScreen() {
         busy = false
     }
 
-    Column(
+    LazyColumn(
         modifier =
             Modifier
-                .fillMaxWidth()
-                .background(BgDark)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .fillMaxSize()
+                .background(BgDark),
+        contentPadding =
+            PaddingValues(
+                start = 16.dp,
+                top = 16.dp,
+                end = 16.dp,
+                bottom = 16.dp + navBarBottomPadding,
+            ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        SectionLabel(stringResource(R.string.google_cloud_services))
+        item("services_section") {
+            SectionLabel(stringResource(R.string.google_cloud_services))
+        }
 
-        GoogleAccountCard(
-            isLoggedIn = googleSignedIn,
-            busy = busy,
-            onSignIn = {
-                val currentActivity = activity ?: return@GoogleAccountCard
-                busy = true
-                CloudSyncManager.signIn(currentActivity) { success, message ->
-                    busy = false
-                    googleSignedIn = success
-                    AppUtils.showToast(context, message)
-                    refreshState()
-                }
-            },
-            onSignOut = {
-                val currentActivity = activity ?: return@GoogleAccountCard
-                busy = true
-                CloudSyncManager.signOut(currentActivity) { success, message ->
-                    busy = false
-                    googleSignedIn = !success
-                    AppUtils.showToast(context, message)
-                    refreshState()
-                }
-            },
-        )
-
-        SectionLabel(stringResource(R.string.google_cloud_store_logins), modifier = Modifier.padding(top = 8.dp))
-
-        StoreLoginCard(
-            state = syncState,
-            busy = busy,
-            onBackup = {
-                val currentActivity = activity ?: return@StoreLoginCard
-                busy = true
-                scope.launch {
-                    try {
-                        val message = CloudSyncManager.backupStoreLogins(currentActivity)
-                        AppUtils.showToast(context, message)
-                        syncState = CloudSyncManager.readStoreLoginState(currentActivity)
-                        googleSignedIn = syncState.googleSignedIn
-                    } finally {
+        item("google_account_card") {
+            GoogleAccountCard(
+                isLoggedIn = googleSignedIn,
+                busy = busy,
+                onSignIn = {
+                    val currentActivity = activity ?: return@GoogleAccountCard
+                    busy = true
+                    CloudSyncManager.signIn(currentActivity) { success, message ->
                         busy = false
-                    }
-                }
-            },
-            onRestore = {
-                val currentActivity = activity ?: return@StoreLoginCard
-                busy = true
-                scope.launch {
-                    try {
-                        val message = CloudSyncManager.restoreStoreLogins(currentActivity)
+                        googleSignedIn = success
                         AppUtils.showToast(context, message)
-                        syncState = CloudSyncManager.readStoreLoginState(currentActivity)
-                        googleSignedIn = syncState.googleSignedIn
-                    } finally {
-                        busy = false
+                        refreshState()
                     }
-                }
-            },
-        )
+                },
+                onSignOut = {
+                    val currentActivity = activity ?: return@GoogleAccountCard
+                    busy = true
+                    CloudSyncManager.signOut(currentActivity) { success, message ->
+                        busy = false
+                        googleSignedIn = !success
+                        AppUtils.showToast(context, message)
+                        refreshState()
+                    }
+                },
+            )
+        }
 
-        SectionLabel(stringResource(R.string.google_cloud_auto_backup), modifier = Modifier.padding(top = 8.dp))
+        item("store_logins_section") {
+            SectionLabel(stringResource(R.string.google_cloud_store_logins), modifier = Modifier.padding(top = 8.dp))
+        }
 
-        AutoBackupCard(
-            enabled = autoBackupEnabled,
-            googleSignedIn = googleSignedIn,
-            busy = busy,
-            onToggle = { newValue ->
-                if (newValue) {
-                    val currentActivity = activity ?: return@AutoBackupCard
+        item("store_login_card") {
+            StoreLoginCard(
+                state = syncState,
+                busy = busy,
+                onBackup = {
+                    val currentActivity = activity ?: return@StoreLoginCard
                     busy = true
                     scope.launch {
                         try {
-                            val alreadyAuthorized = GameSaveBackupManager.requestDriveAuthorization(currentActivity)
-                            if (alreadyAuthorized) {
-                                autoBackupEnabled = true
-                                autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
-                            } else {
-                                // Consent UI launched — toggle will be enabled after user grants access
-                                autoBackupEnabled = true
-                                autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
-                            }
-                        } catch (e: Exception) {
-                            AppUtils.showToast(context, "Drive authorization failed: ${e.message}")
+                            val message = CloudSyncManager.backupStoreLogins(currentActivity)
+                            AppUtils.showToast(context, message)
+                            syncState = CloudSyncManager.readStoreLoginState(currentActivity)
+                            googleSignedIn = syncState.googleSignedIn
                         } finally {
                             busy = false
                         }
                     }
-                } else {
-                    autoBackupEnabled = false
-                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", false).apply()
-                }
-            },
-        )
+                },
+                onRestore = {
+                    val currentActivity = activity ?: return@StoreLoginCard
+                    busy = true
+                    scope.launch {
+                        try {
+                            val message = CloudSyncManager.restoreStoreLogins(currentActivity)
+                            AppUtils.showToast(context, message)
+                            syncState = CloudSyncManager.readStoreLoginState(currentActivity)
+                            googleSignedIn = syncState.googleSignedIn
+                        } finally {
+                            busy = false
+                        }
+                    }
+                },
+            )
+        }
+
+        item("auto_backup_section") {
+            SectionLabel(stringResource(R.string.google_cloud_auto_backup), modifier = Modifier.padding(top = 8.dp))
+        }
+
+        item("auto_backup_card") {
+            AutoBackupCard(
+                enabled = autoBackupEnabled,
+                googleSignedIn = googleSignedIn,
+                busy = busy,
+                onToggle = { newValue ->
+                    if (newValue) {
+                        val currentActivity = activity ?: return@AutoBackupCard
+                        busy = true
+                        scope.launch {
+                            try {
+                                val alreadyAuthorized = GameSaveBackupManager.requestDriveAuthorization(currentActivity)
+                                if (alreadyAuthorized) {
+                                    autoBackupEnabled = true
+                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
+                                } else {
+                                    autoBackupEnabled = true
+                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
+                                }
+                            } catch (e: Exception) {
+                                AppUtils.showToast(context, "Drive authorization failed: ${e.message}")
+                            } finally {
+                                busy = false
+                            }
+                        }
+                    } else {
+                        autoBackupEnabled = false
+                        autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", false).apply()
+                    }
+                },
+            )
+        }
     }
 }
 

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -15,15 +15,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,6 +37,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.CloudSync
@@ -58,6 +63,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -83,7 +89,11 @@ fun GoogleScreen() {
     val context = LocalContext.current
     val activity = context as? Activity
     val scope = rememberCoroutineScope()
-    val navBarBottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navBarStartPadding = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBarEndPadding = navBarPadding.calculateEndPadding(layoutDirection)
+    val navBarBottomPadding = navBarPadding.calculateBottomPadding()
 
     var googleSignedIn by remember { mutableStateOf(false) }
     var syncState by remember { mutableStateOf(CloudSyncManager.StoreLoginSyncState()) }
@@ -120,10 +130,10 @@ fun GoogleScreen() {
                 .background(BgDark),
         contentPadding =
             PaddingValues(
-                start = 16.dp,
+                start = 16.dp + navBarStartPadding,
                 top = 16.dp,
-                end = 16.dp,
-                bottom = 16.dp + navBarBottomPadding,
+                end = 16.dp + navBarEndPadding,
+                bottom = 4.dp + navBarBottomPadding,
             ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -353,81 +363,165 @@ private fun GoogleAccountCard(
         label = "alpha_google",
     )
 
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
-                .background(CardDark)
-                .border(1.dp, CardBorder, RoundedCornerShape(14.dp)),
-    ) {
-        Row(
+    BoxWithConstraints {
+        val compact = maxWidth < 400.dp
+
+        Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 14.dp, vertical = 11.dp),
-            verticalAlignment = Alignment.CenterVertically,
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(CardDark)
+                    .border(1.dp, CardBorder, RoundedCornerShape(14.dp)),
         ) {
-            IconBox(icon = Icons.Outlined.Gamepad, tint = Color(0xFF34A853))
+            if (compact) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 11.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        IconBox(icon = Icons.Outlined.Gamepad, tint = Color(0xFF34A853))
+                        Spacer(Modifier.width(14.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.google_cloud_play_games),
+                                color = TextPrimary,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    if (isLoggedIn) {
+                                        Box(
+                                            modifier =
+                                                Modifier
+                                                    .size(10.dp)
+                                                    .scale(pulseScale)
+                                                    .clip(CircleShape)
+                                                    .background(StatusGreen.copy(alpha = pulseAlpha)),
+                                        )
+                                    }
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .size(6.dp)
+                                                .clip(CircleShape)
+                                                .background(if (isLoggedIn) StatusGreen else TextSecondary.copy(alpha = 0.4f)),
+                                    )
+                                }
+                                Spacer(Modifier.width(6.dp))
+                                Text(
+                                    text =
+                                        when {
+                                            busy -> stringResource(R.string.google_cloud_status_syncing)
+                                            isLoggedIn -> stringResource(R.string.google_cloud_status_connected)
+                                            else -> stringResource(R.string.google_cloud_status_not_signed_in)
+                                        },
+                                    color = if (isLoggedIn) StatusGreen else TextSecondary,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                        }
+                    }
 
-            Spacer(Modifier.width(14.dp))
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.google_cloud_play_games),
-                    color = TextPrimary,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Spacer(Modifier.height(4.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(contentAlignment = Alignment.Center) {
-                        if (isLoggedIn) {
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .size(10.dp)
-                                        .scale(pulseScale)
-                                        .clip(CircleShape)
-                                        .background(StatusGreen.copy(alpha = pulseAlpha)),
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        if (!isLoggedIn) {
+                            ActionButton(
+                                label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_sign_in),
+                                textColor = Color(0xFF34A853),
+                                enabled = !busy,
+                                onClick = onSignIn,
+                            )
+                        } else {
+                            ActionButton(
+                                label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_disable_sync),
+                                textColor = DangerRed,
+                                enabled = !busy,
+                                onClick = onSignOut,
                             )
                         }
-                        Box(
-                            modifier =
-                                Modifier
-                                    .size(6.dp)
-                                    .clip(CircleShape)
-                                    .background(if (isLoggedIn) StatusGreen else TextSecondary.copy(alpha = 0.4f)),
+                    }
+                }
+            } else {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 11.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconBox(icon = Icons.Outlined.Gamepad, tint = Color(0xFF34A853))
+
+                    Spacer(Modifier.width(14.dp))
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.google_cloud_play_games),
+                            color = TextPrimary,
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(contentAlignment = Alignment.Center) {
+                                if (isLoggedIn) {
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .size(10.dp)
+                                                .scale(pulseScale)
+                                                .clip(CircleShape)
+                                                .background(StatusGreen.copy(alpha = pulseAlpha)),
+                                    )
+                                }
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .size(6.dp)
+                                            .clip(CircleShape)
+                                            .background(if (isLoggedIn) StatusGreen else TextSecondary.copy(alpha = 0.4f)),
+                                )
+                            }
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text =
+                                    when {
+                                        busy -> stringResource(R.string.google_cloud_status_syncing)
+                                        isLoggedIn -> stringResource(R.string.google_cloud_status_connected)
+                                        else -> stringResource(R.string.google_cloud_status_not_signed_in)
+                                    },
+                                color = if (isLoggedIn) StatusGreen else TextSecondary,
+                                fontSize = 12.sp,
+                            )
+                        }
+                    }
+
+                    if (!isLoggedIn) {
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_sign_in),
+                            textColor = Color(0xFF34A853),
+                            enabled = !busy,
+                            onClick = onSignIn,
+                        )
+                    } else {
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_disable_sync),
+                            textColor = DangerRed,
+                            enabled = !busy,
+                            onClick = onSignOut,
                         )
                     }
-                    Spacer(Modifier.width(6.dp))
-                    Text(
-                        text =
-                            when {
-                                busy -> stringResource(R.string.google_cloud_status_syncing)
-                                isLoggedIn -> stringResource(R.string.google_cloud_status_connected)
-                                else -> stringResource(R.string.google_cloud_status_not_signed_in)
-                            },
-                        color = if (isLoggedIn) StatusGreen else TextSecondary,
-                        fontSize = 12.sp,
-                    )
                 }
-            }
-
-            if (!isLoggedIn) {
-                ActionButton(
-                    label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_sign_in),
-                    textColor = Color(0xFF34A853),
-                    enabled = !busy,
-                    onClick = onSignIn,
-                )
-            } else {
-                ActionButton(
-                    label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_disable_sync),
-                    textColor = DangerRed,
-                    enabled = !busy,
-                    onClick = onSignOut,
-                )
             }
         }
     }
@@ -461,7 +555,7 @@ private fun StoreLoginCard(
             DateUtils.getRelativeTimeSpanString(it, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS).toString()
         }
 
-    Box(
+    BoxWithConstraints(
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -470,6 +564,8 @@ private fun StoreLoginCard(
                 .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
                 .padding(14.dp),
     ) {
+        val compact = maxWidth < 400.dp
+
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 StatusIconBox(statusColor = statusColor)
@@ -494,62 +590,123 @@ private fun StoreLoginCard(
                 StoreBadgeRow(stores = stores)
             }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text =
-                            when {
-                                state.status == CloudSyncManager.SyncStatus.ERROR -> {
-                                    stringResource(
-                                        R.string.google_cloud_saved_games_unavailable,
-                                    )
-                                }
-
-                                state.cloudStores.isNotEmpty() -> {
-                                    stringResource(R.string.google_cloud_snapshot_ready)
-                                }
-
-                                state.localStores.isNotEmpty() -> {
-                                    stringResource(R.string.google_cloud_waiting_first_backup)
-                                }
-
-                                else -> {
-                                    stringResource(R.string.google_cloud_no_store_logins_detected)
-                                }
-                            },
-                        color = statusColor,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium,
-                    )
-                    if (lastSyncLabel != null) {
-                        Spacer(Modifier.height(2.dp))
+            if (compact) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
                         Text(
-                            text = stringResource(R.string.google_cloud_last_synced, lastSyncLabel),
-                            color = TextSecondary,
-                            fontSize = 11.sp,
+                            text =
+                                when {
+                                    state.status == CloudSyncManager.SyncStatus.ERROR -> {
+                                        stringResource(R.string.google_cloud_saved_games_unavailable)
+                                    }
+
+                                    state.cloudStores.isNotEmpty() -> {
+                                        stringResource(R.string.google_cloud_snapshot_ready)
+                                    }
+
+                                    state.localStores.isNotEmpty() -> {
+                                        stringResource(R.string.google_cloud_waiting_first_backup)
+                                    }
+
+                                    else -> {
+                                        stringResource(R.string.google_cloud_no_store_logins_detected)
+                                    }
+                                },
+                            color = statusColor,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        if (lastSyncLabel != null) {
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = stringResource(R.string.google_cloud_last_synced, lastSyncLabel),
+                                color = TextSecondary,
+                                fontSize = 11.sp,
+                            )
+                        }
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_backup),
+                            textColor = WarningAmber,
+                            icon = Icons.Outlined.Upload,
+                            enabled = !busy && state.googleSignedIn && state.localStores.isNotEmpty(),
+                            onClick = onBackup,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_restore),
+                            textColor = Accent,
+                            icon = Icons.Outlined.Restore,
+                            enabled = !busy && state.googleSignedIn && state.cloudStores.isNotEmpty(),
+                            onClick = onRestore,
                         )
                     }
                 }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text =
+                                when {
+                                    state.status == CloudSyncManager.SyncStatus.ERROR -> {
+                                        stringResource(R.string.google_cloud_saved_games_unavailable)
+                                    }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    ActionButton(
-                        label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_backup),
-                        textColor = WarningAmber,
-                        icon = Icons.Outlined.Upload,
-                        enabled = !busy && state.googleSignedIn && state.localStores.isNotEmpty(),
-                        onClick = onBackup,
-                    )
-                    ActionButton(
-                        label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_restore),
-                        textColor = Accent,
-                        icon = Icons.Outlined.Restore,
-                        enabled = !busy && state.googleSignedIn && state.cloudStores.isNotEmpty(),
-                        onClick = onRestore,
-                    )
+                                    state.cloudStores.isNotEmpty() -> {
+                                        stringResource(R.string.google_cloud_snapshot_ready)
+                                    }
+
+                                    state.localStores.isNotEmpty() -> {
+                                        stringResource(R.string.google_cloud_waiting_first_backup)
+                                    }
+
+                                    else -> {
+                                        stringResource(R.string.google_cloud_no_store_logins_detected)
+                                    }
+                                },
+                            color = statusColor,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        if (lastSyncLabel != null) {
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = stringResource(R.string.google_cloud_last_synced, lastSyncLabel),
+                                color = TextSecondary,
+                                fontSize = 11.sp,
+                            )
+                        }
+                    }
+
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_backup),
+                            textColor = WarningAmber,
+                            icon = Icons.Outlined.Upload,
+                            enabled = !busy && state.googleSignedIn && state.localStores.isNotEmpty(),
+                            onClick = onBackup,
+                        )
+                        ActionButton(
+                            label = if (busy) stringResource(R.string.google_cloud_working) else stringResource(R.string.google_cloud_restore),
+                            textColor = Accent,
+                            icon = Icons.Outlined.Restore,
+                            enabled = !busy && state.googleSignedIn && state.cloudStores.isNotEmpty(),
+                            onClick = onRestore,
+                        )
+                    }
                 }
             }
         }
@@ -558,7 +715,10 @@ private fun StoreLoginCard(
 
 @Composable
 private fun StoreBadgeRow(stores: List<String>) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         stores.forEach { store ->
             Box(
                 modifier =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -759,6 +759,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_other_language_system_default">System default</string>
 
     <string name="settings_other_section_integration">Integration</string>
+    <string name="settings_other_setup_wizard_title">Setup Wizard</string>
+    <string name="settings_other_setup_wizard_summary">Open the setup wizard again to review permissions, system files, and default containers.</string>
     <string name="settings_other_checking_for_updates">Checking for updates\u2026</string>
     <string name="settings_other_update_check_cooldown">Please wait %1$ds before checking again</string>
     <string name="settings_other_persistable_permission_failed">Unable to take persistable permissions: %1$s</string>


### PR DESCRIPTION
## Summary
- continue the Compose migration polish across settings, Google sync, and related UI flows
- add a way to re-enter the setup wizard from the app
- tighten unified hub and top-bar spacing along with other UI refinements

## Why
- the branch is focused on smoothing out the post-migration settings experience and reducing UI rough edges
- re-entering the setup wizard should be available without forcing a reinstall or reset
- the unified hub needed small layout adjustments to behave more cleanly across device configurations

## Validation
- `.\gradlew.bat :app:compileStandardDebugKotlin`