### PR TITLE
fix: NTSync auto-fallback, Turnip driver loading, and container emula…

### DIFF
--- a/app/src/main/cpp/winlator/vulkan.c
+++ b/app/src/main/cpp/winlator/vulkan.c
@@ -22,7 +22,6 @@ PFN_vkEnumeratePhysicalDevices enumeratePhysicalDevices;
 PFN_vkDestroyInstance destroyInstance;
 
 static void *vulkan_handle = NULL;
-static void *vulkan_mapping_handle = NULL;
 
 static char *get_native_library_dir(JNIEnv *env, jobject context) {
   char *native_libdir = NULL;
@@ -196,12 +195,11 @@ static void init_vulkan(JNIEnv *env, jobject context, const char *driver_name) {
   asprintf(&tmpdir, "%s%s", driver_path, "temp");
   mkdir(tmpdir, S_IRWXU | S_IRWXG);
 
-  vulkan_mapping_handle = NULL;
   vulkan_handle = adrenotools_open_libvulkan(
       RTLD_LOCAL | RTLD_NOW,
-      ADRENOTOOLS_DRIVER_CUSTOM | ADRENOTOOLS_DRIVER_GPU_MAPPING_IMPORT, tmpdir,
+      ADRENOTOOLS_DRIVER_CUSTOM, tmpdir,
       native_library_dir, driver_path, library_name, NULL,
-      &vulkan_mapping_handle);
+      NULL);
 }
 
 static VkResult create_instance(jstring driverName, JNIEnv *env,

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -2833,9 +2833,11 @@ private fun AdvancedSection(
     callbacks: GameSettingsCallbacks
 ) {
 
-    // Wine / Proton version (read-only)
+    // Wine / Proton version (read-only) — only show on existing containers
+    // where it's not editable. When creating a new container the user already
+    // selects the Wine Version in the General tab.
     val wineVersionDisplay = state.wineVersionDisplay.value
-    if (wineVersionDisplay.isNotEmpty()) {
+    if (wineVersionDisplay.isNotEmpty() && !state.wineVersionEditable.value) {
         SubsectionLabel(stringResource(R.string.container_wine_version))
         Spacer(Modifier.height(8.dp))
         SettingGroup {

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -414,22 +414,28 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val emulatorArr = context.resources.getStringArray(R.array.emulator_entries).toList()
         state.emulatorEntries.value = emulatorArr
 
-        val wineVersionStr = c?.getWineVersion() ?: WineInfo.MAIN_WINE_VERSION.identifier()
-        val wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersionStr)
-        isArm64EC = wineInfo.isArm64EC()
-        state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
+        // For existing containers, set up emulator lists now from the saved
+        // wine version. For new containers, defer this to
+        // populateContentsDependentData() which runs after the installed wine
+        // list is populated — that way the emulator options (Box64 vs FEXCore)
+        // match the actual wine version the user will see in the General tab.
+        if (c != null) {
+            val wineInfo = WineInfo.fromIdentifier(context, contentsManager, c.getWineVersion())
+            isArm64EC = wineInfo.isArm64EC()
+            state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
 
-        rebuildEmulatorLists()
-        selectByIdentifier(
-            state.emulator32Entries.value,
-            c?.getEmulator() ?: Container.DEFAULT_EMULATOR,
-            state.selectedEmulator
-        )
-        selectByIdentifier(
-            state.emulator64Entries.value,
-            c?.getEmulator64() ?: Container.DEFAULT_EMULATOR64,
-            state.selectedEmulator64
-        )
+            rebuildEmulatorLists()
+            selectByIdentifier(
+                state.emulator32Entries.value,
+                c.getEmulator(),
+                state.selectedEmulator
+            )
+            selectByIdentifier(
+                state.emulator64Entries.value,
+                c.getEmulator64(),
+                state.selectedEmulator64
+            )
+        }
 
         state.localeOptions.value = context.resources.getStringArray(R.array.some_lc_all).toList()
         state.winComponentEntries.value =
@@ -523,17 +529,36 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         state.wineVersionEntries.value = versions
         wineVersionIdentifiers = identifiers
 
-        val currentWine = c?.getWineVersion() ?: WineInfo.MAIN_WINE_VERSION.identifier()
+        // For existing containers, use their saved wine version.
+        // For new containers, use the first actually-installed version from the
+        // populated list instead of the hardcoded MAIN_WINE_VERSION default.
+        // This ensures that if only an arm64ec Proton is installed, the dialog
+        // correctly shows FEXCore/WowBox64 options instead of Box64.
+        val currentWine: String
+        if (c != null) {
+            currentWine = c.getWineVersion()
+        } else if (identifiers.isNotEmpty()) {
+            currentWine = identifiers[0]
+        } else {
+            currentWine = WineInfo.MAIN_WINE_VERSION.identifier()
+        }
         val idx = identifiers.indexOfFirst { it == currentWine }
         state.selectedWineVersion.intValue = if (idx >= 0) idx else 0
 
-        val wineInfo = WineInfo.fromIdentifier(context, contentsManager, currentWine)
+        // Resolve the actual wine info for the selected version and detect
+        // architecture changes from the initial default so emulator lists
+        // and presets are rebuilt correctly.
+        val selectedIdentifier = if (idx >= 0) identifiers[idx]
+            else identifiers.getOrElse(0) { currentWine }
+        val wineInfo = WineInfo.fromIdentifier(context, contentsManager, selectedIdentifier)
         val archChanged = isArm64EC != wineInfo.isArm64EC()
         isArm64EC = wineInfo.isArm64EC()
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
 
         rebuildEmulatorLists()
-        if (archChanged) {
+        // Always reset emulator selections when populating for the first time
+        // or when the architecture changed from the initial default.
+        if (c == null || archChanged) {
             selectByIdentifier(
                 state.emulator32Entries.value,
                 c?.getEmulator() ?: Container.DEFAULT_EMULATOR,
@@ -548,6 +573,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
 
         loadBox64Versions()
         loadFexcoreVersions()
+        loadBox64Presets()
+        loadFexcorePresets()
         loadDxvkConfigState()
         loadWineD3DConfigState()
         updateEmulatorFrameVisibility()
@@ -880,7 +907,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 listOfNotNull(entryById("fexcore"), entryById("wowbox64"))
         } else {
             state.emulator64Entries.value = listOfNotNull(entryById("box64"))
-            state.emulator32Entries.value = listOfNotNull(entryById("wowbox64"))
+            state.emulator32Entries.value = listOfNotNull(entryById("box64"))
         }
 
         val new32 = state.emulator32Entries.value

--- a/app/src/main/runtime/container/Container.java
+++ b/app/src/main/runtime/container/Container.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.util.Iterator;
 
 public class Container {
-    public static final String DEFAULT_ENV_VARS = "WRAPPER_MAX_IMAGE_COUNT=0 VKD3D_SHADER_MODEL=6_6 ZINK_DESCRIPTORS=lazy ZINK_DEBUG=compact MESA_SHADER_CACHE_DISABLE=false MESA_SHADER_CACHE_MAX_SIZE=512MB mesa_glthread=true WINEESYNC=1 TU_DEBUG=noconform,sysmem";
+    public static final String DEFAULT_ENV_VARS = "WRAPPER_MAX_IMAGE_COUNT=0 VKD3D_SHADER_MODEL=6_6 ZINK_DESCRIPTORS=lazy ZINK_DEBUG=compact MESA_SHADER_CACHE_DISABLE=false MESA_SHADER_CACHE_MAX_SIZE=512MB mesa_glthread=true TU_DEBUG=noconform,sysmem";
     public static final String DEFAULT_SCREEN_SIZE = "1280x720";
     public static final String DEFAULT_GRAPHICS_DRIVER = "wrapper";
     public static final String DEFAULT_AUDIO_DRIVER = "alsa";

--- a/app/src/main/runtime/container/ContainerManager.java
+++ b/app/src/main/runtime/container/ContainerManager.java
@@ -231,6 +231,24 @@ public class ContainerManager {
       Log.d("ContainerManager", "createContainer: wineVersion=" + wineVersion);
       container.setWineVersion(wineVersion);
 
+      // Set the correct emulators based on the wine architecture, unless the
+      // caller already specified them in the JSON data.  This ensures every
+      // creation path (manual, contents download, store integration) gets the
+      // right emulator: box64 for x86_64, fexcore for arm64ec.
+      if (!data.has("emulator") || !data.has("emulator64")) {
+          WineInfo wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersion);
+          if (wineInfo.isArm64EC()) {
+              if (!data.has("emulator"))   container.setEmulator("fexcore");
+              if (!data.has("emulator64")) container.setEmulator64("fexcore");
+          } else {
+              if (!data.has("emulator"))   container.setEmulator("box64");
+              if (!data.has("emulator64")) container.setEmulator64("box64");
+          }
+          Log.d("ContainerManager", "createContainer: auto-set emulators for arch="
+              + wineInfo.getArch() + " emulator=" + container.getEmulator()
+              + " emulator64=" + container.getEmulator64());
+      }
+
       if (!extractContainerPatternFile(
           container, container.getWineVersion(), contentsManager, containerDir, null)) {
         Log.e(

--- a/app/src/main/runtime/content/AdrenotoolsManager.java
+++ b/app/src/main/runtime/content/AdrenotoolsManager.java
@@ -279,6 +279,8 @@ public class AdrenotoolsManager {
                 envVars.put("ADRENOTOOLS_DRIVER_PATH", driverPath);
                 envVars.put("ADRENOTOOLS_HOOKS_PATH", imagefs.getLibDir());
                 envVars.put("ADRENOTOOLS_DRIVER_NAME", getLibraryName(adrenotoolsDriverId));
+                envVars.put("ADRENOTOOLS_DRIVER_CUSTOM", "1");
+                envVars.put("ADRENOTOOLS_DRIVER_GPU_MAPPING_IMPORT", "1");
 
                 File winlatorDir = new File(SettingsConfig.DEFAULT_WINLATOR_PATH);
                 File qglConfig = new File(winlatorDir, "qgl_config.txt");

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2861,13 +2861,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     "' effective='" + effectiveCustomEnvVars + "'");
             envVars.putAll(effectiveCustomEnvVars);
 
-            // Normalize synchronization environment variables (NTSync / ESync / FSync).
+            // Normalize synchronization environment variables (NTSync / ESync).
+            // This auto-detects NTSync and falls back to ESync when unavailable.
             normalizeSyncEnvVars(envVars);
-
-            if (!envVars.has("WINEESYNC") && !envVars.has("WINENTSYNC")
-                    && !envVars.has("PROTON_USE_NTSYNC")) {
-                envVars.put("WINEESYNC", "1");
-            }
 
             ArrayList<String> bindingPaths = new ArrayList<>();
             String drives = shortcut != null ? getShortcutSetting("drives", container.getDrives()) : container.getDrives();
@@ -3702,7 +3698,6 @@ public class XServerDisplayActivity extends AppCompatActivity {
             WineD3DConfigUtils.setEnvVars(this, dxwrapperConfig, envVars);
         }
 
-        envVars.put("VK_ICD_FILENAMES", imageFs.getShareDir() + "/vulkan/icd.d/wrapper_icd.aarch64.json");
         envVars.put("GALLIUM_DRIVER", "zink");
 
         if (firstTimeBoot) {
@@ -3727,6 +3722,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     envVars.get("ADRENOTOOLS_DRIVER_NAME") + " hooks=" +
                     envVars.get("ADRENOTOOLS_HOOKS_PATH"));
         }
+
+        envVars.put("VK_ICD_FILENAMES", imageFs.getShareDir() + "/vulkan/icd.d/wrapper_icd.aarch64.json");
 
         String vulkanVersion = graphicsDriverConfig.get("vulkanVersion");
         if (vulkanVersion == null) vulkanVersion = "1.3";
@@ -5187,51 +5184,66 @@ public class XServerDisplayActivity extends AppCompatActivity {
     /**
      * Normalizes synchronization environment variables.
      *
-     * NTSync, ESync, and FSync are mutually exclusive kernel-level synchronization
-     * methods for Wine. This method enforces correct precedence:
+     * NTSync and ESync are the two synchronization methods available on Android.
+     * FSync is compiled out of the Android Wine build (futex_waitv not reliable
+     * on Android bionic), so it is always disabled here.
      *
-     * 1. If NTSync is requested (PROTON_USE_NTSYNC=1 or WINENTSYNC=1):
-     *    a. If /dev/ntsync is accessible: enable NTSync, disable ESync and FSync
-     *    b. If /dev/ntsync is NOT accessible: fall back to plain Wine server sync
-     *       (disable all fast-sync methods for maximum compatibility)
+     * Priority logic:
      *
-     * 2. Translates PROTON_USE_NTSYNC into WINENTSYNC so both Proton-patched and
-     *    Crossover/Wine-GE builds activate the driver regardless of which env var
-     *    name their patches use.
+     * 1. If the user explicitly set WINEESYNC=1 (without any NTSync variable):
+     *    bypass NTSync detection entirely, use ESync.
+     *
+     * 2. If the user explicitly set WINENTSYNC=1 or PROTON_USE_NTSYNC=1:
+     *    try NTSync. If /dev/ntsync is not accessible, fall back to ESync
+     *    automatically (never drop to plain wineserver sync).
+     *
+     * 3. If no sync variables are set at all:
+     *    auto-detect NTSync — use it if /dev/ntsync is accessible,
+     *    otherwise fall back to ESync.
      */
     private void normalizeSyncEnvVars(com.winlator.cmod.runtime.wine.EnvVars envVars) {
-        boolean ntSyncRequested = "1".equals(envVars.get("PROTON_USE_NTSYNC"))
-                || "1".equals(envVars.get("WINENTSYNC"));
+        boolean esyncExplicit = "1".equals(envVars.get("WINEESYNC"));
+        boolean ntSyncExplicit = "1".equals(envVars.get("WINENTSYNC"))
+                || "1".equals(envVars.get("PROTON_USE_NTSYNC"));
 
-        if (!ntSyncRequested) return;
+        // FSync is always disabled on Android (compiled out of Wine build).
+        envVars.remove("WINEFSYNC");
+        envVars.put("PROTON_NO_FSYNC", "1");
 
-        if (canAccessNtsyncDevice()) {
-            // NTSync available — enable it and disable competing sync methods
-            envVars.put("WINENTSYNC", "1");
-            envVars.put("PROTON_USE_NTSYNC", "1");
-
-            // Explicitly disable ESync and FSync (mutually exclusive with NTSync)
-            envVars.remove("WINEESYNC");
-            envVars.remove("WINEFSYNC");
-            envVars.put("PROTON_NO_ESYNC", "1");
-            envVars.put("PROTON_NO_FSYNC", "1");
-
-            Log.d("XServerDisplayActivity", "NTSync: enabled — disabled ESync/FSync");
-        } else {
-            // NTSync requested but device is inaccessible — fall back to plain sync.
-            // Standard Winlator often forces ESync by default, but if NTSync failed,
-            // forcing ESync can cause "Too many open files" errors. Plain server-side
-            // sync is the safest fallback to ensure the game actually boots.
+        if (esyncExplicit && !ntSyncExplicit) {
+            // User explicitly chose ESync — honour that, skip NTSync detection.
             envVars.remove("WINENTSYNC");
             envVars.remove("PROTON_USE_NTSYNC");
-            envVars.remove("WINEESYNC");
-            envVars.remove("WINEFSYNC");
-            envVars.put("WINE_DISABLE_FAST_SYNC", "1");
-            envVars.put("PROTON_NO_ESYNC", "1");
-            envVars.put("PROTON_NO_FSYNC", "1");
+            envVars.put("WINEESYNC", "1");
+            envVars.remove("PROTON_NO_ESYNC");
+            Log.d("XServerDisplayActivity",
+                    "Sync: user selected ESync — using ESync, skipping NTSync detection");
+            return;
+        }
 
-            Log.w("XServerDisplayActivity",
-                    "NTSync: requested but /dev/ntsync not accessible — falling back to plain sync");
+        // Either NTSync was explicitly requested, or no sync vars are set at all.
+        // In both cases: try NTSync first, fall back to ESync if unavailable.
+        if (canAccessNtsyncDevice()) {
+            // NTSync available — enable it, disable ESync (mutually exclusive).
+            envVars.put("WINENTSYNC", "1");
+            envVars.put("PROTON_USE_NTSYNC", "1");
+            envVars.remove("WINEESYNC");
+            envVars.put("PROTON_NO_ESYNC", "1");
+            Log.d("XServerDisplayActivity",
+                    "Sync: NTSync enabled (/dev/ntsync accessible) — disabled ESync");
+        } else {
+            // NTSync not available — fall back to ESync automatically.
+            envVars.remove("WINENTSYNC");
+            envVars.remove("PROTON_USE_NTSYNC");
+            envVars.put("WINEESYNC", "1");
+            envVars.remove("PROTON_NO_ESYNC");
+            if (ntSyncExplicit) {
+                Log.w("XServerDisplayActivity",
+                        "Sync: NTSync requested but /dev/ntsync not accessible — falling back to ESync");
+            } else {
+                Log.d("XServerDisplayActivity",
+                        "Sync: NTSync not available (no /dev/ntsync) — using ESync");
+            }
         }
     }
 

--- a/app/src/main/shared/ui/widget/EnvVarsView.java
+++ b/app/src/main/shared/ui/widget/EnvVarsView.java
@@ -40,8 +40,6 @@ public class EnvVarsView extends FrameLayout {
     {"MESA_SHADER_CACHE_DISABLE", "CHECKBOX", "false", "true"},
     {"mesa_glthread", "CHECKBOX", "false", "true"},
     {"WINEESYNC", "CHECKBOX", "0", "1"},
-    {"WINEFSYNC", "CHECKBOX", "0", "1"},
-    {"PROTON_USE_NTSYNC", "CHECKBOX", "0", "1"},
     {"WINENTSYNC", "CHECKBOX", "0", "1"},
     {"FD_DEV_FEATURES", "SELECT_MULTIPLE", "enable_tp_ubwc_flag_hint=1", "storage_8bit=1"},
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
…tor selection

- NTSync/ESync sync: auto-detect NTSync, fall back to ESync if unavailable, honour explicit user selection, remove WINEESYNC from container defaults
- Turnip GPU: add ADRENOTOOLS_DRIVER_CUSTOM and GPU_MAPPING_IMPORT env vars so the wrapper library loads the custom Turnip driver in Wine child processes
- vulkan.c: remove GPU_MAPPING_IMPORT C flag to match Ludashi
- Container creation: defer emulator list init until wine list is populated so arm64ec Proton correctly shows FEXCore instead of Box64
- ContainerManager.createContainer: auto-set emulator based on wine arch (box64 for x86_64, fexcore for arm64ec) for all creation paths
- x86_64 containers: both 64-bit and 32-bit emulator set to Box64
- Hide redundant Wine Version from Advanced tab when creating new containers