### PR TITLE
Fix app exit cleanup and background resource retention

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -12,6 +12,7 @@ import com.winlator.cmod.feature.stores.gog.service.GOGConstants
 import com.winlator.cmod.feature.stores.gog.service.GOGService
 import com.winlator.cmod.feature.stores.steam.events.EventDispatcher
 import com.winlator.cmod.feature.stores.steam.service.SteamService
+import com.winlator.cmod.shared.android.NotificationHelper
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.runtime.display.XServerDisplayActivity
 import com.winlator.cmod.shared.android.RefreshRateUtils
@@ -42,6 +43,9 @@ class PluviaApp : Application() {
         PrefManager.init(this)
         GOGConstants.init(this)
         GOGAuthManager.updateLoginStatus(this)
+
+        // Sweep any stale app-owned notifications left behind by abnormal kills.
+        NotificationHelper.cancelAll(this)
 
         if (PrefManager.enableSteamLogs) {
             timber.log.Timber.plant(timber.log.Timber.DebugTree())

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -10,7 +10,6 @@ import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import android.os.Bundle
-import android.os.Process
 import android.provider.DocumentsContract
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
@@ -519,6 +518,7 @@ class UnifiedActivity :
     override fun onPause() {
         super.onPause()
         chasingBordersPaused.value = true
+        UpdateChecker.stopBackgroundLoop()
     }
 
     override fun onResume() {
@@ -697,6 +697,16 @@ class UnifiedActivity :
         super.onNewIntent(intent)
         setIntent(intent)
         handleSettingsIntent(intent)
+    }
+
+    private fun requestAppExit() {
+        UpdateChecker.stopBackgroundLoop()
+        UpdateChecker.cancelPostGameCheck()
+        PluviaApp.events.emit(AndroidEvent.EndProcess)
+        SteamService.stop()
+        EpicService.stop()
+        GOGService.stop()
+        finishAndRemoveTask()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -1474,9 +1484,7 @@ class UnifiedActivity :
                             // Exit button
                             Button(
                                 onClick = {
-                                    // Kill all WinNative processes and close fully
-                                    finishAffinity()
-                                    Process.killProcess(Process.myPid())
+                                    requestAppExit()
                                 },
                                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935)),
                                 shape = RoundedCornerShape(12.dp),

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -186,6 +186,7 @@ import com.winlator.cmod.runtime.input.ControllerHelper
 import com.winlator.cmod.runtime.wine.PeIconExtractor
 import com.winlator.cmod.shared.android.ActivityResultHost
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.android.NotificationHelper
 import com.winlator.cmod.shared.android.RefreshRateUtils
 import com.winlator.cmod.shared.io.StorageUtils
 import com.winlator.cmod.shared.ui.CarouselView
@@ -706,6 +707,7 @@ class UnifiedActivity :
         SteamService.stop()
         EpicService.stop()
         GOGService.stop()
+        NotificationHelper.cancelAll(this)
         finishAndRemoveTask()
     }
 

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -481,7 +481,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
     }
 
     private fun loadContentsAsync() {
-        Executors.newSingleThreadExecutor().execute {
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
             try {
                 contentsManager.syncContents()
                 activity.runOnUiThread {
@@ -496,6 +497,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 activity.runOnUiThread {
                     state.isLoaded.value = true
                 }
+            } finally {
+                executor.shutdown()
             }
         }
     }

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -693,7 +693,8 @@ class SetupWizardActivity : FragmentActivity() {
         val imageFs = ImageFs.find(this)
         val rootDir = imageFs.rootDir
 
-        Executors.newSingleThreadExecutor().execute {
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
             try {
                 clearRootDir(rootDir)
 
@@ -778,6 +779,8 @@ class SetupWizardActivity : FragmentActivity() {
                     imageFsInstalling.value = false
                     wizardError.value = "ImageFS install failed: ${e.message}"
                 }
+            } finally {
+                executor.shutdown()
             }
         }
     }

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -498,7 +498,8 @@ class ShortcutSettingsComposeDialog private constructor(
     }
 
     private fun loadContentsAsync() {
-        Executors.newSingleThreadExecutor().execute {
+        val executor = Executors.newSingleThreadExecutor()
+        executor.execute {
             try {
                 contentsManager.syncContents()
                 activity.runOnUiThread {
@@ -513,6 +514,8 @@ class ShortcutSettingsComposeDialog private constructor(
                 activity.runOnUiThread {
                     state.isLoaded.value = true
                 }
+            } finally {
+                executor.shutdown()
             }
         }
     }

--- a/app/src/main/feature/stores/epic/service/EpicService.kt
+++ b/app/src/main/feature/stores/epic/service/EpicService.kt
@@ -20,6 +20,7 @@ import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.feature.stores.steam.utils.ContainerUtils
 import com.winlator.cmod.feature.stores.steam.utils.MarkerUtils
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
+import com.winlator.cmod.runtime.session.GameSessionTracker
 import com.winlator.cmod.shared.android.NotificationHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -826,6 +827,19 @@ class EpicService : Service() {
         }
 
         return START_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+
+        if (GameSessionTracker.isSessionActive()) {
+            Timber.tag("EPIC").i("Task removed while a game session is active; keeping service alive")
+        } else if (!hasActiveOperations()) {
+            Timber.tag("EPIC").i("Task removed while idle; stopping service")
+            stopSelf()
+        } else {
+            Timber.tag("EPIC").i("Task removed but active operations are still running; keeping service alive")
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/feature/stores/epic/service/EpicService.kt
+++ b/app/src/main/feature/stores/epic/service/EpicService.kt
@@ -753,7 +753,7 @@ class EpicService : Service() {
 
         val instance = getInstance()
         // Start as foreground service
-        val notification = notificationHelper.createForegroundNotification("Connected")
+        val notification = notificationHelper.createForegroundNotification("Epic connected")
         startForeground(1, notification)
 
         // Determine if we should sync based on the action

--- a/app/src/main/feature/stores/gog/service/GOGService.kt
+++ b/app/src/main/feature/stores/gog/service/GOGService.kt
@@ -16,6 +16,7 @@ import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.feature.stores.steam.utils.ContainerUtils
 import com.winlator.cmod.feature.stores.steam.utils.MarkerUtils
 import com.winlator.cmod.runtime.container.Container
+import com.winlator.cmod.runtime.session.GameSessionTracker
 import com.winlator.cmod.shared.android.NotificationHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -175,7 +176,10 @@ class GOGService : Service() {
         // SYNC & OPERATIONS
         // ==========================================================================
 
-        fun hasActiveOperations(): Boolean = syncInProgress || backgroundSyncJob?.isActive == true
+        fun hasActiveOperations(): Boolean =
+            syncInProgress ||
+                backgroundSyncJob?.isActive == true ||
+                hasActiveDownload()
 
         private fun setSyncInProgress(inProgress: Boolean) {
             syncInProgress = inProgress
@@ -895,6 +899,19 @@ class GOGService : Service() {
         }
 
         return START_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+
+        if (GameSessionTracker.isSessionActive()) {
+            Timber.i("[GOGService] Task removed while a game session is active; keeping service alive")
+        } else if (!hasActiveOperations()) {
+            Timber.i("[GOGService] Task removed while idle; stopping service")
+            stopSelf()
+        } else {
+            Timber.i("[GOGService] Task removed but active operations are still running; keeping service alive")
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/feature/stores/gog/service/GOGService.kt
+++ b/app/src/main/feature/stores/gog/service/GOGService.kt
@@ -828,7 +828,7 @@ class GOGService : Service() {
         Timber.d("[GOGService] onStartCommand() - action: ${intent?.action}")
 
         // Start as foreground service
-        val notification = notificationHelper.createForegroundNotification("Connected")
+        val notification = notificationHelper.createForegroundNotification("GOG connected")
         startForeground(1, notification)
 
         // Determine if we should sync based on the action

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -59,6 +59,7 @@ import com.winlator.cmod.feature.stores.steam.utils.LicenseSerializer
 import com.winlator.cmod.feature.stores.steam.utils.MarkerUtils
 import com.winlator.cmod.feature.stores.steam.utils.Net
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
+import com.winlator.cmod.runtime.session.GameSessionTracker
 import com.winlator.cmod.feature.stores.steam.utils.SteamUtils
 import com.winlator.cmod.feature.stores.steam.utils.generateSteamApp
 import com.winlator.cmod.feature.sync.google.CloudSyncManager
@@ -5027,6 +5028,19 @@ class SteamService :
         return START_STICKY
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+
+        if (GameSessionTracker.isSessionActive()) {
+            Timber.i("Task removed while a game session is active; keeping Steam service alive")
+        } else if (!hasActiveOperations()) {
+            Timber.i("Task removed while Steam service is idle; stopping service")
+            scope.launch { stop() }
+        } else {
+            Timber.i("Task removed but Steam service still has active operations; keeping service alive")
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
 
@@ -5096,6 +5110,7 @@ class SteamService :
             // callback does it for us
         } else {
             clearValues()
+            stopSelf()
         }
     }
 

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -4940,6 +4940,7 @@ class SteamService :
 
                 val event = AndroidEvent.EndProcess
                 PluviaApp.events.emit(event)
+                NotificationHelper.cancelAll(applicationContext)
 
                 return START_NOT_STICKY
             }

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -5145,7 +5145,7 @@ class SteamService :
     }
 
     private fun reconnect() {
-        notificationHelper.notify("Retrying...")
+        notificationHelper.notify("Steam retrying...")
 
         isConnected = false
 
@@ -5277,7 +5277,7 @@ class SteamService :
                 // Tell steam we're online, this allows friends to update.
                 _steamFriends?.setPersonaState(EPersonaState.from(PrefManager.personaState) ?: EPersonaState.Online)
 
-                notificationHelper.notify("Connected")
+                notificationHelper.notify("Steam connected")
 
                 _loginResult = LoginResult.Success
             }
@@ -5300,7 +5300,7 @@ class SteamService :
 
         _isLoggedInFlow.value = false
 
-        notificationHelper.notify("Disconnected...")
+        notificationHelper.notify("Steam disconnected")
 
         if (isLoggingOut || callback.result == EResult.LogonSessionReplaced) {
             // logOut() already handled cleanup; just stop the service.

--- a/app/src/main/feature/sync/google/ContainerBackupManager.java
+++ b/app/src/main/feature/sync/google/ContainerBackupManager.java
@@ -48,7 +48,6 @@ public final class ContainerBackupManager {
   private static final int AUTH_SESSION_RETRY_COUNT = 5;
   private static final long AUTH_SESSION_RETRY_DELAY_MS = 750L;
 
-  private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
   private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
   private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=UTF-8");
   private static final MediaType ZIP_MEDIA_TYPE = MediaType.get("application/zip");
@@ -109,12 +108,12 @@ public final class ContainerBackupManager {
 
   public static void backupContainer(
       Activity activity, Container container, ResultCallback<BackupResult> callback) {
-    EXECUTOR.execute(() -> post(callback, performBackup(activity, container)));
+    executeAsync(() -> post(callback, performBackup(activity, container)));
   }
 
   public static void prepareRestore(
       Activity activity, Container container, ResultCallback<RestorePreparation> callback) {
-    EXECUTOR.execute(() -> post(callback, prepareRestoreInternal(activity, container)));
+    executeAsync(() -> post(callback, prepareRestoreInternal(activity, container)));
   }
 
   public static void restoreContainerFromDriveFile(
@@ -122,7 +121,19 @@ public final class ContainerBackupManager {
       Container container,
       DriveBackupFile driveFile,
       ResultCallback<BackupResult> callback) {
-    EXECUTOR.execute(() -> post(callback, performRestore(activity, container, driveFile)));
+    executeAsync(() -> post(callback, performRestore(activity, container, driveFile)));
+  }
+
+  private static void executeAsync(Runnable action) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
+        () -> {
+          try {
+            action.run();
+          } finally {
+            executor.shutdown();
+          }
+        });
   }
 
   private static <T> void post(ResultCallback<T> callback, T value) {

--- a/app/src/main/runtime/audio/midi/MidiHandler.java
+++ b/app/src/main/runtime/audio/midi/MidiHandler.java
@@ -9,6 +9,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ public class MidiHandler {
   private long lastMidiMsgTime = 0;
   private ShortMessage message = new ShortMessage();
   private ScheduledExecutorService scheduler;
+  private ExecutorService socketExecutor;
   private static final long CHECK_DELAY = 200;
 
   public void setSoundBank(SF2Soundbank soundBank) {
@@ -45,8 +47,13 @@ public class MidiHandler {
   }
 
   public void start() {
+    if (running) {
+      return;
+    }
+
     running = true;
-    Executors.newSingleThreadExecutor()
+    socketExecutor = Executors.newSingleThreadExecutor();
+    socketExecutor
         .execute(
             () -> {
               try {
@@ -78,6 +85,11 @@ public class MidiHandler {
     if (scheduler != null) {
       scheduler.shutdown();
       scheduler = null;
+    }
+
+    if (socketExecutor != null) {
+      socketExecutor.shutdownNow();
+      socketExecutor = null;
     }
   }
 
@@ -114,7 +126,10 @@ public class MidiHandler {
       case RequestCodes.MIDI_CLOSE:
         clearRecv();
         clearSynth();
-        if (scheduler != null) scheduler.shutdown();
+        if (scheduler != null) {
+          scheduler.shutdown();
+          scheduler = null;
+        }
         break;
       case RequestCodes.MIDI_RESET:
         // stub

--- a/app/src/main/runtime/audio/midi/MidiManager.java
+++ b/app/src/main/runtime/audio/midi/MidiManager.java
@@ -36,27 +36,31 @@ public class MidiManager {
   }
 
   public static void load(File file, OnMidiLoadedCallback callback) {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
               try {
                 SF2Soundbank soundBank = new SF2Soundbank(file);
                 callback.onSuccess(soundBank);
               } catch (Exception e) {
                 callback.onFailed(e);
+              } finally {
+                executor.shutdown();
               }
             });
   }
 
   public static void load(InputStream in, OnMidiLoadedCallback callback) throws IOException {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
               try {
                 SF2Soundbank soundBank = new SF2Soundbank(in);
                 callback.onSuccess(soundBank);
               } catch (Exception e) {
                 callback.onFailed(e);
+              } finally {
+                executor.shutdown();
               }
             });
   }
@@ -94,18 +98,22 @@ public class MidiManager {
       return;
     }
 
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              if (FileUtils.copy(context, uri, dest)) {
-                try {
-                  new SF2Soundbank(dest);
-                  callback.onSuccess();
-                } catch (Exception e) {
-                  dest.delete();
-                  callback.onFailed(ERROR_BADFORMAT);
-                }
-              } else callback.onFailed(ERROR_UNKNOWN);
+              try {
+                if (FileUtils.copy(context, uri, dest)) {
+                  try {
+                    new SF2Soundbank(dest);
+                    callback.onSuccess();
+                  } catch (Exception e) {
+                    dest.delete();
+                    callback.onFailed(ERROR_BADFORMAT);
+                  }
+                } else callback.onFailed(ERROR_UNKNOWN);
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 

--- a/app/src/main/runtime/container/ContainerManager.java
+++ b/app/src/main/runtime/container/ContainerManager.java
@@ -153,11 +153,15 @@ public class ContainerManager {
   public void createContainerAsync(
       final JSONObject data, ContentsManager contentsManager, Callback<Container> callback) {
     final Handler handler = new Handler(Looper.getMainLooper());
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              final Container container = createContainer(data, contentsManager);
-              handler.post(() -> callback.call(container));
+              try {
+                final Container container = createContainer(data, contentsManager);
+                handler.post(() -> callback.call(container));
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 
@@ -168,25 +172,33 @@ public class ContainerManager {
   public void duplicateContainerAsync(
       Container container, Callback<Integer> progressCallback, Runnable callback) {
     final Handler handler = new Handler(Looper.getMainLooper());
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              Callback<Integer> uiProgress =
-                  progressCallback != null
-                      ? progress -> handler.post(() -> progressCallback.call(progress))
-                      : null;
-              duplicateContainer(container, uiProgress);
-              handler.post(callback);
+              try {
+                Callback<Integer> uiProgress =
+                    progressCallback != null
+                        ? progress -> handler.post(() -> progressCallback.call(progress))
+                        : null;
+                duplicateContainer(container, uiProgress);
+                handler.post(callback);
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 
   public void removeContainerAsync(Container container, Runnable callback) {
     final Handler handler = new Handler(Looper.getMainLooper());
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              removeContainer(container);
-              handler.post(callback);
+              try {
+                removeContainer(container);
+                handler.post(callback);
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -68,6 +68,7 @@ import com.winlator.cmod.feature.setup.SetupWizardActivity;
 import com.winlator.cmod.runtime.container.Container;
 import com.winlator.cmod.runtime.container.ContainerManager;
 import com.winlator.cmod.runtime.container.Shortcut;
+import com.winlator.cmod.runtime.session.GameSessionTracker;
 import com.winlator.cmod.shared.ui.dialog.ContentDialog;
 import com.winlator.cmod.feature.settings.DebugDialog;
 import com.winlator.cmod.feature.settings.DXVKConfigUtils;
@@ -488,6 +489,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        GameSessionTracker.onSessionStarted();
         AppUtils.hideSystemUI(this);
         AppUtils.keepScreenOn(this);
         // Clean up any shared debug logs and prepare for fresh session logging
@@ -1160,7 +1162,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 // No profile defined, run the simulated dialog confirmation for input controls
                 simulateConfirmInputControlsDialog();
             }
-            Executors.newSingleThreadExecutor().execute(() -> {
+            final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.execute(() -> {
+                try {
                 // Cancel any pending post-game update check since we're launching a new game
                 UpdateChecker.INSTANCE.cancelPostGameCheck();
 
@@ -1214,6 +1218,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     setupXEnvironment();
                 } catch (PackageManager.NameNotFoundException e) {
                     throw new RuntimeException(e);
+                }
+                } finally {
+                    executor.shutdown();
                 }
             });
         };
@@ -1717,7 +1724,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
         Log.d("XServerDisplayActivity",
                 "Steam wrapper terminated with status " + status + "; watching Wine processes before exiting");
 
-        Executors.newSingleThreadExecutor().execute(() -> {
+        final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
             try {
                 long startTime = System.currentTimeMillis();
                 long lastNonCoreSeenAt = -1L;
@@ -1770,6 +1778,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 }
             } finally {
                 steamExitWatchRunning.set(false);
+                executor.shutdown();
             }
         });
 
@@ -2074,6 +2083,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        GameSessionTracker.onSessionEnded();
         super.onDestroy();
         // Schedule a deferred update check 10 s after game exit
         UpdateChecker.INSTANCE.schedulePostGameCheck(this);

--- a/app/src/main/runtime/display/environment/ImageFsInstaller.java
+++ b/app/src/main/runtime/display/environment/ImageFsInstaller.java
@@ -96,68 +96,72 @@ public abstract class ImageFsInstaller {
 
     SettingsConfig.resetEmulatorsVersion(activity);
 
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              clearRootDir(rootDir);
-              final byte compressionRatio = 22;
-              final long contentLength =
-                  (long) (FileUtils.getSize(activity, "imagefs.txz") * (100.0f / compressionRatio));
-              AtomicLong totalSizeRef = new AtomicLong();
+              try {
+                clearRootDir(rootDir);
+                final byte compressionRatio = 22;
+                final long contentLength =
+                    (long) (FileUtils.getSize(activity, "imagefs.txz") * (100.0f / compressionRatio));
+                AtomicLong totalSizeRef = new AtomicLong();
 
-              boolean success =
-                  TarCompressorUtils.extract(
-                      TarCompressorUtils.Type.XZ,
-                      activity,
-                      "imagefs.txz",
-                      rootDir,
-                      (file, size) -> {
-                        if (size > 0) {
-                          long totalSize = totalSizeRef.addAndGet(size);
-                          final int progress = (int) (((float) totalSize / contentLength) * 100);
-                          if (listener != null) listener.onProgress(progress);
+                boolean success =
+                    TarCompressorUtils.extract(
+                        TarCompressorUtils.Type.XZ,
+                        activity,
+                        "imagefs.txz",
+                        rootDir,
+                        (file, size) -> {
+                          if (size > 0) {
+                            long totalSize = totalSizeRef.addAndGet(size);
+                            final int progress = (int) (((float) totalSize / contentLength) * 100);
+                            if (listener != null) listener.onProgress(progress);
+                          }
+                          return file;
+                        });
+
+                if (success) {
+                  ExecutorService pool = Executors.newFixedThreadPool(3);
+                  CountDownLatch latch = new CountDownLatch(3);
+                  pool.execute(
+                      () -> {
+                        try {
+                          installWineFromAssets(activity);
+                        } finally {
+                          latch.countDown();
                         }
-                        return file;
                       });
+                  pool.execute(
+                      () -> {
+                        try {
+                          installDriversFromAssets(activity);
+                        } finally {
+                          latch.countDown();
+                        }
+                      });
+                  pool.execute(
+                      () -> {
+                        try {
+                          installGuestExtras(activity, rootDir);
+                        } finally {
+                          latch.countDown();
+                        }
+                      });
+                  try {
+                    latch.await();
+                  } catch (InterruptedException ignored) {
+                  }
+                  pool.shutdown();
+                  imageFs.createImgVersionFile(LATEST_VERSION);
+                  resetContainerImgVersions(activity);
+                } else
+                  AppUtils.showToast(activity, R.string.setup_wizard_unable_to_install_system_files);
 
-              if (success) {
-                ExecutorService pool = Executors.newFixedThreadPool(3);
-                CountDownLatch latch = new CountDownLatch(3);
-                pool.execute(
-                    () -> {
-                      try {
-                        installWineFromAssets(activity);
-                      } finally {
-                        latch.countDown();
-                      }
-                    });
-                pool.execute(
-                    () -> {
-                      try {
-                        installDriversFromAssets(activity);
-                      } finally {
-                        latch.countDown();
-                      }
-                    });
-                pool.execute(
-                    () -> {
-                      try {
-                        installGuestExtras(activity, rootDir);
-                      } finally {
-                        latch.countDown();
-                      }
-                    });
-                try {
-                  latch.await();
-                } catch (InterruptedException ignored) {
-                }
-                pool.shutdown();
-                imageFs.createImgVersionFile(LATEST_VERSION);
-                resetContainerImgVersions(activity);
-              } else
-                AppUtils.showToast(activity, R.string.setup_wizard_unable_to_install_system_files);
-
-              if (listener != null) listener.onFinished(success);
+                if (listener != null) listener.onFinished(success);
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 
@@ -178,75 +182,79 @@ public abstract class ImageFsInstaller {
     activity.runOnUiThread(() -> dialog.show(R.string.setup_wizard_installing_system_files));
 
     File rootDir = imageFs.getRootDir();
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              clearRootDir(rootDir);
-              final byte compressionRatio = 22;
-              final long contentLength =
-                  (long) (FileUtils.getSize(activity, "imagefs.txz") * (100.0f / compressionRatio));
-              AtomicLong totalSizeRef = new AtomicLong();
+              try {
+                clearRootDir(rootDir);
+                final byte compressionRatio = 22;
+                final long contentLength =
+                    (long) (FileUtils.getSize(activity, "imagefs.txz") * (100.0f / compressionRatio));
+                AtomicLong totalSizeRef = new AtomicLong();
 
-              boolean success =
-                  TarCompressorUtils.extract(
-                      TarCompressorUtils.Type.XZ,
-                      activity,
-                      "imagefs.txz",
-                      rootDir,
-                      (file, size) -> {
-                        if (size > 0) {
-                          long totalSize = totalSizeRef.addAndGet(size);
-                          final int progress = (int) (((float) totalSize / contentLength) * 100);
-                          activity.runOnUiThread(() -> dialog.setProgress(progress));
+                boolean success =
+                    TarCompressorUtils.extract(
+                        TarCompressorUtils.Type.XZ,
+                        activity,
+                        "imagefs.txz",
+                        rootDir,
+                        (file, size) -> {
+                          if (size > 0) {
+                            long totalSize = totalSizeRef.addAndGet(size);
+                            final int progress = (int) (((float) totalSize / contentLength) * 100);
+                            activity.runOnUiThread(() -> dialog.setProgress(progress));
+                          }
+                          return file;
+                        });
+
+                if (success) {
+                  ExecutorService pool = Executors.newFixedThreadPool(2);
+                  CountDownLatch latch = new CountDownLatch(2);
+                  pool.execute(
+                      () -> {
+                        try {
+                          String[] versions =
+                              activity.getResources().getStringArray(R.array.wine_entries);
+                          for (String version : versions) {
+                            File outFile = new File(rootDir, "/opt/" + version);
+                            outFile.mkdirs();
+                            TarCompressorUtils.extract(
+                                TarCompressorUtils.Type.XZ, activity, version + ".txz", outFile);
+                          }
+                        } catch (Exception e) {
+                          /* wine assets may not exist */
+                        } finally {
+                          latch.countDown();
                         }
-                        return file;
                       });
-
-              if (success) {
-                ExecutorService pool = Executors.newFixedThreadPool(2);
-                CountDownLatch latch = new CountDownLatch(2);
-                pool.execute(
-                    () -> {
-                      try {
-                        String[] versions =
-                            activity.getResources().getStringArray(R.array.wine_entries);
-                        for (String version : versions) {
-                          File outFile = new File(rootDir, "/opt/" + version);
-                          outFile.mkdirs();
-                          TarCompressorUtils.extract(
-                              TarCompressorUtils.Type.XZ, activity, version + ".txz", outFile);
+                  pool.execute(
+                      () -> {
+                        try {
+                          installGuestExtras(activity, rootDir);
+                        } finally {
+                          latch.countDown();
                         }
-                      } catch (Exception e) {
-                        /* wine assets may not exist */
-                      } finally {
-                        latch.countDown();
-                      }
-                    });
-                pool.execute(
-                    () -> {
-                      try {
-                        installGuestExtras(activity, rootDir);
-                      } finally {
-                        latch.countDown();
-                      }
-                    });
-                try {
-                  latch.await();
-                } catch (InterruptedException ignored) {
+                      });
+                  try {
+                    latch.await();
+                  } catch (InterruptedException ignored) {
+                  }
+                  pool.shutdown();
+                  clearSteamDllMarkers(activity);
+                  imageFs.createImgVersionFile(LATEST_VERSION);
+                } else {
+                  activity.runOnUiThread(
+                      () ->
+                          AppUtils.showToast(
+                              activity,
+                              R.string.setup_wizard_unable_to_install_system_files,
+                              android.widget.Toast.LENGTH_LONG));
                 }
-                pool.shutdown();
-                clearSteamDllMarkers(activity);
-                imageFs.createImgVersionFile(LATEST_VERSION);
-              } else {
-                activity.runOnUiThread(
-                    () ->
-                        AppUtils.showToast(
-                            activity,
-                            R.string.setup_wizard_unable_to_install_system_files,
-                            android.widget.Toast.LENGTH_LONG));
-              }
 
-              dialog.closeOnUiThread();
+                dialog.closeOnUiThread();
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -29,8 +29,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class WinHandler {
@@ -75,6 +77,9 @@ public class WinHandler {
   private boolean xinputDisabledInitialized = false;
   private ExternalController currentController;
   private final GamepadState outputGamepadState = new GamepadState();
+  private ExecutorService sendExecutor;
+  private ExecutorService receiveExecutor;
+  private ScheduledExecutorService delayedCommandExecutor;
   private int lastGamepadSource = 0;
   private float smoothedGyroX = 0.0f;
   private float smoothedGyroY = 0.0f;
@@ -310,8 +315,8 @@ public class WinHandler {
   }
 
   private void startSendThread() {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    sendExecutor = Executors.newSingleThreadExecutor();
+    sendExecutor.execute(
             () -> {
               while (this.running) {
                 synchronized (this.actions) {
@@ -329,14 +334,17 @@ public class WinHandler {
 
   public void stop() {
     this.running = false;
+    this.initReceived = false;
     closeFakeInputWriter();
     if (this.socket != null) {
       this.socket.close();
       this.socket = null;
     }
     synchronized (this.actions) {
+      this.actions.clear();
       this.actions.notify();
     }
+    shutdownExecutors();
   }
 
   private void handleRequest(byte requestCode, int port) {
@@ -395,8 +403,8 @@ public class WinHandler {
     }
     this.running = true;
     startSendThread();
-    Executors.newSingleThreadExecutor()
-        .execute(
+    receiveExecutor = Executors.newSingleThreadExecutor();
+    receiveExecutor.execute(
             () -> {
               try {
                 this.socket = new DatagramSocket((SocketAddress) null);
@@ -413,6 +421,21 @@ public class WinHandler {
               } catch (IOException e) {
               }
             });
+  }
+
+  private void shutdownExecutors() {
+    if (sendExecutor != null) {
+      sendExecutor.shutdownNow();
+      sendExecutor = null;
+    }
+    if (receiveExecutor != null) {
+      receiveExecutor.shutdownNow();
+      receiveExecutor = null;
+    }
+    if (delayedCommandExecutor != null) {
+      delayedCommandExecutor.shutdownNow();
+      delayedCommandExecutor = null;
+    }
   }
 
   public void sendGamepadState() {
@@ -995,7 +1018,9 @@ public class WinHandler {
     if (command == null || command.trim().isEmpty() || delaySeconds < 0) {
       return;
     }
-    Executors.newSingleThreadScheduledExecutor()
-        .schedule(() -> exec(command), delaySeconds, TimeUnit.SECONDS);
+    if (delayedCommandExecutor == null || delayedCommandExecutor.isShutdown()) {
+      delayedCommandExecutor = Executors.newSingleThreadScheduledExecutor();
+    }
+    delayedCommandExecutor.schedule(() -> exec(command), delaySeconds, TimeUnit.SECONDS);
   }
 }

--- a/app/src/main/runtime/session/GameSessionTracker.kt
+++ b/app/src/main/runtime/session/GameSessionTracker.kt
@@ -1,0 +1,20 @@
+package com.winlator.cmod.runtime.session
+
+import java.util.concurrent.atomic.AtomicInteger
+
+object GameSessionTracker {
+    private val activeSessions = AtomicInteger(0)
+
+    @JvmStatic
+    fun onSessionStarted() {
+        activeSessions.incrementAndGet()
+    }
+
+    @JvmStatic
+    fun onSessionEnded() {
+        activeSessions.updateAndGet { count -> if (count > 0) count - 1 else 0 }
+    }
+
+    @JvmStatic
+    fun isSessionActive(): Boolean = activeSessions.get() > 0
+}

--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -219,8 +219,8 @@ public abstract class ProcessHelper {
   }
 
   private static void createDebugThread(final InputStream inputStream) {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
               try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
                 String line;
@@ -234,14 +234,16 @@ public abstract class ProcessHelper {
                 }
               } catch (IOException e) {
                 Log.e("ProcessHelper", "Error in debug thread", e);
+              } finally {
+                executor.shutdown();
               }
             });
   }
 
   private static void createWaitForThread(
       java.lang.Process process, final Callback<Integer> terminationCallback) {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             new Runnable() {
               @Override
               public void run() {
@@ -250,7 +252,10 @@ public abstract class ProcessHelper {
                   drainDeadChildren("process waitFor");
                   terminationCallback.call(status);
                 } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
                   Log.e("ProcessHelper", "Error waiting for process termination", e);
+                } finally {
+                  executor.shutdown();
                 }
               }
             });

--- a/app/src/main/runtime/wine/WineRequestHandler.java
+++ b/app/src/main/runtime/wine/WineRequestHandler.java
@@ -25,6 +25,7 @@ public class WineRequestHandler {
 
   private Context context;
   private ServerSocket serverSocket;
+  private ExecutorService requestExecutor;
 
   public ServerSocket getServerSocket() {
     return serverSocket;
@@ -35,8 +36,12 @@ public class WineRequestHandler {
   }
 
   public void start() {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
-    executor.execute(
+    if (requestExecutor != null && !requestExecutor.isShutdown()) {
+      return;
+    }
+
+    requestExecutor = Executors.newSingleThreadExecutor();
+    requestExecutor.execute(
         () -> {
           try {
             serverSocket = new ServerSocket(20000);
@@ -48,6 +53,8 @@ public class WineRequestHandler {
               handleRequest(inputStream, outputStream, requestCode);
             }
           } catch (IOException e) {
+          } finally {
+            serverSocket = null;
           }
         });
   }
@@ -58,6 +65,11 @@ public class WineRequestHandler {
         serverSocket.close();
       } catch (IOException e) {
       }
+    }
+
+    if (requestExecutor != null) {
+      requestExecutor.shutdownNow();
+      requestExecutor = null;
     }
   }
 

--- a/app/src/main/shared/android/NotificationHelper.kt
+++ b/app/src/main/shared/android/NotificationHelper.kt
@@ -26,6 +26,13 @@ class NotificationHelper
             private const val NOTIFICATION_ID = 1
 
             const val ACTION_EXIT = BuildConfig.APPLICATION_ID + ".EXIT"
+
+            @JvmStatic
+            fun cancelAll(context: Context) {
+                val notificationManager =
+                    context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+                notificationManager.cancelAll()
+            }
         }
 
         private val notificationManager: NotificationManager =

--- a/app/src/main/shared/io/FileUtils.java
+++ b/app/src/main/shared/io/FileUtils.java
@@ -456,7 +456,15 @@ public abstract class FileUtils {
   }
 
   public static void getSizeAsync(File file, Callback<Long> callback) {
-    Executors.newSingleThreadExecutor().execute(() -> getSize(file, callback));
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
+        () -> {
+          try {
+            getSize(file, callback);
+          } finally {
+            executor.shutdown();
+          }
+        });
   }
 
   private static void getSize(File file, Callback<Long> callback) {

--- a/app/src/main/shared/io/HttpUtils.java
+++ b/app/src/main/shared/io/HttpUtils.java
@@ -34,7 +34,15 @@ public abstract class HttpUtils {
   }
 
   public static void download(final String url, final Callback<String> onDownloadComplete) {
-    Executors.newSingleThreadExecutor().execute(() -> downloadAsync(url, onDownloadComplete));
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
+        () -> {
+          try {
+            downloadAsync(url, onDownloadComplete);
+          } finally {
+            executor.shutdown();
+          }
+        });
   }
 
   private static void downloadAsync(
@@ -83,27 +91,31 @@ public abstract class HttpUtils {
     final DownloadProgressDialog dialog = new DownloadProgressDialog(activity);
     final AtomicBoolean interruptRef = new AtomicBoolean();
     dialog.show(() -> interruptRef.set(true));
-    Executors.newSingleThreadExecutor()
-        .execute(
+    final java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.execute(
             () -> {
-              downloadAsync(
-                  url,
-                  destination,
-                  interruptRef,
-                  (progress) -> {
-                    activity.runOnUiThread(
-                        () -> {
-                          dialog.setProgress(progress);
-                        });
-                  },
-                  (success) -> {
-                    if (!success && destination.isFile()) destination.delete();
-                    activity.runOnUiThread(
-                        () -> {
-                          dialog.close();
-                          onDownloadComplete.call(success);
-                        });
-                  });
+              try {
+                downloadAsync(
+                    url,
+                    destination,
+                    interruptRef,
+                    (progress) -> {
+                      activity.runOnUiThread(
+                          () -> {
+                            dialog.setProgress(progress);
+                          });
+                    },
+                    (success) -> {
+                      if (!success && destination.isFile()) destination.delete();
+                      activity.runOnUiThread(
+                          () -> {
+                            dialog.close();
+                            onDownloadComplete.call(success);
+                          });
+                    });
+              } finally {
+                executor.shutdown();
+              }
             });
   }
 }


### PR DESCRIPTION
- Replaces process-kill app exit with explicit shutdown of update loops, store services, and app task removal.
- Adds `onTaskRemoved()` handling for Steam, Epic, and GOG services so idle services stop instead of lingering after the task is dismissed.
- Keeps store services alive while a game session is active to avoid mid-session shutdown from the new task-removal guards.
- Fixes the Steam stop path so the service calls `stopSelf()` even when already disconnected.
- Shuts down one-shot and session-owned executors after work completes so helper threads do not remain resident until process death.
- Clears all app-owned notifications on explicit app exit and on the notification action exit path.
- Sweeps stale app-owned notifications on the next app launch so abnormal kills do not leave old notifications behind.
- Addresses reports that the app can appear closed while still holding RAM and continuing background activity.
- Validation: `git diff --check`
- Validation: Gradle compilation was not run here because `java` and `JAVA_HOME` are not available on this machine.