### PR TITLE
Improve in-game drawer swipe controls

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -520,6 +520,12 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="session_drawer_pause">Pause</string>
     <string name="session_drawer_wine_processes_paused">Wine-processer er sat på pause</string>
     <string name="session_drawer_pause_all_wine_processes">Sæt alle Wine-processer på pause</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Bat.</string>
+    <string name="session_drawer_hud_element_graph">Graf</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Vil du afslutte denne proces?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -520,6 +520,12 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="session_drawer_pause">Pausieren</string>
     <string name="session_drawer_wine_processes_paused">Wine-Prozesse sind pausiert</string>
     <string name="session_drawer_pause_all_wine_processes">Alle Wine-Prozesse pausieren</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Akku</string>
+    <string name="session_drawer_hud_element_graph">Graph</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Möchtest du diesen Prozess beenden?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -520,6 +520,12 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="session_drawer_pause">Pausar</string>
     <string name="session_drawer_wine_processes_paused">Los procesos de Wine están pausados</string>
     <string name="session_drawer_pause_all_wine_processes">Pausar todos los procesos de Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Bat.</string>
+    <string name="session_drawer_hud_element_graph">Gráf.</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">¿Deseas finalizar este proceso?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -520,6 +520,12 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="session_drawer_pause">Pause</string>
     <string name="session_drawer_wine_processes_paused">Les processus Wine sont en pause</string>
     <string name="session_drawer_pause_all_wine_processes">Mettre en pause tous les processus Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Batt.</string>
+    <string name="session_drawer_hud_element_graph">Graphe</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Voulez-vous terminer ce processus ?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -520,6 +520,12 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="session_drawer_pause">Pausa</string>
     <string name="session_drawer_wine_processes_paused">Processi Wine in pausa</string>
     <string name="session_drawer_pause_all_wine_processes">Metti in pausa tutti i processi Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Batt.</string>
+    <string name="session_drawer_hud_element_graph">Graf.</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Vuoi terminare questo processo?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -520,6 +520,12 @@
     <string name="session_drawer_pause">일시 중지</string>
     <string name="session_drawer_wine_processes_paused">Wine 프로세스가 일시 중지되었습니다</string>
     <string name="session_drawer_pause_all_wine_processes">모든 Wine 프로세스 일시 중지</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">배터리</string>
+    <string name="session_drawer_hud_element_graph">그래프</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">이 프로세스를 종료하시겠습니까?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -520,6 +520,12 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="session_drawer_pause">Wstrzymaj</string>
     <string name="session_drawer_wine_processes_paused">Procesy Wine są wstrzymane</string>
     <string name="session_drawer_pause_all_wine_processes">Wstrzymaj wszystkie procesy Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Bat.</string>
+    <string name="session_drawer_hud_element_graph">Wykr.</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Czy chcesz zakończyć ten proces?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -520,6 +520,12 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="session_drawer_pause">Pausar</string>
     <string name="session_drawer_wine_processes_paused">Processos do Wine estao pausados</string>
     <string name="session_drawer_pause_all_wine_processes">Pausar todos os processos do Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Bat.</string>
+    <string name="session_drawer_hud_element_graph">Graf.</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Deseja encerrar este processo?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -520,6 +520,12 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="session_drawer_pause">Pauza</string>
     <string name="session_drawer_wine_processes_paused">Procesele Wine sunt in pauza</string>
     <string name="session_drawer_pause_all_wine_processes">Pune in pauza toate procesele Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Bat.</string>
+    <string name="session_drawer_hud_element_graph">Grafic</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Doresti sa opresti acest proces?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -520,6 +520,12 @@
     <string name="session_drawer_pause">Пауза</string>
     <string name="session_drawer_wine_processes_paused">Процеси Wine призупинені</string>
     <string name="session_drawer_pause_all_wine_processes">Призупинити всі процеси Wine</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">Бат.</string>
+    <string name="session_drawer_hud_element_graph">Графік</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Ви хочете завершити цей процес?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -520,6 +520,12 @@
     <string name="session_drawer_pause">暂停</string>
     <string name="session_drawer_wine_processes_paused">Wine 进程已暂停</string>
     <string name="session_drawer_pause_all_wine_processes">暂停所有 Wine 进程</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">电量</string>
+    <string name="session_drawer_hud_element_graph">图表</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">您要结束此进程吗？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -520,6 +520,12 @@
     <string name="session_drawer_pause">暫停</string>
     <string name="session_drawer_wine_processes_paused">Wine 程序已暫停</string>
     <string name="session_drawer_pause_all_wine_processes">暫停所有 Wine 程序</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">電量</string>
+    <string name="session_drawer_hud_element_graph">圖表</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">您要結束此程序嗎？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,6 +531,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_pip_subtitle">Shrink the game into a floating window</string>
     <string name="session_drawer_task_manager_subtitle">Inspect and manage running processes</string>
     <string name="session_drawer_magnifier_subtitle">Zoom into the display</string>
+    <string name="session_drawer_magnifier_disabled_native_subtitle">Disabled while Native Rendering is enabled</string>
     <string name="session_drawer_logs_subtitle">Open Wine and Box64 logs</string>
     <string name="session_drawer_exit_subtitle">Close the running session</string>
     <string name="session_drawer_touchscreen_overlay">Touchscreen Overlay</string>
@@ -538,6 +539,24 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_pause">Pause</string>
     <string name="session_drawer_wine_processes_paused">Wine processes are paused</string>
     <string name="session_drawer_pause_all_wine_processes">Pause all Wine processes</string>
+    <string name="session_drawer_controls_section">Controls</string>
+    <string name="session_drawer_session_section">Session</string>
+    <string name="session_drawer_header_subtitle">Quick access to controls, overlays, and session tools</string>
+    <string name="session_drawer_swipe_hint">Swipe away to jump back into the game</string>
+    <string name="session_drawer_hud_summary">Tune overlay visibility and data points</string>
+    <string name="session_drawer_hud_disabled_hint">Turn on the overlay to customize it</string>
+    <string name="session_drawer_hud_alpha">Alpha</string>
+    <string name="session_drawer_hud_scale">Scale</string>
+    <string name="session_drawer_hud_elements">HUD Elements</string>
+    <string name="session_drawer_hud_element_fps">FPS</string>
+    <string name="session_drawer_hud_element_api">API</string>
+    <string name="session_drawer_hud_element_gpu">GPU</string>
+    <string name="session_drawer_hud_element_cpu">CPU</string>
+    <string name="session_drawer_hud_element_battery">BAT</string>
+    <string name="session_drawer_hud_element_graph">Graph</string>
+    <string name="session_drawer_hud_alpha_input_title">Set Alpha</string>
+    <string name="session_drawer_hud_scale_input_title">Set Scale</string>
+    <string name="session_drawer_hud_input_hint">Enter a value from %1$d to %2$d. Values above the limit are clamped.</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Do you want to end this process?</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -272,6 +272,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
     private float hudScale = 1.0f;
     private boolean[] hudElements = new boolean[]{true, true, true, true, true, true};
     private boolean dualSeriesBattery = false;
+    private boolean hudCardExpanded = true;
+    private XServerDrawerStateHolder drawerStateHolder;
+    private XServerDrawerActionListener drawerActionListener;
 
     // Inside the XServerDisplayActivity class
     private SensorManager sensorManager;
@@ -2188,13 +2191,12 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 hudTransparency,
                 hudScale,
                 hudElements,
-                dualSeriesBattery
+                dualSeriesBattery,
+                hudCardExpanded
         );
-        XServerDrawerMenuKt.setupXServerDrawerComposeView(
-                navigationComposeView,
-                state,
-                this,
-                new XServerDrawerActionListener() {
+
+        if (drawerActionListener == null) {
+            drawerActionListener = new XServerDrawerActionListener() {
                     @Override
                     public void onActionSelected(int itemId) {
                         handleDrawerAction(itemId);
@@ -2231,8 +2233,27 @@ public class XServerDisplayActivity extends AppCompatActivity {
                         if (frameRating != null) frameRating.setDualSeriesBattery(enabled);
                         renderDrawerMenu();
                     }
-                }
-        );
+
+                    @Override
+                    public void onHUDCardExpandedChanged(boolean expanded) {
+                        hudCardExpanded = expanded;
+                        renderDrawerMenu();
+                    }
+                };
+        }
+
+        if (drawerStateHolder == null) {
+            drawerStateHolder = new XServerDrawerStateHolder(state);
+            XServerDrawerMenuKt.setupXServerDrawerComposeView(
+                    navigationComposeView,
+                    drawerStateHolder,
+                    this,
+                    drawerActionListener
+            );
+            return;
+        }
+
+        drawerStateHolder.setState(state);
     }
 
     private void loadHUDSettings() {
@@ -2292,9 +2313,11 @@ public class XServerDisplayActivity extends AppCompatActivity {
         switch (itemId) {
             case R.id.main_menu_keyboard:
                 AppUtils.showKeyboard(this);
+                drawerLayout.closeDrawers();
                 break;
             case R.id.main_menu_input_controls:
                 showInputControlsDialog();
+                drawerLayout.closeDrawers();
                 break;
             case R.id.main_menu_fps_monitor:
                 if (frameRating == null) {
@@ -2310,6 +2333,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 boolean becomingVisible = !isFpsVisible;
                 frameRating.setVisibility(becomingVisible ? View.VISIBLE : View.GONE);
                 if (becomingVisible) {
+                    hudCardExpanded = true;
                     syncFrameRatingWithExistingWindows();
                     applyHUDSettings();
                 }
@@ -2353,6 +2377,11 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 new TaskManagerDialog(this).show();
                 break;
             case R.id.main_menu_magnifier:
+                if (isNativeRenderingEnabled) {
+                    showToast(this, getString(R.string.session_drawer_magnifier_disabled_native_subtitle));
+                    renderDrawerMenu();
+                    break;
+                }
                 if (magnifierView == null) {
                     FrameLayout container = findViewById(R.id.FLXServerDisplay);
                     magnifierView = new MagnifierView(this);
@@ -2371,6 +2400,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 break;
             case R.id.main_menu_screen_effects:
                 new ScreenEffectDialog(this).show();
+                drawerLayout.closeDrawers();
                 break;
             case R.id.main_menu_logs:
                 debugDialog.show();

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -2,15 +2,24 @@ package com.winlator.cmod.runtime.display
 
 import android.app.Activity
 import android.content.Context
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -23,12 +32,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ExitToApp
 import androidx.compose.material.icons.automirrored.outlined.ViewList
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Fullscreen
 import androidx.compose.material.icons.outlined.Keyboard
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.Monitor
 import androidx.compose.material.icons.outlined.Mouse
@@ -39,29 +52,79 @@ import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.ZoomIn
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.winlator.cmod.R
+import com.winlator.cmod.shared.theme.WinNativeAccent
+import com.winlator.cmod.shared.theme.WinNativeBackground
+import com.winlator.cmod.shared.theme.WinNativeOutline
+import com.winlator.cmod.shared.theme.WinNativePanel
+import com.winlator.cmod.shared.theme.WinNativeSurface
+import com.winlator.cmod.shared.theme.WinNativeSurfaceAlt
+import com.winlator.cmod.shared.theme.WinNativeTextPrimary
+import com.winlator.cmod.shared.theme.WinNativeTextSecondary
+import com.winlator.cmod.shared.theme.WinNativeTheme
+import com.winlator.cmod.shared.ui.dialog.WinNativeDialogButton
+import com.winlator.cmod.shared.ui.dialog.WinNativeDialogShell
+import com.winlator.cmod.shared.ui.outlinedSwitchColors
+import kotlin.math.roundToInt
+
+private val DrawerHeroTop = Color(0xFF171E2E)
+private val DrawerHeroBottom = Color(0xFF11161F)
+private val DrawerIconBox = Color(0xFF242434)
+private val DrawerActiveSurface = Color(0xFF1E2A3D)
+private val DrawerExitSurface = Color(0xFF1F1A21)
+private val DrawerExitSurfacePressed = Color(0xFF251D25)
+private val DrawerExitOutline = Color(0xFF4B3038)
+private val DrawerExitIconBox = Color(0xFF2B2026)
+private val DrawerExitTint = Color(0xFFE07A84)
+
+private val DrawerPrimaryItemIds =
+    setOf(
+        R.id.main_menu_keyboard,
+        R.id.main_menu_input_controls,
+        R.id.main_menu_fps_monitor,
+    )
+
+private enum class HUDMetricEditor(
+    val minPercent: Int,
+    val maxPercent: Int,
+) {
+    ALPHA(minPercent = 10, maxPercent = 100),
+    SCALE(minPercent = 50, maxPercent = 200),
+}
 
 data class XServerDrawerItem(
     val itemId: Int,
@@ -69,6 +132,7 @@ data class XServerDrawerItem(
     val subtitle: String,
     val icon: ImageVector,
     val active: Boolean = false,
+    val enabled: Boolean = true,
 )
 
 data class XServerDrawerState(
@@ -77,7 +141,14 @@ data class XServerDrawerState(
     val hudScale: Float = 1.0f,
     val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
     val dualSeriesBatteryEnabled: Boolean = false,
+    val hudCardExpanded: Boolean = false,
 )
+
+class XServerDrawerStateHolder(
+    initialState: XServerDrawerState,
+) {
+    var state by mutableStateOf(initialState, neverEqualPolicy())
+}
 
 interface XServerDrawerActionListener {
     fun onActionSelected(itemId: Int)
@@ -92,6 +163,8 @@ interface XServerDrawerActionListener {
     fun onHUDScaleChanged(scale: Float)
 
     fun onDualSeriesBatteryChanged(enabled: Boolean)
+
+    fun onHUDCardExpandedChanged(expanded: Boolean)
 }
 
 fun buildXServerDrawerState(
@@ -109,9 +182,18 @@ fun buildXServerDrawerState(
     hudScale: Float = 1.0f,
     hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
     dualSeriesBatteryEnabled: Boolean = false,
+    hudCardExpanded: Boolean = false,
 ): XServerDrawerState {
     val items =
         mutableListOf(
+            XServerDrawerItem(
+                itemId = R.id.main_menu_fps_monitor,
+                title = context.getString(R.string.session_drawer_fps_monitor),
+                subtitle =
+                    if (fpsMonitorEnabled) context.getString(R.string.common_ui_enabled) else context.getString(R.string.common_ui_disabled),
+                icon = Icons.Outlined.Monitor,
+                active = fpsMonitorEnabled,
+            ),
             XServerDrawerItem(
                 itemId = R.id.main_menu_keyboard,
                 title = context.getString(R.string.session_drawer_keyboard),
@@ -125,30 +207,10 @@ fun buildXServerDrawerState(
                 icon = Icons.Outlined.SportsEsports,
             ),
             XServerDrawerItem(
-                itemId = R.id.main_menu_fps_monitor,
-                title = context.getString(R.string.session_drawer_fps_monitor),
-                subtitle =
-                    if (fpsMonitorEnabled) {
-                        context.getString(
-                            R.string.common_ui_enabled,
-                        )
-                    } else {
-                        context.getString(R.string.common_ui_disabled)
-                    },
-                icon = Icons.Outlined.Monitor,
-                active = fpsMonitorEnabled,
-            ),
-            XServerDrawerItem(
                 itemId = R.id.main_menu_relative_mouse_movement,
                 title = context.getString(R.string.session_drawer_relative_mouse_movement),
                 subtitle =
-                    if (relativeMouseEnabled) {
-                        context.getString(
-                            R.string.common_ui_enabled,
-                        )
-                    } else {
-                        context.getString(R.string.common_ui_disabled)
-                    },
+                    if (relativeMouseEnabled) context.getString(R.string.common_ui_enabled) else context.getString(R.string.common_ui_disabled),
                 icon = Icons.Outlined.Mouse,
                 active = relativeMouseEnabled,
             ),
@@ -156,13 +218,7 @@ fun buildXServerDrawerState(
                 itemId = R.id.main_menu_disable_mouse,
                 title = context.getString(R.string.session_drawer_mouse_input),
                 subtitle =
-                    if (mouseDisabled) {
-                        context.getString(
-                            R.string.common_ui_disabled,
-                        )
-                    } else {
-                        context.getString(R.string.common_ui_enabled)
-                    },
+                    if (mouseDisabled) context.getString(R.string.common_ui_disabled) else context.getString(R.string.common_ui_enabled),
                 icon = Icons.Outlined.Mouse,
                 active = !mouseDisabled,
             ),
@@ -189,13 +245,7 @@ fun buildXServerDrawerState(
                 itemId = R.id.main_menu_pause,
                 title = if (paused) context.getString(R.string.session_drawer_resume) else context.getString(R.string.session_drawer_pause),
                 subtitle =
-                    if (paused) {
-                        context.getString(
-                            R.string.session_drawer_wine_processes_paused,
-                        )
-                    } else {
-                        context.getString(R.string.session_drawer_pause_all_wine_processes)
-                    },
+                    if (paused) context.getString(R.string.session_drawer_wine_processes_paused) else context.getString(R.string.session_drawer_pause_all_wine_processes),
                 icon = if (paused) Icons.Outlined.PlayArrow else Icons.Outlined.Pause,
                 active = paused,
             ),
@@ -218,8 +268,14 @@ fun buildXServerDrawerState(
             XServerDrawerItem(
                 itemId = R.id.main_menu_magnifier,
                 title = context.getString(R.string.session_drawer_magnifier),
-                subtitle = context.getString(R.string.session_drawer_magnifier_subtitle),
+                subtitle =
+                    if (nativeRenderingEnabled) {
+                        context.getString(R.string.session_drawer_magnifier_disabled_native_subtitle)
+                    } else {
+                        context.getString(R.string.session_drawer_magnifier_subtitle)
+                    },
                 icon = Icons.Outlined.ZoomIn,
+                enabled = !nativeRenderingEnabled,
             )
     }
 
@@ -241,27 +297,26 @@ fun buildXServerDrawerState(
             icon = Icons.AutoMirrored.Outlined.ExitToApp,
         )
 
-    return XServerDrawerState(items, hudTransparency, hudScale, hudElements, dualSeriesBatteryEnabled)
+    return XServerDrawerState(
+        items = items,
+        hudTransparency = hudTransparency,
+        hudScale = hudScale,
+        hudElements = hudElements,
+        dualSeriesBatteryEnabled = dualSeriesBatteryEnabled,
+        hudCardExpanded = hudCardExpanded,
+    )
 }
 
 fun setupXServerDrawerComposeView(
     composeView: ComposeView,
-    state: XServerDrawerState,
-    activity: Activity,
+    stateHolder: XServerDrawerStateHolder,
+    _activity: Activity,
     listener: XServerDrawerActionListener,
 ) {
     composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     composeView.setContent {
-        MaterialTheme(
-            colorScheme =
-                darkColorScheme(
-                    primary = Color(0xFF2F81F7),
-                    background = Color(0xFF141B24),
-                    surface = Color(0xFF1E252E),
-                    onSurface = Color(0xFFE6EDF3),
-                ),
-        ) {
-            XServerDrawerContent(state = state, listener = listener)
+        WinNativeTheme {
+            XServerDrawerContent(state = stateHolder.state, listener = listener)
         }
     }
 }
@@ -271,29 +326,238 @@ private fun XServerDrawerContent(
     state: XServerDrawerState,
     listener: XServerDrawerActionListener,
 ) {
+    val primaryItems = remember(state.items) { state.items.filter { it.itemId in DrawerPrimaryItemIds } }
+    val secondaryItems = remember(state.items) { state.items.filterNot { it.itemId in DrawerPrimaryItemIds } }
+
     Surface(
         modifier =
             Modifier
                 .fillMaxHeight()
                 .width(336.dp),
-        color = Color(0xFF141B24),
+        color = WinNativeBackground,
         tonalElevation = 0.dp,
     ) {
         Column(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color(0xFF141B24))
-                    .padding(horizontal = 14.dp, vertical = 12.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            colorStops =
+                                arrayOf(
+                                    0.0f to DrawerHeroTop,
+                                    0.42f to DrawerHeroBottom,
+                                    1.0f to WinNativeBackground,
+                                ),
+                        ),
+                    )
+                    .padding(horizontal = 14.dp, vertical = 14.dp)
                     .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            state.items.forEach { item ->
-                XServerDrawerRow(item = item, onClick = { listener.onActionSelected(item.itemId) })
-                if (item.itemId == R.id.main_menu_fps_monitor && item.active) {
-                    XServerHUDSettingsExpanded(state, listener)
+            DrawerHeroCard()
+            primaryItems.forEach { item ->
+                if (item.itemId == R.id.main_menu_fps_monitor) {
+                    XServerHUDCard(
+                        item = item,
+                        state = state,
+                        listener = listener,
+                        onToggleMonitor = { listener.onActionSelected(item.itemId) },
+                    )
+                } else {
+                    XServerDrawerActionCard(
+                        item = item,
+                        onClick = { listener.onActionSelected(item.itemId) },
+                    )
                 }
             }
+
+            secondaryItems.forEach { item ->
+                XServerDrawerActionCard(
+                    item = item,
+                    onClick = { listener.onActionSelected(item.itemId) },
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+        }
+    }
+}
+
+@Composable
+private fun DrawerHeroCard() {
+    Text(
+        text = "WinNative",
+        color = WinNativeAccent,
+        fontSize = 21.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.65.sp,
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+    )
+}
+
+@Composable
+private fun XServerHUDCard(
+    item: XServerDrawerItem,
+    state: XServerDrawerState,
+    listener: XServerDrawerActionListener,
+    onToggleMonitor: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val statusInteractionSource = remember { MutableInteractionSource() }
+    val active = item.active
+    val expanded = active && state.hudCardExpanded
+    val cardClick =
+        if (active) {
+            { listener.onHUDCardExpandedChanged(!state.hudCardExpanded) }
+        } else {
+            onToggleMonitor
+        }
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.985f else 1f,
+        animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
+        label = "hudCardScale",
+    )
+    val cardColor by animateColorAsState(
+        targetValue =
+            when {
+                active -> DrawerActiveSurface
+                pressed -> WinNativeSurfaceAlt
+                else -> WinNativeSurface
+            },
+        animationSpec = tween(180),
+        label = "hudCardColor",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (active) WinNativeAccent.copy(alpha = 0.34f) else WinNativeOutline,
+        animationSpec = tween(180),
+        label = "hudCardBorder",
+    )
+    val iconBoxColor by animateColorAsState(
+        targetValue = if (active) WinNativeAccent.copy(alpha = 0.16f) else DrawerIconBox,
+        animationSpec = tween(180),
+        label = "hudIconBoxColor",
+    )
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+        label = "hudChevronRotation",
+    )
+    val subtitle =
+        when {
+            !active -> stringResource(R.string.session_drawer_hud_disabled_hint)
+            expanded -> stringResource(R.string.session_drawer_hud_summary)
+            else -> item.subtitle
+        }
+    val shape = RoundedCornerShape(20.dp)
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }.clip(shape)
+                .background(cardColor)
+                .border(BorderStroke(1.dp, borderColor), shape),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = cardClick,
+                    ).padding(horizontal = 14.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .width(4.dp)
+                        .height(42.dp)
+                        .clip(CircleShape)
+                        .background(if (active) WinNativeAccent else Color.Transparent),
+            )
+            Spacer(Modifier.width(10.dp))
+            Box(
+                modifier =
+                    Modifier
+                        .size(44.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(iconBoxColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = item.icon,
+                    contentDescription = null,
+                    tint = if (active) WinNativeAccent else WinNativeTextPrimary,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    color = WinNativeTextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 15.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = subtitle,
+                    color = WinNativeTextSecondary,
+                    fontSize = 11.sp,
+                    lineHeight = 14.sp,
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            DrawerStatusPill(
+                text = if (active) stringResource(R.string.common_ui_on) else stringResource(R.string.common_ui_off),
+                active = active,
+                interactionSource = statusInteractionSource,
+                onClick = onToggleMonitor,
+            )
+            if (active) {
+                Spacer(Modifier.width(6.dp))
+                val chevronSource = remember { MutableInteractionSource() }
+                Box(
+                    modifier =
+                        Modifier
+                            .size(34.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(WinNativePanel)
+                            .border(1.dp, WinNativeOutline, RoundedCornerShape(12.dp))
+                            .clickable(
+                                interactionSource = chevronSource,
+                                indication = null,
+                                onClick = { listener.onHUDCardExpandedChanged(!state.hudCardExpanded) },
+                            ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.KeyboardArrowDown,
+                        contentDescription = null,
+                        tint = WinNativeAccent,
+                        modifier =
+                            Modifier
+                                .size(18.dp)
+                                .rotate(chevronRotation),
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = fadeIn(tween(180)) + expandVertically(tween(220, easing = FastOutSlowInEasing)),
+            exit = fadeOut(tween(140)) + shrinkVertically(tween(180, easing = FastOutSlowInEasing)),
+        ) {
+            XServerHUDSettingsExpanded(state = state, listener = listener)
         }
     }
 }
@@ -303,142 +567,393 @@ private fun XServerHUDSettingsExpanded(
     state: XServerDrawerState,
     listener: XServerDrawerActionListener,
 ) {
-    val card = Color(0xFF232C40)
-    val accent = Color(0xFF2F81F7)
-    val textSecondary = Color(0xFF8B949E)
+    var activeEditor by remember { mutableStateOf<HUDMetricEditor?>(null) }
+    val elementNames =
+        listOf(
+            stringResource(R.string.session_drawer_hud_element_fps),
+            stringResource(R.string.session_drawer_hud_element_api),
+            stringResource(R.string.session_drawer_hud_element_gpu),
+            stringResource(R.string.session_drawer_hud_element_cpu),
+            stringResource(R.string.session_drawer_hud_element_battery),
+            stringResource(R.string.session_drawer_hud_element_graph),
+        )
+
+    activeEditor?.let { editor ->
+        HUDMetricInputDialog(
+            editor = editor,
+            initialPercent =
+                when (editor) {
+                    HUDMetricEditor.ALPHA -> (state.hudTransparency * 100).roundToInt()
+                    HUDMetricEditor.SCALE -> (state.hudScale * 100).roundToInt()
+                },
+            onDismiss = { activeEditor = null },
+            onConfirm = { enteredPercent ->
+                activeEditor = null
+                when (editor) {
+                    HUDMetricEditor.ALPHA -> {
+                        listener.onHUDTransparencyChanged(enteredPercent.coerceIn(editor.minPercent, editor.maxPercent) / 100f)
+                    }
+                    HUDMetricEditor.SCALE -> {
+                        listener.onHUDScaleChanged(enteredPercent.coerceIn(editor.minPercent, editor.maxPercent) / 100f)
+                    }
+                }
+            },
+        )
+    }
 
     Column(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(18.dp))
-                .background(card)
-                .padding(12.dp),
+                .padding(start = 14.dp, end = 14.dp, bottom = 14.dp),
     ) {
-        // Transparency Slider
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(WinNativePanel)
+                    .border(1.dp, WinNativeOutline, RoundedCornerShape(18.dp))
+                    .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = "Alpha ${(state.hudTransparency * 100).toInt()}%",
-                color = textSecondary,
-                fontSize = 11.sp,
-                modifier = Modifier.width(70.dp),
-            )
-            Slider(
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                DrawerMetricChip(
+                    label = stringResource(R.string.session_drawer_hud_alpha),
+                    value = "${(state.hudTransparency * 100).toInt()}%",
+                    modifier = Modifier.weight(1f),
+                    onClick = { activeEditor = HUDMetricEditor.ALPHA },
+                )
+                DrawerMetricChip(
+                    label = stringResource(R.string.session_drawer_hud_scale),
+                    value = "${(state.hudScale * 100).toInt()}%",
+                    modifier = Modifier.weight(1f),
+                    onClick = { activeEditor = HUDMetricEditor.SCALE },
+                )
+            }
+
+            DrawerSliderRow(
+                label = stringResource(R.string.session_drawer_hud_alpha),
+                valueText = "${(state.hudTransparency * 100).toInt()}%",
                 value = state.hudTransparency,
-                onValueChange = { listener.onHUDTransparencyChanged(it) },
                 valueRange = 0.1f..1f,
-                modifier = Modifier.weight(1f),
-                colors =
-                    SliderDefaults.colors(
-                        thumbColor = accent,
-                        activeTrackColor = accent,
-                        inactiveTrackColor = accent.copy(alpha = 0.24f),
-                    ),
+                steps = 8,
+                onValueChange = { listener.onHUDTransparencyChanged(it.snapToStep(0.1f, 0.1f, 1f)) },
             )
-        }
 
-        Spacer(Modifier.height(4.dp))
-
-        // Scale Slider
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "Scale ${(state.hudScale * 100).toInt()}%",
-                color = textSecondary,
-                fontSize = 11.sp,
-                modifier = Modifier.width(70.dp),
-            )
-            Slider(
+            DrawerSliderRow(
+                label = stringResource(R.string.session_drawer_hud_scale),
+                valueText = "${(state.hudScale * 100).toInt()}%",
                 value = state.hudScale,
-                onValueChange = { listener.onHUDScaleChanged(it) },
                 valueRange = 0.5f..2.0f,
-                modifier = Modifier.weight(1f),
-                colors =
-                    SliderDefaults.colors(
-                        thumbColor = accent,
-                        activeTrackColor = accent,
-                        inactiveTrackColor = accent.copy(alpha = 0.24f),
-                    ),
+                steps = 14,
+                onValueChange = { listener.onHUDScaleChanged(it.snapToStep(0.1f, 0.5f, 2.0f)) },
             )
-        }
 
-        Spacer(Modifier.height(8.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.session_drawer_hud_elements),
+                    color = WinNativeTextSecondary,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 0.3.sp,
+                )
 
-        // Toggles Grid (3 columns, 2 rows)
-        val elementNames = listOf("FPS", "API", "GPU", "CPU", "BAT", "Graph")
-
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            for (row in 0..1) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    for (col in 0..2) {
-                        val index = row * 3 + col
-                        if (index < elementNames.size) {
-                            HUDCheckmarkToggle(
+                for (row in 0..1) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        for (col in 0..2) {
+                            val index = row * 3 + col
+                            HUDToggleChip(
                                 label = elementNames[index],
                                 checked = state.hudElements[index],
-                                onCheckedChange = { listener.onHUDElementToggled(index, it) },
+                                onClick = { listener.onHUDElementToggled(index, !state.hudElements[index]) },
                                 modifier = Modifier.weight(1f),
                             )
                         }
                     }
                 }
             }
+
+            DrawerBooleanRow(
+                title = stringResource(R.string.session_drawer_dual_series_battery),
+                checked = state.dualSeriesBatteryEnabled,
+                onCheckedChange = listener::onDualSeriesBatteryChanged,
+            )
         }
+    }
+}
 
-        Spacer(Modifier.height(8.dp))
+@Composable
+private fun DrawerMetricChip(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.985f else 1f,
+        animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
+        label = "drawerMetricScale_$label",
+    )
 
-        HUDCheckmarkToggle(
-            label = stringResource(R.string.session_drawer_dual_series_battery),
-            checked = state.dualSeriesBatteryEnabled,
-            onCheckedChange = listener::onDualSeriesBatteryChanged,
-            modifier = Modifier.fillMaxWidth(),
+    Column(
+        modifier =
+            modifier
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(WinNativeSurfaceAlt)
+                .border(1.dp, WinNativeOutline, RoundedCornerShape(12.dp))
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                )
+                .padding(horizontal = 10.dp, vertical = 7.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = label.uppercase(),
+            color = WinNativeTextSecondary,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.6.sp,
+        )
+        Spacer(Modifier.height(1.dp))
+        Text(
+            text = value,
+            color = WinNativeTextPrimary,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
         )
     }
 }
 
 @Composable
-private fun HUDCheckmarkToggle(
+private fun DrawerSliderRow(
+    label: String,
+    valueText: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    onValueChange: (Float) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                color = WinNativeTextPrimary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = valueText,
+                color = WinNativeAccent,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            steps = steps,
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                SliderDefaults.colors(
+                    thumbColor = WinNativeAccent,
+                    activeTrackColor = WinNativeAccent,
+                    inactiveTrackColor = WinNativeSurfaceAlt,
+                    activeTickColor = Color.Transparent,
+                    inactiveTickColor = Color.Transparent,
+                ),
+        )
+    }
+}
+
+private fun Float.snapToStep(
+    step: Float,
+    min: Float,
+    max: Float,
+): Float = (min + (((this - min) / step).roundToInt() * step)).coerceIn(min, max)
+
+@Composable
+private fun HUDMetricInputDialog(
+    editor: HUDMetricEditor,
+    initialPercent: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (Int) -> Unit,
+) {
+    var value by remember { mutableStateOf(initialPercent.toString()) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    fun submit() {
+        val parsed = value.toIntOrNull() ?: initialPercent
+        onConfirm(parsed.coerceIn(editor.minPercent, editor.maxPercent))
+    }
+
+    WinNativeDialogShell(
+        onDismiss = onDismiss,
+        title =
+            when (editor) {
+                HUDMetricEditor.ALPHA -> stringResource(R.string.session_drawer_hud_alpha_input_title)
+                HUDMetricEditor.SCALE -> stringResource(R.string.session_drawer_hud_scale_input_title)
+            },
+        maxWidth = 380.dp,
+    ) {
+        Text(
+            text = stringResource(R.string.session_drawer_hud_input_hint, editor.minPercent, editor.maxPercent),
+            color = WinNativeTextSecondary,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+        )
+        Spacer(Modifier.height(14.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = { incoming -> value = incoming.filter(Char::isDigit) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            suffix = {
+                Text(
+                    text = "%",
+                    color = WinNativeTextSecondary,
+                    fontSize = 13.sp,
+                )
+            },
+            textStyle = androidx.compose.material3.MaterialTheme.typography.bodyMedium.copy(color = WinNativeTextPrimary),
+            colors =
+                OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = WinNativeAccent,
+                    unfocusedBorderColor = WinNativeOutline,
+                    focusedTextColor = WinNativeTextPrimary,
+                    unfocusedTextColor = WinNativeTextPrimary,
+                    focusedContainerColor = WinNativeBackground,
+                    unfocusedContainerColor = WinNativeBackground,
+                    focusedLabelColor = WinNativeTextSecondary,
+                    unfocusedLabelColor = WinNativeTextSecondary,
+                    cursorColor = WinNativeAccent,
+                ),
+            keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done,
+                ),
+            keyboardActions =
+                KeyboardActions(
+                    onDone = {
+                        keyboardController?.hide()
+                        submit()
+                    },
+                ),
+        )
+        Spacer(Modifier.height(16.dp))
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(WinNativeOutline),
+        )
+        Spacer(Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+        ) {
+            WinNativeDialogButton(
+                label = stringResource(R.string.common_ui_cancel),
+                textColor = WinNativeTextPrimary,
+                onClick = onDismiss,
+            )
+            WinNativeDialogButton(
+                label = stringResource(R.string.common_ui_apply),
+                textColor = WinNativeAccent,
+                backgroundColor = WinNativeAccent.copy(alpha = 0.12f),
+                borderColor = WinNativeAccent.copy(alpha = 0.3f),
+                onClick = {
+                    keyboardController?.hide()
+                    submit()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun HUDToggleChip(
     label: String,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val textPrimary = Color(0xFFE6EDF3)
-    val accent = Color(0xFF2F81F7)
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val bgColor by animateColorAsState(
+        targetValue =
+            when {
+                checked -> WinNativeAccent.copy(alpha = 0.16f)
+                pressed -> WinNativeSurface
+                else -> WinNativeSurfaceAlt
+            },
+        animationSpec = tween(160),
+        label = "hudChipBg",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (checked) WinNativeAccent.copy(alpha = 0.34f) else WinNativeOutline,
+        animationSpec = tween(160),
+        label = "hudChipBorder",
+    )
 
     Row(
         modifier =
             modifier
-                .clip(RoundedCornerShape(8.dp))
-                .clickable { onCheckedChange(!checked) }
-                .padding(vertical = 4.dp),
+                .clip(RoundedCornerShape(14.dp))
+                .background(bgColor)
+                .border(1.dp, borderColor, RoundedCornerShape(14.dp))
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                ).padding(horizontal = 10.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Start,
     ) {
-        Checkbox(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-            modifier = Modifier.size(24.dp),
-            colors =
-                CheckboxDefaults.colors(
-                    checkedColor = accent,
-                    uncheckedColor = Color(0xFF394048),
-                    checkmarkColor = Color.White,
-                ),
-        )
-        Spacer(Modifier.width(4.dp))
+        Box(
+            modifier =
+                Modifier
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(if (checked) WinNativeAccent else DrawerIconBox),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (checked) {
+                Icon(
+                    imageVector = Icons.Outlined.Check,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(7.dp))
         Text(
             text = label,
-            color = textPrimary,
-            fontSize = 11.sp,
+            color = WinNativeTextPrimary,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
@@ -446,57 +961,177 @@ private fun HUDCheckmarkToggle(
 }
 
 @Composable
-private fun XServerDrawerRow(
-    item: XServerDrawerItem,
-    onClick: () -> Unit,
+private fun DrawerBooleanRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
 ) {
-    val accent = Color(0xFF2F81F7)
-    val surface = Color(0xFF1E252E)
-    val card = Color(0xFF232C40)
-    val textPrimary = Color(0xFFE6EDF3)
-    val textSecondary = Color(0xFF8B949E)
+    val rowInteractionSource = remember { MutableInteractionSource() }
+    val switchInteractionSource = remember { MutableInteractionSource() }
 
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(18.dp))
-                .background(card)
-                .then(
-                    if (item.active) {
-                        Modifier.border(
-                            BorderStroke(1.dp, accent.copy(alpha = 0.45f)),
-                            RoundedCornerShape(18.dp),
-                        )
+                .clip(RoundedCornerShape(16.dp))
+                .background(WinNativeSurfaceAlt)
+                .border(1.dp, WinNativeOutline, RoundedCornerShape(16.dp))
+                .clickable(
+                    interactionSource = rowInteractionSource,
+                    indication = null,
+                ) { onCheckedChange(!checked) }
+                .padding(horizontal = 11.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = WinNativeTextPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.height(1.dp))
+            Text(
+                text =
+                    if (checked) {
+                        stringResource(R.string.common_ui_enabled)
                     } else {
-                        Modifier
+                        stringResource(R.string.common_ui_disabled)
                     },
-                ).clickable(onClick = onClick)
-                .padding(horizontal = 14.dp, vertical = 12.dp),
+                color = WinNativeTextSecondary,
+                fontSize = 10.sp,
+            )
+        }
+        CompositionLocalProvider(LocalRippleConfiguration provides null) {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                interactionSource = switchInteractionSource,
+                colors = outlinedSwitchColors(WinNativeAccent, WinNativeTextSecondary),
+            )
+        }
+    }
+}
+
+@Composable
+private fun XServerDrawerActionCard(
+    item: XServerDrawerItem,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val enabled = item.enabled
+    val isExitAction = item.itemId == R.id.main_menu_exit
+    val scale by animateFloatAsState(
+        targetValue = if (pressed && enabled) 0.985f else 1f,
+        animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
+        label = "drawerActionScale_${item.itemId}",
+    )
+    val cardColor by animateColorAsState(
+        targetValue =
+            when {
+                !enabled -> WinNativePanel
+                item.active -> DrawerActiveSurface
+                isExitAction && pressed -> DrawerExitSurfacePressed
+                isExitAction -> DrawerExitSurface
+                pressed -> WinNativeSurfaceAlt
+                else -> WinNativeSurface
+            },
+        animationSpec = tween(180),
+        label = "drawerActionCardColor_${item.itemId}",
+    )
+    val borderColor by animateColorAsState(
+        targetValue =
+            when {
+                !enabled -> WinNativeOutline.copy(alpha = 0.72f)
+                item.active -> WinNativeAccent.copy(alpha = 0.28f)
+                isExitAction -> DrawerExitOutline
+                else -> WinNativeOutline
+            },
+        animationSpec = tween(180),
+        label = "drawerActionBorderColor_${item.itemId}",
+    )
+    val iconBoxColor by animateColorAsState(
+        targetValue =
+            when {
+                !enabled -> DrawerIconBox.copy(alpha = 0.72f)
+                item.active -> WinNativeAccent.copy(alpha = 0.16f)
+                isExitAction -> DrawerExitIconBox
+                else -> DrawerIconBox
+            },
+        animationSpec = tween(180),
+        label = "drawerActionIconColor_${item.itemId}",
+    )
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (enabled) 1f else 0.56f,
+        animationSpec = tween(180),
+        label = "drawerActionAlpha_${item.itemId}",
+    )
+    val shape = RoundedCornerShape(20.dp)
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }.clip(shape)
+                .background(cardColor)
+                .border(BorderStroke(1.dp, borderColor), shape)
+                .clickable(
+                    enabled = enabled,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                ).padding(horizontal = 14.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier =
                 Modifier
-                    .size(42.dp)
+                    .width(4.dp)
+                    .height(40.dp)
+                    .clip(CircleShape)
+                    .background(if (item.active && enabled) WinNativeAccent else Color.Transparent),
+        )
+        Spacer(Modifier.width(10.dp))
+        Box(
+            modifier =
+                Modifier
+                    .size(44.dp)
                     .clip(RoundedCornerShape(14.dp))
-                    .background(surface),
+                    .background(iconBoxColor)
+                    .graphicsLayer {
+                        alpha = contentAlpha
+                    },
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = item.icon,
                 contentDescription = null,
-                tint = if (item.active) accent else textPrimary,
+                tint =
+                    when {
+                        !enabled -> WinNativeTextSecondary
+                        item.active -> WinNativeAccent
+                        isExitAction -> DrawerExitTint
+                        else -> WinNativeTextPrimary
+                    },
                 modifier = Modifier.size(22.dp),
             )
         }
-
         Spacer(Modifier.width(12.dp))
-
-        Column(modifier = Modifier.weight(1f)) {
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .graphicsLayer {
+                        alpha = contentAlpha
+                    },
+        ) {
             Text(
                 text = item.title,
-                color = textPrimary,
+                color = WinNativeTextPrimary,
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 14.sp,
                 maxLines = 1,
@@ -505,31 +1140,65 @@ private fun XServerDrawerRow(
             Spacer(Modifier.height(3.dp))
             Text(
                 text = item.subtitle,
-                color = textSecondary,
+                color = WinNativeTextSecondary,
                 fontSize = 11.sp,
                 lineHeight = 14.sp,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
         }
-
-        if (item.active) {
+        if (!enabled) {
             Spacer(Modifier.width(10.dp))
-            Box(
-                modifier =
-                    Modifier
-                        .clip(CircleShape)
-                        .background(accent.copy(alpha = 0.18f))
-                        .padding(horizontal = 10.dp, vertical = 5.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringResource(R.string.common_ui_on).uppercase(),
-                    color = accent,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
+            DrawerStatusPill(
+                text = stringResource(R.string.common_ui_disabled),
+                active = false,
+            )
+        } else if (item.active) {
+            Spacer(Modifier.width(10.dp))
+            DrawerStatusPill(
+                text = stringResource(R.string.common_ui_on),
+                active = true,
+            )
         }
+    }
+}
+
+@Composable
+private fun DrawerStatusPill(
+    text: String,
+    active: Boolean,
+    interactionSource: MutableInteractionSource? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    val background = if (active) WinNativeAccent.copy(alpha = 0.16f) else WinNativePanel
+    val border = if (active) WinNativeAccent.copy(alpha = 0.26f) else WinNativeOutline
+    val textColor = if (active) WinNativeAccent else WinNativeTextSecondary
+    val baseModifier =
+        Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(background)
+            .border(1.dp, border, RoundedCornerShape(999.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+
+    Box(
+        modifier =
+            if (onClick != null && interactionSource != null) {
+                baseModifier.clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                )
+            } else {
+                baseModifier
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text.uppercase(),
+            color = textColor,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.6.sp,
+        )
     }
 }


### PR DESCRIPTION
This updates the in-game drawer so the HUD controls behave better during play and the menu is easier to dismiss when swiping back into the game. The drawer state is now preserved across re-renders, the FPS/HUD controls live in an expandable card, and actions like keyboard, input controls, and screen effects close the drawer at the right time.

It also disables the magnifier while Native Rendering is enabled and adds the new drawer copy across the current translations.

Validated with `.\gradlew.bat :app:assembleStandardDebug :app:assembleLudashiDebug --build-cache --parallel -x lint`. 