### PR TITLE
Improve non-game UI smoothness on 120 Hz displays

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -112,15 +112,15 @@ class PluviaApp : Application() {
                     activity: Activity,
                     savedInstanceState: Bundle?,
                 ) {
-                    if (activity !is XServerDisplayActivity) {
-                        RefreshRateUtils.applyPreferredRefreshRate(activity)
+                    if (shouldManageAppRefreshRate(activity)) {
+                        RefreshRateUtils.onActivityCreated(activity)
                     }
                 }
 
                 override fun onActivityResumed(activity: Activity) {
                     currentForegroundActivity = activity
-                    if (activity !is XServerDisplayActivity) {
-                        RefreshRateUtils.applyPreferredRefreshRate(activity)
+                    if (shouldManageAppRefreshRate(activity)) {
+                        RefreshRateUtils.onActivityResumed(activity)
                     }
                 }
 
@@ -140,11 +140,19 @@ class PluviaApp : Application() {
                 ) {}
 
                 override fun onActivityDestroyed(activity: Activity) {
+                    if (shouldManageAppRefreshRate(activity)) {
+                        RefreshRateUtils.onActivityDestroyed(activity)
+                    }
                     if (currentForegroundActivity === activity) {
                         currentForegroundActivity = null
                     }
                 }
             },
         )
+    }
+
+    private fun shouldManageAppRefreshRate(activity: Activity): Boolean {
+        // Game windows own per-title refresh policy and should not inherit the global app override.
+        return activity !is XServerDisplayActivity
     }
 }

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -187,6 +187,7 @@ import com.winlator.cmod.runtime.input.ControllerHelper
 import com.winlator.cmod.runtime.wine.PeIconExtractor
 import com.winlator.cmod.shared.android.ActivityResultHost
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.android.RefreshRateUtils
 import com.winlator.cmod.shared.io.StorageUtils
 import com.winlator.cmod.shared.ui.CarouselView
 import com.winlator.cmod.shared.ui.FourByTwoGridView
@@ -625,11 +626,19 @@ class UnifiedActivity :
         window.decorView.rootView.dispatchKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_UP, keyCode))
     }
 
+    private fun reapplyPreferredRefreshRate() {
+        if (isFinishing || isDestroyed) return
+        RefreshRateUtils.applyPreferredRefreshRate(this)
+    }
+
     private fun navigateToSettings(
         item: SettingsNavItem = SettingsNavItem.CONTAINERS,
         profileId: Int = 0,
         editContainerId: Int = 0,
     ) {
+        // Settings is an in-activity navigation target, so entering it does not trigger an
+        // Activity resume. Reassert the preferred display mode at the activity boundary.
+        reapplyPreferredRefreshRate()
         val route = buildSettingsRoute(item, profileId, editContainerId)
         val nav = rootNavController
         if (nav == null) {

--- a/app/src/main/feature/settings/nav/SettingsNavGraph.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavGraph.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.fragment.compose.AndroidFragment
 import androidx.navigation.compose.NavHost
@@ -79,8 +78,7 @@ fun SettingsHost(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .fillMaxHeight()
-                        .graphicsLayer(),
+                        .fillMaxHeight(),
             ) {
                 composable(SettingsRoutes.fromNavItem(SettingsNavItem.CONTAINERS)) {
                     AndroidFragment<ContainersFragment>()

--- a/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -127,8 +126,7 @@ fun SettingsNavSidebar(
     Row(
         modifier =
             Modifier
-                .fillMaxHeight()
-                .graphicsLayer(),
+                .fillMaxHeight(),
     ) {
         Column(
             modifier =

--- a/app/src/main/shared/android/RefreshRateUtils.java
+++ b/app/src/main/shared/android/RefreshRateUtils.java
@@ -5,16 +5,22 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 import android.view.Display;
+import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
+import java.util.WeakHashMap;
 
 public final class RefreshRateUtils {
   private static final String TAG = "RefreshRateUtils";
   private static final float DEFAULT_REFRESH_RATE = 60f;
+  private static final Map<Activity, ViewTreeObserver.OnWindowFocusChangeListener>
+      WINDOW_FOCUS_LISTENERS = new WeakHashMap<>();
 
   private RefreshRateUtils() {}
 
@@ -181,6 +187,51 @@ public final class RefreshRateUtils {
 
   @Nullable private static Display getDisplay(Activity activity) {
     return activity.getWindow().getDecorView().getDisplay();
+  }
+
+  public static void onActivityCreated(Activity activity) {
+    attachWindowFocusListener(activity);
+    applyPreferredRefreshRate(activity);
+  }
+
+  public static void onActivityResumed(Activity activity) {
+    applyPreferredRefreshRate(activity);
+  }
+
+  public static void onActivityDestroyed(Activity activity) {
+    detachWindowFocusListener(activity);
+  }
+
+  private static void attachWindowFocusListener(Activity activity) {
+    if (WINDOW_FOCUS_LISTENERS.containsKey(activity)) return;
+
+    View decorView = activity.getWindow().getDecorView();
+    if (decorView == null) return;
+
+    ViewTreeObserver observer = decorView.getViewTreeObserver();
+    if (!observer.isAlive()) return;
+
+    // Some devices do not fully honor the preferred mode until the window regains focus.
+    ViewTreeObserver.OnWindowFocusChangeListener listener =
+        hasFocus -> {
+          if (hasFocus) {
+            applyPreferredRefreshRate(activity);
+          }
+        };
+    observer.addOnWindowFocusChangeListener(listener);
+    WINDOW_FOCUS_LISTENERS.put(activity, listener);
+  }
+
+  private static void detachWindowFocusListener(Activity activity) {
+    ViewTreeObserver.OnWindowFocusChangeListener listener = WINDOW_FOCUS_LISTENERS.remove(activity);
+    if (listener == null) return;
+
+    View decorView = activity.getWindow().getDecorView();
+    if (decorView == null) return;
+
+    ViewTreeObserver observer = decorView.getViewTreeObserver();
+    if (!observer.isAlive()) return;
+    observer.removeOnWindowFocusChangeListener(listener);
   }
 
   public static void applyPreferredRefreshRate(Activity activity) {

--- a/app/src/main/shared/ui/widget/ChasingBorderModifier.kt
+++ b/app/src/main/shared/ui/widget/ChasingBorderModifier.kt
@@ -1,4 +1,5 @@
 package com.winlator.cmod.shared.ui.widget
+
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
@@ -10,11 +11,10 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -39,19 +39,17 @@ fun Modifier.chasingBorder(
         val borderWidthPx = borderWidth.value * density
 
         val infiniteTransition = rememberInfiniteTransition(label = "chasingBorder")
-        val animatedRotation by infiniteTransition.animateFloat(
-            initialValue = 0f,
-            targetValue = 360f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation = tween(durationMillis = animationDurationMs, easing = LinearEasing),
-                    repeatMode = RepeatMode.Restart,
-                ),
-            label = "borderRotation",
-        )
-        // When paused, skip the animated state read so Compose stops invalidating
-        // the draw scope — the border renders once and stays static until resumed.
-        val rotationDegrees = if (paused) 0f else animatedRotation
+        val animatedRotation =
+            infiniteTransition.animateFloat(
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec =
+                    infiniteRepeatable(
+                        animation = tween(durationMillis = animationDurationMs, easing = LinearEasing),
+                        repeatMode = RepeatMode.Restart,
+                    ),
+                label = "borderRotation",
+            )
 
         val gradientColors =
             remember {
@@ -65,61 +63,52 @@ fun Modifier.chasingBorder(
             }
         val gradientStops = remember { floatArrayOf(0f, 0.25f, 0.50f, 0.75f, 1f) }
 
-        val drawState =
-            remember {
-                ChasingBorderDrawState(
-                    paint =
-                        Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                            style = Paint.Style.STROKE
-                            strokeWidth = borderWidthPx
-                            strokeCap = Paint.Cap.ROUND
-                            strokeJoin = Paint.Join.ROUND
-                        },
-                )
-            }
-
-        this.drawWithContent {
-            drawContent()
-
+        drawWithCache {
             val w = size.width
             val h = size.height
-            if (w <= 0 || h <= 0) return@drawWithContent
 
-            // Rebuild path and shader when size changes
-            if (drawState.lastWidth != w || drawState.lastHeight != h) {
-                drawState.lastWidth = w
-                drawState.lastHeight = h
+            if (w <= 0f || h <= 0f) {
+                onDrawWithContent { drawContent() }
+            } else {
                 val inset = borderWidthPx / 2f
-                drawState.rect.set(inset, inset, w - inset, h - inset)
-                drawState.path.reset()
-                drawState.path.addRoundRect(
-                    drawState.rect,
-                    cornerRadiusPx,
-                    cornerRadiusPx,
-                    Path.Direction.CW,
-                )
-                drawState.paint.shader =
+                val rect = RectF(inset, inset, w - inset, h - inset)
+                val path =
+                    Path().apply {
+                        addRoundRect(
+                            rect,
+                            cornerRadiusPx,
+                            cornerRadiusPx,
+                            Path.Direction.CW,
+                        )
+                    }
+                val shader =
                     SweepGradient(
                         w / 2f,
                         h / 2f,
                         gradientColors,
                         gradientStops,
                     )
+                val matrix = Matrix()
+                val paint =
+                    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                        style = Paint.Style.STROKE
+                        strokeWidth = borderWidthPx
+                        strokeCap = Paint.Cap.ROUND
+                        strokeJoin = Paint.Join.ROUND
+                        this.shader = shader
+                    }
+
+                onDrawWithContent {
+                    drawContent()
+
+                    // Read the animated value in draw so 120 Hz devices only redraw the border
+                    // instead of forcing a full recomposition every frame.
+                    val rotationDegrees = if (paused) 0f else animatedRotation.value
+                    matrix.setRotate(rotationDegrees, w / 2f, h / 2f)
+                    shader.setLocalMatrix(matrix)
+
+                    drawContext.canvas.nativeCanvas.drawPath(path, paint)
+                }
             }
-
-            // Rotate the sweep gradient
-            drawState.matrix.setRotate(rotationDegrees, w / 2f, h / 2f)
-            drawState.paint.shader?.setLocalMatrix(drawState.matrix)
-
-            drawContext.canvas.nativeCanvas.drawPath(drawState.path, drawState.paint)
         }
     }
-
-private class ChasingBorderDrawState(
-    val paint: Paint,
-    val path: Path = Path(),
-    val rect: RectF = RectF(),
-    val matrix: Matrix = Matrix(),
-    var lastWidth: Float = -1f,
-    var lastHeight: Float = -1f,
-)


### PR DESCRIPTION
- Move the shared chasing-border animation to draw-phase reads so high-refresh UI scrolling no longer triggers per-frame recomposition.
- Cache the chasing-border path, shader, and paint with `drawWithCache` so steady-state scrolling avoids rebuilding border draw state.
- Remove redundant `graphicsLayer()` wrappers from the settings sidebar host and settings content host.
- Centralize preferred refresh-rate reapply in `PluviaApp` for non-game activities only.
- Reapply the preferred mode on activity creation, resume, and window focus return so devices that defer the mode until unlock or refocus stay smooth.
- Reassert the preferred mode when `UnifiedActivity` navigates into settings because that route change happens inside the same activity and does not trigger resume.
- Leave `XServerDisplayActivity` game refresh handling untouched.
- Validation: `git diff --check`.
- Validation: Gradle compile was not run because `JAVA_HOME` / `java` is not available in this environment.