### PR TITLE
Align controller and touchscreen fixes with upstream

### DIFF
--- a/app/src/main/cpp/winlator/fakeinput.cpp
+++ b/app/src/main/cpp/winlator/fakeinput.cpp
@@ -35,12 +35,12 @@
 
 #define EXPORT __attribute__((visibility("default"))) extern "C"
 
-static constexpr uint16_t GAMEPAD_VENDOR_ID = 0x1234;
-static constexpr uint16_t GAMEPAD_PRODUCT_ID = 0x5678;
-static constexpr uint16_t GAMEPAD_VERSION = 0x0001;
-static constexpr const char *GAMEPAD_NAME = "Generic HID Gamepad";
-static constexpr const char *GAMEPAD_PHYS = "usb-fakeinput/input0";
-static constexpr const char *GAMEPAD_UNIQ = "000000000001";
+static constexpr uint16_t GAMEPAD_VENDOR_ID_BASE = 0x1234;
+static constexpr uint16_t GAMEPAD_PRODUCT_ID_BASE = 0x5678;
+static constexpr uint16_t GAMEPAD_VERSION = 0x0110;
+static constexpr const char *GAMEPAD_NAME_TEMPLATE = "Generic HID Gamepad %d";
+static constexpr const char *GAMEPAD_PHYS_TEMPLATE = "usb-fakeinput/input%d";
+static constexpr const char *GAMEPAD_UNIQ_TEMPLATE = "0000000000%02d";
 static constexpr uint8_t GAMEPAD_AXIS_COUNT = 8;
 static constexpr uint8_t GAMEPAD_BUTTON_COUNT = 11;
 
@@ -192,12 +192,12 @@ __attribute__((visibility("hidden"))) int get_event_number(const char *event) {
 }
 
 __attribute__((visibility("hidden"))) static void
-copy_ioctl_string(int op, void *argp, const char *value) {
+copy_slot_ioctl_string(int op, void *argp, const char *format, int event_number) {
   size_t size = _IOC_SIZE(op);
   if (!argp || size == 0)
     return;
 
-  snprintf(static_cast<char *>(argp), size, "%s", value);
+  snprintf(static_cast<char *>(argp), size, format, event_number);
 }
 
 __attribute__((visibility("hidden"))) static bool is_fake_input_fd(int fd) {
@@ -412,6 +412,7 @@ EXPORT int ioctl(int fd, int op, ...) {
   int type = (op >> 8 & 0xFF);
   int number = (op >> 0 & 0xFF);
   const char *event = controller->second;
+  int event_number = get_event_number(event);
 
   if (type == 0x45 && number == 0x1) {
     Logger::log("Hooking ioctl EVIOCGVERSION for event %s\n", event);
@@ -423,22 +424,22 @@ EXPORT int ioctl(int fd, int op, ...) {
     struct input_id id;
     memset(&id, 0, sizeof(id));
     id.bustype = 0x03;
-    id.vendor = GAMEPAD_VENDOR_ID;
-    id.product = GAMEPAD_PRODUCT_ID;
+    id.vendor = static_cast<uint16_t>(GAMEPAD_VENDOR_ID_BASE + event_number);
+    id.product = static_cast<uint16_t>(GAMEPAD_PRODUCT_ID_BASE + event_number);
     id.version = GAMEPAD_VERSION;
     memcpy(argp, (void *)&id, sizeof(id));
     return 0;
   } else if (type == 0x45 && number == 0x6) {
     Logger::log("Hooking ioctl EVIOCGNAME for event %s\n", event);
-    copy_ioctl_string(op, argp, GAMEPAD_NAME);
+    copy_slot_ioctl_string(op, argp, GAMEPAD_NAME_TEMPLATE, event_number);
     return 0;
   } else if (type == 0x45 && number == 0x7) {
     Logger::log("Hooking ioctl EVIOCGPHYS for event %s\n", event);
-    copy_ioctl_string(op, argp, GAMEPAD_PHYS);
+    copy_slot_ioctl_string(op, argp, GAMEPAD_PHYS_TEMPLATE, event_number);
     return 0;
   } else if (type == 0x45 && number == 0x8) {
     Logger::log("Hooking ioctl EVIOCGUNIQ for event %s\n", event);
-    copy_ioctl_string(op, argp, GAMEPAD_UNIQ);
+    copy_slot_ioctl_string(op, argp, GAMEPAD_UNIQ_TEMPLATE, event_number);
     return 0;
   } else if (type == 0x45 && number == 0x9) {
     Logger::log("Hooking ioctl EVIOCGPROP for event %s\n", event);
@@ -554,7 +555,7 @@ EXPORT int ioctl(int fd, int op, ...) {
     return 0;
   } else if (type == 0x6A && number == 0x13) {
     Logger::log("Hooking ioctl JSIOCGNAME(len) for event %s\n", event);
-    copy_ioctl_string(op, argp, GAMEPAD_NAME);
+    copy_slot_ioctl_string(op, argp, GAMEPAD_NAME_TEMPLATE, event_number);
     return 0;
   } else {
     Logger::log("Unhandled evdev ioctl, type %d number %d\n", type, number);
@@ -612,8 +613,14 @@ EXPORT ssize_t write(int fd, const void *buf, size_t count) {
   auto controller = controller_map.find(fd);
   if (controller != controller_map.end() &&
       count == sizeof(struct input_event)) {
+    const struct input_event *ev = static_cast<const struct input_event *>(buf);
     uint16_t slot = static_cast<uint16_t>(get_event_number(controller->second));
-    check_ff_event(static_cast<const struct input_event *>(buf), slot);
+    check_ff_event(ev, slot);
+    // FF control events are commands sent to the fake device, not controller input.
+    // Writing them back into the fake evdev file lets Wine read them as input and can
+    // stall or corrupt controller state, so consume them here.
+    if (ev->type == EV_FF)
+      return static_cast<ssize_t>(count);
   }
   return my_write(fd, buf, count);
 }
@@ -622,12 +629,31 @@ EXPORT ssize_t writev(int fd, const struct iovec *iov, int iovcnt) {
   auto controller = controller_map.find(fd);
   if (controller != controller_map.end()) {
     uint16_t slot = static_cast<uint16_t>(get_event_number(controller->second));
+    std::vector<struct iovec> filtered;
+    filtered.reserve(iovcnt);
+    ssize_t filtered_out_bytes = 0;
+
     for (int i = 0; i < iovcnt; i++) {
       if (iov[i].iov_len == sizeof(struct input_event)) {
-        check_ff_event(static_cast<const struct input_event *>(iov[i].iov_base),
-                       slot);
+        const struct input_event *ev =
+            static_cast<const struct input_event *>(iov[i].iov_base);
+        check_ff_event(ev, slot);
+        if (ev->type == EV_FF) {
+          filtered_out_bytes += static_cast<ssize_t>(iov[i].iov_len);
+          continue;
+        }
       }
+      filtered.push_back(iov[i]);
     }
+
+    if (filtered.empty())
+      return filtered_out_bytes;
+
+    ssize_t written =
+        syscall(SYS_writev, fd, filtered.data(), static_cast<int>(filtered.size()));
+    if (written < 0)
+      return written;
+    return written + filtered_out_bytes;
   }
   return syscall(SYS_writev, fd, iov, iovcnt);
 }

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -267,6 +267,8 @@ class GameSettingsStateHolder {
     // Input
     val controlsProfileEntries = mutableStateOf<List<String>>(emptyList())
     val selectedControlsProfile = mutableIntStateOf(0)
+    val numControllersEntries = mutableStateOf<List<String>>(emptyList())
+    val selectedNumControllers = mutableIntStateOf(0)
     val disableXInput = mutableStateOf(false)
     val simTouchScreen = mutableStateOf(false)
     val sdl2Compatibility = mutableStateOf(false)
@@ -2636,6 +2638,15 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 entries = state.controlsProfileEntries.value,
                 selectedIndex = state.selectedControlsProfile.intValue,
                 onSelected = { state.selectedControlsProfile.intValue = it }
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            SettingDropdown(
+                label = stringResource(R.string.num_controllers),
+                entries = state.numControllersEntries.value,
+                selectedIndex = state.selectedNumControllers.intValue,
+                onSelected = { state.selectedNumControllers.intValue = it }
             )
 
             Spacer(Modifier.height(12.dp))

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -449,6 +449,13 @@ class ShortcutSettingsComposeDialog private constructor(
             context.resources.getStringArray(R.array.dinput_mapper_type_entries).toList()
         state.dInputMapperTypeEntries.value = dInputArr
 
+        val numControllersArr =
+            context.resources.getStringArray(R.array.num_controllers_entries).toList()
+        state.numControllersEntries.value = numControllersArr
+        val numControllers = shortcut.getExtra("numControllers", "1").toIntOrNull() ?: 1
+        state.selectedNumControllers.intValue =
+            (numControllers - 1).coerceIn(0, (numControllersArr.size - 1).coerceAtLeast(0))
+
         // Startup selection
         val startupArr =
             context.resources.getStringArray(R.array.startup_selection_entries).toList()
@@ -1005,6 +1012,16 @@ class ShortcutSettingsComposeDialog private constructor(
                 "controlsProfile",
                 if (controlsProfile > 0) controlsProfile.toString() else null
             )
+
+            val numControllerEntries = state.numControllersEntries.value
+            val numControllerIndex = state.selectedNumControllers.intValue
+            val numControllers =
+                if (numControllerIndex in numControllerEntries.indices) {
+                    numControllerEntries[numControllerIndex].toIntOrNull() ?: (numControllerIndex + 1)
+                } else {
+                    1
+                }
+            shortcut.putExtra("numControllers", numControllers.toString())
 
             // CPU list
             val cpuList = buildCpuListString(state.cpuChecked.value)
@@ -1656,7 +1673,7 @@ class ShortcutSettingsComposeDialog private constructor(
 
         // Reset container-derived state to the new container. Shortcut-only
         // fields (name, launchExePath, execArgs, refreshRate, controlsProfile,
-        // disableXInput, simTouchScreen) travel with the shortcut and are not
+        // numControllers, disableXInput, simTouchScreen) travel with the shortcut and are not
         // touched here.
         applyContainerDefaultsToState(newContainer)
         loadGraphicsDriverConfigState(newContainer)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -222,6 +222,12 @@
         <item>Box64</item>
         <item>Wowbox64</item>
     </string-array>
+    <string-array name="num_controllers_entries">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+    </string-array>
     <string-array name="wine_entries">
     </string-array>
 </resources>

--- a/app/src/main/res/values/refs.xml
+++ b/app/src/main/res/values/refs.xml
@@ -12,6 +12,7 @@
 
     <item type="id" name="main_menu_keyboard" />
     <item type="id" name="main_menu_fps_monitor" />
+    <item type="id" name="main_menu_controller_manager" />
     <item type="id" name="main_menu_relative_mouse_movement" />
     <item type="id" name="main_menu_disable_mouse" />
     <item type="id" name="main_menu_screen_effects" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="shortcuts_properties_exec_arguments">Exec Arguments</string>
     <string name="shortcuts_properties_target_path">Target Path</string>
     <string name="shortcuts_properties_disable_xinput">Disable Xinput (For Exclusive M/KB Control)</string>
+    <string name="num_controllers">Number of Controllers</string>
     <string name="shortcuts_properties_exclusive_input">Exclusive Input</string>
     <string name="shortcuts_properties_custom_game_settings">Custom Game Settings</string>
     <string name="shortcuts_properties_use_cold_client">Use ColdClient Launcher</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -103,6 +103,7 @@ import com.winlator.cmod.runtime.wine.WineThemeManager;
 import com.winlator.cmod.runtime.wine.WineUtils;
 import com.winlator.cmod.runtime.compat.fexcore.FEXCoreManager;
 import com.winlator.cmod.runtime.compat.gamefixes.GameFixes;
+import com.winlator.cmod.runtime.input.ControllerAssignmentDialog;
 import com.winlator.cmod.runtime.input.InputControlsDialog;
 import com.winlator.cmod.runtime.input.controls.ControlsProfile;
 import com.winlator.cmod.runtime.input.controls.ControllerManager;
@@ -2319,6 +2320,10 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 showInputControlsDialog();
                 drawerLayout.closeDrawers();
                 break;
+            case R.id.main_menu_controller_manager:
+                ControllerAssignmentDialog.show(this, winHandler);
+                drawerLayout.closeDrawers();
+                break;
             case R.id.main_menu_fps_monitor:
                 if (frameRating == null) {
                     FrameLayout rootView = findViewById(R.id.FLXServerDisplay);
@@ -3043,6 +3048,10 @@ public class XServerDisplayActivity extends AppCompatActivity {
             }
         }
 
+        // Reserve controller slots before Wine starts so connected pads are
+        // visible immediately without waiting for a first input event.
+        winHandler.preAssignConnectedControllers();
+
         // Start all environment components (XServer, Audio, etc.)
         environment.startEnvironmentComponents();
 
@@ -3684,6 +3693,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
         touchpadView.setPointerButtonRightEnabled(false);
 
         inputControlsView.invalidate();
+        if (winHandler != null) {
+            winHandler.sendGamepadState();
+        }
     }
 
     private void hideInputControls() {
@@ -3696,6 +3708,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
         touchpadView.setPointerButtonRightEnabled(true);
 
         inputControlsView.invalidate();
+        if (winHandler != null) {
+            winHandler.sendGamepadState();
+        }
     }
 
     private void extractGraphicsDriverFiles() {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -295,6 +295,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
     private Handler  timeoutHandler = new Handler(Looper.getMainLooper());
     private Runnable hideControlsRunnable;
+    private boolean forwardingWakeTouchGesture = false;
     private final AtomicBoolean exitRequested = new AtomicBoolean(false);
     private final AtomicBoolean steamExitWatchRunning = new AtomicBoolean(false);
 
@@ -570,11 +571,9 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
 
         // Handler and Runnable to manage timeout for hiding controls
-
-        boolean isTimeoutEnabled = preferences.getBoolean("touchscreen_timeout_enabled", true);
-
         hideControlsRunnable = () -> {
-            if (isTimeoutEnabled) {
+            if (isTouchscreenTimeoutEnabled() && hasActiveTouchscreenProfile()) {
+                forwardingWakeTouchGesture = false;
                 inputControlsView.setVisibility(View.GONE);
                 Log.d("XServerDisplayActivity", "Touchscreen controls hidden after timeout.");
             }
@@ -1578,6 +1577,12 @@ public class XServerDisplayActivity extends AppCompatActivity {
         if (environment != null) {
             xServerView.onResume();
             environment.onResume();
+        }
+        if (inputControlsView != null && touchpadView != null) {
+            ControlsProfile activeProfile = inputControlsView.getProfile();
+            if (activeProfile == null) activeProfile = resolvePreferredStartupProfile();
+            if (activeProfile != null) showInputControls(activeProfile);
+            else startTouchscreenTimeout();
         }
         startTime = System.currentTimeMillis();
         handler.postDelayed(savePlaytimeRunnable, SAVE_INTERVAL_MS);
@@ -3121,14 +3126,6 @@ public class XServerDisplayActivity extends AppCompatActivity {
         rootView.addView(inputControlsView);
 
 
-        startTouchscreenTimeout();
-
-        // Inside onCreate(), after initializing controls
-        boolean isTimeoutEnabled = preferences.getBoolean("touchscreen_timeout_enabled", false);
-        if (isTimeoutEnabled) {
-            startTouchscreenTimeout();
-        }
-
         // FPS monitor is a global sticky preference - persists across all games/containers
         effectiveShowFPS = preferences.getBoolean("fps_monitor_enabled", false);
         if (effectiveShowFPS) {
@@ -3161,6 +3158,8 @@ public class XServerDisplayActivity extends AppCompatActivity {
             String simTouchScreen = shortcut.getExtra("simTouchScreen");
             touchpadView.setSimTouchScreen(simTouchScreen.equals("1"));
         }
+
+        startTouchscreenTimeout();
 
         AppUtils.observeSoftKeyboardVisibility(drawerLayout, renderer::setScreenOffsetYRelativeToCursor);
     }
@@ -3609,20 +3608,97 @@ public class XServerDisplayActivity extends AppCompatActivity {
         return null;
     }
 
+    private boolean hasActiveTouchscreenProfile() {
+        return inputControlsView != null && inputControlsView.getProfile() != null;
+    }
+
+    private boolean isTouchscreenTimeoutEnabled() {
+        return preferences.getBoolean("touchscreen_timeout_enabled", false);
+    }
+
+    private void cancelTouchscreenTimeout() {
+        if (timeoutHandler != null && hideControlsRunnable != null) {
+            timeoutHandler.removeCallbacks(hideControlsRunnable);
+        }
+    }
+
+    private void resetTouchscreenTimeout() {
+        if (!isTouchscreenTimeoutEnabled()
+                || !hasActiveTouchscreenProfile()
+                || inputControlsView.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        cancelTouchscreenTimeout();
+        timeoutHandler.postDelayed(hideControlsRunnable, 5000);
+    }
+
+    private void persistSelectedProfile(ControlsProfile profile) {
+        SharedPreferences.Editor editor = preferences.edit();
+        if (profile != null) {
+            int selectedProfileIndex = -1;
+            ArrayList<ControlsProfile> profiles = inputControlsManager.getProfiles(true);
+            for (int i = 0; i < profiles.size(); i++) {
+                ControlsProfile storedProfile = profiles.get(i);
+                if (storedProfile != null && storedProfile.id == profile.id) {
+                    selectedProfileIndex = i;
+                    break;
+                }
+            }
+            editor.putInt("selected_profile_id", profile.id);
+            editor.putInt("selected_profile_index", selectedProfileIndex);
+        } else {
+            editor.remove("selected_profile_id");
+            editor.putInt("selected_profile_index", -1);
+        }
+        editor.apply();
+    }
+
+    private boolean handleTouchscreenTimeoutWakeTouch(MotionEvent event) {
+        if (!hasActiveTouchscreenProfile()) return false;
+
+        int action = event.getActionMasked();
+        boolean controlsHidden = inputControlsView.getVisibility() != View.VISIBLE;
+
+        if (controlsHidden && action == MotionEvent.ACTION_DOWN) {
+            forwardingWakeTouchGesture = true;
+        }
+
+        if (!forwardingWakeTouchGesture) return false;
+
+        inputControlsView.setVisibility(View.VISIBLE);
+        inputControlsView.requestFocus();
+        resetTouchscreenTimeout();
+
+        boolean handled = inputControlsView.onTouchEvent(event);
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            forwardingWakeTouchGesture = false;
+        }
+        return handled;
+    }
+
     private ControlsProfile resolvePreferredStartupProfile() {
         ArrayList<ControlsProfile> profiles = inputControlsManager.getProfiles(true);
+        int selectedProfileId = preferences.getInt("selected_profile_id", 0);
         int selectedProfileIndex = preferences.getInt("selected_profile_index", -1);
-        ControlsProfile selectedProfile = null;
+        ControlsProfile selectedProfile =
+                selectedProfileId != 0 ? inputControlsManager.getProfile(selectedProfileId) : null;
 
-        if (selectedProfileIndex >= 0 && selectedProfileIndex < profiles.size()) {
+        if (selectedProfile == null
+                && selectedProfileIndex >= 0
+                && selectedProfileIndex < profiles.size()) {
             selectedProfile = profiles.get(selectedProfileIndex);
         }
 
-        if (selectedProfile != null && selectedProfile.isVirtualGamepad()) {
-            Log.d("XServerDisplayActivity", "Skipping automatic startup for Virtual Gamepad profile=" + selectedProfile.getName());
-            return null;
+        if (selectedProfile != null) {
+            Log.d(
+                    "XServerDisplayActivity",
+                    "Resolved startup profile="
+                            + selectedProfile.getName()
+                            + " id="
+                            + selectedProfile.id
+                            + " virtual="
+                            + selectedProfile.isVirtualGamepad());
         }
-
         return selectedProfile;
     }
 
@@ -3645,12 +3721,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         if (startupProfile != null) showInputControls(startupProfile);
         else hideInputControls();
 
-        // Timeout logic should only apply if the controls are visible
-        if (isTimeoutEnabled && inputControlsView.getVisibility() == View.VISIBLE) {
-            startTouchscreenTimeout(); // Start timeout if enabled and controls are visible
-        } else {
-            touchpadView.setOnTouchListener(null); // Disable the timeout listener if not needed
-        }
+        startTouchscreenTimeout();
 
         Log.d("XServerDisplayActivity", "Input controls simulated confirmation executed. startupProfile=" + (startupProfile != null ? startupProfile.getName() : "none"));
 
@@ -3658,41 +3729,22 @@ public class XServerDisplayActivity extends AppCompatActivity {
     }
 
     private void startTouchscreenTimeout() {
-        boolean isTimeoutEnabled = preferences.getBoolean("touchscreen_timeout_enabled", false);
+        if (inputControlsView == null || touchpadView == null) return;
+        boolean shouldUseTimeout = isTouchscreenTimeoutEnabled() && hasActiveTouchscreenProfile();
+        forwardingWakeTouchGesture = false;
 
-        if (isTimeoutEnabled) {
-            // Show controls initially and set up touch event listeners
+        if (shouldUseTimeout) {
+            Log.d("XServerDisplayActivity", "Timeout is enabled for active touchscreen controls.");
+            touchpadView.setOnTouchListener((v, event) -> handleTouchscreenTimeoutWakeTouch(event));
+            if (inputControlsView.getVisibility() == View.VISIBLE) resetTouchscreenTimeout();
+            else cancelTouchscreenTimeout();
+            return;
+        }
+
+        cancelTouchscreenTimeout();
+        touchpadView.setOnTouchListener(null);
+        if (hasActiveTouchscreenProfile()) {
             inputControlsView.setVisibility(View.VISIBLE);
-            Log.d("XServerDisplayActivity", "Timeout is enabled, setting up timeout logic.");
-
-            // Attach the OnTouchListener to reset the timeout on touch events
-            touchpadView.setOnTouchListener((v, event) -> {
-                int action = event.getAction();
-                if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_MOVE) {
-                    // Reset the timeout on any touch event
-                    //Log.d("XServerDisplayActivity", "Touch detected, resetting timeout.");
-
-                    // Keep the controls visible
-                    inputControlsView.setVisibility(View.VISIBLE);
-
-                    // Remove any pending hide callbacks and reset the timeout
-                    timeoutHandler.removeCallbacks(hideControlsRunnable);
-                    timeoutHandler.postDelayed(hideControlsRunnable, 5000); // Reset timeout
-                }
-
-                return false; // Allow the touch event to propagate
-            });
-
-            // Reset the timeout when the controls are initially displayed
-            timeoutHandler.removeCallbacks(hideControlsRunnable);
-            timeoutHandler.postDelayed(hideControlsRunnable, 5000); // Hide after 5 seconds of inactivity
-        } else {
-            // If timeout is disabled, keep the controls always visible
-            Log.d("XServerDisplayActivity", "Timeout is disabled, controls will stay visible.");
-
-            inputControlsView.setVisibility(View.VISIBLE); // Ensure controls are visible
-            timeoutHandler.removeCallbacks(hideControlsRunnable); // Remove any existing hide callbacks
-            touchpadView.setOnTouchListener(null); // Remove the touch listener
         }
     }
 
@@ -3704,6 +3756,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         inputControlsView.setVisibility(View.VISIBLE);
         inputControlsView.requestFocus();
         inputControlsView.setProfile(profile);
+        persistSelectedProfile(profile);
         Log.d("XServerDisplayActivity", "showInputControls: profile=" + profile.getName() + " id=" + profile.id + " virtual=" + profile.isVirtualGamepad());
 
         touchpadView.setSensitivity(profile.getCursorSpeed() * globalCursorSpeed);
@@ -3713,12 +3766,14 @@ public class XServerDisplayActivity extends AppCompatActivity {
         if (winHandler != null) {
             winHandler.sendGamepadState();
         }
+        startTouchscreenTimeout();
     }
 
     private void hideInputControls() {
         inputControlsView.setShowTouchscreenControls(true);
         inputControlsView.setVisibility(View.GONE);
         inputControlsView.setProfile(null);
+        persistSelectedProfile(null);
 
         touchpadView.setSensitivity(globalCursorSpeed);
         touchpadView.setPointerButtonLeftEnabled(true);
@@ -3728,6 +3783,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
         if (winHandler != null) {
             winHandler.sendGamepadState();
         }
+        startTouchscreenTimeout();
     }
 
     private void extractGraphicsDriverFiles() {

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -207,6 +207,12 @@ fun buildXServerDrawerState(
                 icon = Icons.Outlined.SportsEsports,
             ),
             XServerDrawerItem(
+                itemId = R.id.main_menu_controller_manager,
+                title = context.getString(R.string.session_gamepad_controller_manager),
+                subtitle = context.getString(R.string.session_gamepad_external_controllers),
+                icon = Icons.Outlined.SportsEsports,
+            ),
+            XServerDrawerItem(
                 itemId = R.id.main_menu_relative_mouse_movement,
                 title = context.getString(R.string.session_drawer_relative_mouse_movement),
                 subtitle =

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -760,18 +760,17 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
 
     File devInputDir = new File(imageFs.getRootDir(), "dev/input");
     devInputDir.mkdirs();
-    // Pre-create all 4 event files so Wine's winebus/SDL can detect
-    // up to 4 controllers on startup.
-    for (int i = 0; i < 4; i++) {
-      File eventFile = new File(devInputDir, "event" + i);
-      if (!eventFile.exists()) {
-        try {
-          eventFile.createNewFile();
-        } catch (Exception e) {
-        }
+    // XServerDisplayActivity pre-creates the configured controller count after the
+    // shortcut is loaded. Keep event0 available here as a minimum fallback.
+    File event0 = new File(devInputDir, "event0");
+    if (!event0.exists()) {
+      try {
+        event0.createNewFile();
+      } catch (Exception e) {
       }
     }
     envVars.put("FAKE_EVDEV_DIR", devInputDir.getAbsolutePath());
+    envVars.put("FAKE_EVDEV_VIBRATION", "1");
 
     // Ensure Proton-flavoured winebus.sys uses the evdev/SDL path that
     // libfakeinput.so hooks, and does not filter out our fake gamepad.

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -677,7 +677,10 @@ public class WinHandler {
           this.fallbackSlot = -1;
         }
         if (this.writers[slot] != null) {
-          this.writers[slot].softRelease();
+          // Fake evdev nodes are regular files; preserving them across release keeps old events
+          // readable on the next open and can replay stale input.
+          this.writers[slot].destroy();
+          this.writers[slot] = null;
         }
         this.usedSlots.remove(slot);
         Log.d("WinHandler", "Device " + deviceId + " disconnected. Slot " + slot + " released.");

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -1,7 +1,12 @@
 package com.winlator.cmod.runtime.display.winhandler;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.input.InputManager;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -24,6 +29,8 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -67,12 +74,16 @@ public class WinHandler {
   private final Map<Integer, ExternalController> controllers = new HashMap();
   private byte inputType = 4;
   private final List<Integer> gamepadClients = new CopyOnWriteArrayList();
-  private FakeInputWriter[] writers = new FakeInputWriter[4];
+  private FakeInputWriter[] writers = new FakeInputWriter[MAX_CONTROLLERS];
   private Map<Integer, Integer> deviceToSlot = new HashMap();
   private Map<String, Integer> descriptorToSlot = new HashMap<>(); // physical device → slot
   private Map<Integer, String> deviceToDescriptor = new HashMap<>(); // deviceId → descriptor
   private Set<Integer> usedSlots = new HashSet();
   private boolean xinputDisabledInitialized = false;
+  private LocalServerSocket vibrationServer;
+  private volatile boolean vibrationRunning = false;
+  private final boolean[] vibrationEnabledSlots = new boolean[MAX_CONTROLLERS];
+  private int fallbackSlot = -1;
   private ExternalController currentController;
   private final GamepadState outputGamepadState = new GamepadState();
   private int lastGamepadSource = 0;
@@ -87,7 +98,9 @@ public class WinHandler {
   private final InputManager.InputDeviceListener inputDeviceListener =
       new InputManager.InputDeviceListener() {
         @Override
-        public void onInputDeviceAdded(int deviceId) {}
+        public void onInputDeviceAdded(int deviceId) {
+          WinHandler.this.assignConnectedDeviceIfPossible(deviceId, "hotplug");
+        }
 
         @Override
         public void onInputDeviceRemoved(int deviceId) {
@@ -100,9 +113,100 @@ public class WinHandler {
 
   public WinHandler(XServerDisplayActivity activity) {
     this.activity = activity;
-    this.inputManager = (InputManager) activity.getSystemService("input");
+    this.inputManager = (InputManager) activity.getSystemService(Context.INPUT_SERVICE);
     this.inputManager.registerInputDeviceListener(this.inputDeviceListener, null);
     this.preferences = PreferenceManager.getDefaultSharedPreferences(activity.getBaseContext());
+    for (int i = 0; i < MAX_CONTROLLERS; i++) {
+      String key = "vibration_slot_" + i;
+      String legacyKey = "vibrate_slot_" + i;
+      if (this.preferences.contains(key)) {
+        this.vibrationEnabledSlots[i] = this.preferences.getBoolean(key, true);
+      } else {
+        this.vibrationEnabledSlots[i] = this.preferences.getBoolean(legacyKey, true);
+      }
+    }
+  }
+
+  public int preAssignConnectedControllers() {
+    if (this.fakeInputBasePath == null || this.fakeInputBasePath.isEmpty()) {
+      Log.w("WinHandler", "Skipping pre-assignment: fake input path is not set yet.");
+      return 0;
+    }
+
+    int assignedCount = 0;
+    for (int deviceId : getConnectedGamepadDeviceIds()) {
+      if (this.usedSlots.size() >= MAX_CONTROLLERS) {
+        break;
+      }
+      if (assignConnectedDeviceIfPossible(deviceId, "startup-scan")) {
+        assignedCount++;
+      }
+    }
+
+    Log.d("WinHandler", "Pre-assigned " + assignedCount + " controller(s) before Wine startup.");
+    return assignedCount;
+  }
+
+  private int[] getConnectedGamepadDeviceIds() {
+    int[] deviceIds = android.view.InputDevice.getDeviceIds();
+    Integer[] sortedIds = new Integer[deviceIds.length];
+    for (int i = 0; i < deviceIds.length; i++) {
+      sortedIds[i] = deviceIds[i];
+    }
+
+    Arrays.sort(
+        sortedIds,
+        Comparator.comparing(
+                (Integer id) -> {
+                  android.view.InputDevice device = android.view.InputDevice.getDevice(id);
+                  if (device == null) {
+                    return "";
+                  }
+                  String physicalId = ExternalController.getPhysicalDeviceIdentifier(device);
+                  if (physicalId != null && !physicalId.isEmpty()) {
+                    return physicalId;
+                  }
+                  String descriptor = device.getDescriptor();
+                  return descriptor != null ? descriptor : "";
+                })
+            .thenComparingInt(Integer::intValue));
+
+    int[] result = new int[sortedIds.length];
+    for (int i = 0; i < sortedIds.length; i++) {
+      result[i] = sortedIds[i];
+    }
+    return result;
+  }
+
+  private boolean assignConnectedDeviceIfPossible(int deviceId, String source) {
+    if (this.deviceToSlot.containsKey(deviceId)) {
+      return false;
+    }
+
+    if (this.usedSlots.size() >= MAX_CONTROLLERS) {
+      Log.d(
+          "WinHandler", "Ignoring device " + deviceId + " from " + source + ": slot limit reached.");
+      return false;
+    }
+
+    android.view.InputDevice device = android.view.InputDevice.getDevice(deviceId);
+    if (!ExternalController.isGameController(device)) {
+      return false;
+    }
+
+    ExternalController controller = getController(deviceId);
+    if (controller == null) {
+      return false;
+    }
+
+    int slot = assignSlot(deviceId);
+    if (slot >= 0) {
+      Log.d(
+          "WinHandler",
+          "Auto-assigned device " + deviceId + " to slot " + slot + " via " + source + ".");
+      return true;
+    }
+    return false;
   }
 
   public DatagramSocket getSocket() {
@@ -521,7 +625,7 @@ public class WinHandler {
     }
 
     // Assign a new slot
-    for (int slot = 0; slot < 4; slot++) {
+    for (int slot = 0; slot < MAX_CONTROLLERS; slot++) {
       if (!this.usedSlots.contains(slot)) {
         this.usedSlots.add(slot);
         this.deviceToSlot.put(deviceId, slot);
@@ -569,6 +673,9 @@ public class WinHandler {
       }
 
       if (!slotStillInUse) {
+        if (this.fallbackSlot == slot) {
+          this.fallbackSlot = -1;
+        }
         if (this.writers[slot] != null) {
           this.writers[slot].softRelease();
         }
@@ -597,14 +704,139 @@ public class WinHandler {
     if (fakeInputPath != null && !fakeInputPath.isEmpty()) {
       this.fakeInputBasePath = fakeInputPath;
       Log.d("WinHandler", "FakeInputWriter base path set: " + fakeInputPath);
+      startVibrationListener();
     }
+  }
+
+  public void startVibrationListener() {
+    if (this.vibrationRunning) {
+      return;
+    }
+    this.vibrationRunning = true;
+
+    Executors.newSingleThreadExecutor()
+        .execute(
+            () -> {
+              try {
+                this.vibrationServer = new LocalServerSocket("winlator_vibration");
+                Log.d(
+                    "WinHandler",
+                    "Vibration listener started on abstract socket: winlator_vibration");
+
+                while (this.vibrationRunning) {
+                  LocalSocket client = this.vibrationServer.accept();
+                  try {
+                    java.io.InputStream is = client.getInputStream();
+                    byte[] buffer = new byte[8];
+                    int read = is.read(buffer);
+                    if (read == 8) {
+                      int strong = (buffer[0] & 255) | ((buffer[1] & 255) << 8);
+                      int weak = (buffer[2] & 255) | ((buffer[3] & 255) << 8);
+                      int durationMs = (buffer[4] & 255) | ((buffer[5] & 255) << 8);
+                      int slot = (buffer[6] & 255) | ((buffer[7] & 255) << 8);
+                      triggerVibration(strong, weak, durationMs, slot);
+                    }
+                    client.close();
+                  } catch (IOException e) {
+                    Log.e("WinHandler", "Vibration client error: " + e.getMessage());
+                  }
+                }
+              } catch (IOException e) {
+                if (this.vibrationRunning) {
+                  Log.e("WinHandler", "Vibration listener error: " + e.getMessage());
+                }
+              }
+            });
+  }
+
+  private void triggerVibration(int strong, int weak, int durationMs, int slot) {
+    if (slot >= 0 && slot < MAX_CONTROLLERS && !this.vibrationEnabledSlots[slot]) {
+      return;
+    }
+
+    Vibrator vibrator = null;
+    Integer slotOwner = null;
+    for (Map.Entry<Integer, Integer> entry : this.deviceToSlot.entrySet()) {
+      if (entry.getValue() == slot) {
+        if (entry.getKey() == OSC_DEVICE_ID) {
+          slotOwner = entry.getKey();
+          break;
+        }
+        if (slotOwner == null) {
+          slotOwner = entry.getKey();
+        }
+      }
+    }
+
+    if (slotOwner != null && slotOwner == OSC_DEVICE_ID) {
+      vibrator = (Vibrator) this.activity.getSystemService(Context.VIBRATOR_SERVICE);
+    } else if (slotOwner != null) {
+      for (Map.Entry<Integer, Integer> entry : this.deviceToSlot.entrySet()) {
+        if (entry.getValue() != slot || entry.getKey() == OSC_DEVICE_ID) {
+          continue;
+        }
+        android.view.InputDevice device = android.view.InputDevice.getDevice(entry.getKey());
+        if (device == null) {
+          continue;
+        }
+        Vibrator candidate = device.getVibrator();
+        if (candidate != null && candidate.hasVibrator()) {
+          vibrator = candidate;
+          break;
+        }
+      }
+
+      if ((vibrator == null || !vibrator.hasVibrator())
+          && !this.deviceToSlot.containsKey(OSC_DEVICE_ID)
+          && (this.fallbackSlot == -1 || this.fallbackSlot == slot)) {
+        vibrator = (Vibrator) this.activity.getSystemService(Context.VIBRATOR_SERVICE);
+        this.fallbackSlot = slot;
+      }
+    }
+
+    if (vibrator == null || !vibrator.hasVibrator()) {
+      return;
+    }
+
+    if (strong > 0 || weak > 0) {
+      int intensity = Math.max(strong, weak);
+      int amplitude = Math.min(255, Math.max(1, (int) ((intensity / 65535.0f) * 255.0f)));
+      int duration = Math.max(1, durationMs);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        vibrator.vibrate(VibrationEffect.createOneShot(duration, amplitude));
+      } else {
+        vibrator.vibrate(duration);
+      }
+    } else {
+      vibrator.cancel();
+    }
+  }
+
+  public boolean isVibrationEnabledForSlot(int slot) {
+    return slot >= 0 && slot < MAX_CONTROLLERS && this.vibrationEnabledSlots[slot];
+  }
+
+  public void setVibrationEnabledForSlot(int slot, boolean enabled) {
+    if (slot < 0 || slot >= MAX_CONTROLLERS) {
+      return;
+    }
+    this.vibrationEnabledSlots[slot] = enabled;
+    this.preferences
+        .edit()
+        .putBoolean("vibration_slot_" + slot, enabled)
+        .putBoolean("vibrate_slot_" + slot, enabled)
+        .apply();
+  }
+
+  public int getMaxControllers() {
+    return MAX_CONTROLLERS;
   }
 
   public void closeFakeInputWriter() {
     if (this.inputManager != null && this.inputDeviceListener != null) {
       this.inputManager.unregisterInputDeviceListener(this.inputDeviceListener);
     }
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < MAX_CONTROLLERS; i++) {
       if (this.writers[i] != null) {
         this.writers[i].destroy();
         this.writers[i] = null;
@@ -615,6 +847,15 @@ public class WinHandler {
     this.deviceToDescriptor.clear();
     this.usedSlots.clear();
     this.controllers.clear();
+    this.fallbackSlot = -1;
+    this.vibrationRunning = false;
+    if (this.vibrationServer != null) {
+      try {
+        this.vibrationServer.close();
+      } catch (IOException ignored) {
+      }
+      this.vibrationServer = null;
+    }
     this.currentController = null;
     this.lastGamepadSource = GAMEPAD_SOURCE_NONE;
     this.smoothedGyroX = 0.0f;

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -765,14 +765,20 @@ public class ControlElement {
         && (binding == Binding.GAMEPAD_BUTTON_L3 || binding == Binding.GAMEPAD_BUTTON_R3);
   }
 
+  private void dispatchButtonBinding(Binding primary, Binding secondary, boolean pressed) {
+    inputControlsView.handleInputEvent(primary, pressed);
+    if (secondary != Binding.NONE && secondary != primary) {
+      inputControlsView.handleInputEvent(secondary, pressed);
+    }
+  }
+
   public boolean handleTouchDown(int pointerId, float x, float y) {
     if (currentPointerId == -1 && containsPoint(x, y)) {
       currentPointerId = pointerId;
       if (type == Type.BUTTON) {
         if (isKeepButtonPressedAfterMinTime()) touchTime = System.currentTimeMillis();
         if (!toggleSwitch || !selected) {
-          inputControlsView.handleInputEvent(getBindingAt(0), true);
-          inputControlsView.handleInputEvent(getBindingAt(1), true);
+          dispatchButtonBinding(getBindingAt(0), getBindingAt(1), true);
         }
         inputControlsView.invalidate();
         return true;
@@ -955,16 +961,14 @@ public class ControlElement {
         long delay = Math.max(0L, BUTTON_MIN_TIME_TO_KEEP_PRESSED - held);
         inputControlsView.postDelayed(
             () -> {
-              inputControlsView.handleInputEvent(binding, false);
-              inputControlsView.handleInputEvent(bindingSecondary, false);
+              dispatchButtonBinding(binding, bindingSecondary, false);
               inputControlsView.invalidate();
             },
             delay);
         touchTime = null;
       } else {
         if (!toggleSwitch || selected) {
-          inputControlsView.handleInputEvent(binding, false);
-          inputControlsView.handleInputEvent(bindingSecondary, false);
+          dispatchButtonBinding(binding, bindingSecondary, false);
         }
         if (toggleSwitch) selected = !selected;
       }

--- a/app/src/main/runtime/input/controls/FakeInputWriter.java
+++ b/app/src/main/runtime/input/controls/FakeInputWriter.java
@@ -216,8 +216,6 @@ public class FakeInputWriter {
     for (int i = 0; i < 10; i++) {
       writeButton(i, state.isPressed((byte) i));
     }
-    // Always write all axes in every sync frame so the game/Wine input driver
-    // never sees a partial update that could reset missing axes to zero
     int lx = (int) (state.thumbLX * 32767.0f);
     int ly = (int) (state.thumbLY * 32767.0f);
     int rx = (int) (state.thumbRX * 32767.0f);
@@ -225,19 +223,31 @@ public class FakeInputWriter {
     int tl = (int) (state.triggerL * 255.0f);
     int tr = (int) (state.triggerR * 255.0f);
 
-    writeEvent((short) 3, (short) 0, lx);
-    writeEvent((short) 3, (short) 1, ly);
-    writeEvent((short) 3, (short) 3, rx);
-    writeEvent((short) 3, (short) 4, ry);
-    writeEvent((short) 3, (short) 10, tl);
-    writeEvent((short) 3, (short) 9, tr);
-
-    this.prevThumbLX = lx;
-    this.prevThumbLY = ly;
-    this.prevThumbRX = rx;
-    this.prevThumbRY = ry;
-    this.prevTriggerL = tl;
-    this.prevTriggerR = tr;
+    // The fake evdev file is effectively a queue, so unchanged axes must stay silent.
+    if (lx != this.prevThumbLX) {
+      this.prevThumbLX = lx;
+      writeEvent((short) 3, (short) 0, lx);
+    }
+    if (ly != this.prevThumbLY) {
+      this.prevThumbLY = ly;
+      writeEvent((short) 3, (short) 1, ly);
+    }
+    if (rx != this.prevThumbRX) {
+      this.prevThumbRX = rx;
+      writeEvent((short) 3, (short) 3, rx);
+    }
+    if (ry != this.prevThumbRY) {
+      this.prevThumbRY = ry;
+      writeEvent((short) 3, (short) 4, ry);
+    }
+    if (tl != this.prevTriggerL) {
+      this.prevTriggerL = tl;
+      writeEvent((short) 3, (short) 10, tl);
+    }
+    if (tr != this.prevTriggerR) {
+      this.prevTriggerR = tr;
+      writeEvent((short) 3, (short) 9, tr);
+    }
 
     int hatY = 1;
     if (state.dpad[3]) {

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -343,6 +343,16 @@ public class InputControlsView extends View {
     this.showTouchscreenControls = showTouchscreenControls;
   }
 
+  private boolean shouldBlockTouchpadFallback() {
+    return profile != null && profile.isVirtualGamepad() && showTouchscreenControls;
+  }
+
+  private void dispatchUnhandledTouch(MotionEvent event) {
+    if (touchpadView != null && !shouldBlockTouchpadFallback()) {
+      touchpadView.onTouchEvent(event);
+    }
+  }
+
   public int getPrimaryColor() {
     return Color.argb((int) (overlayOpacity * 255), 255, 255, 255);
   }
@@ -672,7 +682,7 @@ public class InputControlsView extends View {
                 break;
               }
             }
-            if (!handled) touchpadView.onTouchEvent(event);
+            if (!handled) dispatchUnhandledTouch(event);
             break;
           }
         case MotionEvent.ACTION_MOVE:
@@ -694,7 +704,7 @@ public class InputControlsView extends View {
                   }
                 }
               }
-              if (!handled) touchpadView.onTouchEvent(event);
+              if (!handled) dispatchUnhandledTouch(event);
             }
             break;
           }
@@ -713,7 +723,7 @@ public class InputControlsView extends View {
                 }
               }
             }
-            if (!handled) touchpadView.onTouchEvent(event);
+            if (!handled) dispatchUnhandledTouch(event);
             break;
           }
         case MotionEvent.ACTION_CANCEL:
@@ -724,7 +734,7 @@ public class InputControlsView extends View {
               if (activeElement != null) activeElement.handleTouchUp(activePointerId);
             }
             activeTouchElements.clear();
-            touchpadView.onTouchEvent(event);
+            dispatchUnhandledTouch(event);
             break;
           }
       }
@@ -733,6 +743,11 @@ public class InputControlsView extends View {
   }
 
   private void resetTouchscreenTimeout() {
+    if (!preferences.getBoolean("touchscreen_timeout_enabled", false)
+        || getVisibility() != View.VISIBLE
+        || profile == null) {
+      return;
+    }
     if (timeoutHandler != null && hideControlsRunnable != null) {
       // Cancel any pending hide requests
       timeoutHandler.removeCallbacks(hideControlsRunnable);
@@ -829,42 +844,60 @@ public class InputControlsView extends View {
       boolean sendUpdate) {
     WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
     if (binding.isGamepad()) {
+      if (profile == null && controller == null) return;
       GamepadState state =
           (controller != null) ? controller.remappedState : profile.getGamepadState();
+      boolean stateChanged = false;
 
       int buttonIdx = binding.ordinal() - Binding.GAMEPAD_BUTTON_A.ordinal();
       if (buttonIdx <= ExternalController.IDX_BUTTON_R2) {
-        if (buttonIdx == ExternalController.IDX_BUTTON_L2)
-          state.triggerL = isActionDown ? (offset != 0 ? offset : 1.0f) : 0f;
-        else if (buttonIdx == ExternalController.IDX_BUTTON_R2)
-          state.triggerR = isActionDown ? (offset != 0 ? offset : 1.0f) : 0f;
-        else state.setPressed(buttonIdx, isActionDown);
+        if (buttonIdx == ExternalController.IDX_BUTTON_L2) {
+          float value = isActionDown ? (offset != 0 ? offset : 1.0f) : 0f;
+          stateChanged = Float.compare(state.triggerL, value) != 0;
+          state.triggerL = value;
+        } else if (buttonIdx == ExternalController.IDX_BUTTON_R2) {
+          float value = isActionDown ? (offset != 0 ? offset : 1.0f) : 0f;
+          stateChanged = Float.compare(state.triggerR, value) != 0;
+          state.triggerR = value;
+        } else {
+          stateChanged = state.isPressed(buttonIdx) != isActionDown;
+          if (stateChanged) state.setPressed(buttonIdx, isActionDown);
+        }
       } else if (binding == Binding.GAMEPAD_LEFT_THUMB_UP
           || binding == Binding.GAMEPAD_LEFT_THUMB_DOWN) {
         float val = (isActionDown && offset == 0) ? 1.0f : Math.abs(offset);
-        state.thumbLY = isActionDown ? (binding == Binding.GAMEPAD_LEFT_THUMB_UP ? -val : val) : 0;
+        float value = isActionDown ? (binding == Binding.GAMEPAD_LEFT_THUMB_UP ? -val : val) : 0;
+        stateChanged = Float.compare(state.thumbLY, value) != 0;
+        state.thumbLY = value;
       } else if (binding == Binding.GAMEPAD_LEFT_THUMB_LEFT
           || binding == Binding.GAMEPAD_LEFT_THUMB_RIGHT) {
         float val = (isActionDown && offset == 0) ? 1.0f : Math.abs(offset);
-        state.thumbLX =
-            isActionDown ? (binding == Binding.GAMEPAD_LEFT_THUMB_LEFT ? -val : val) : 0;
+        float value = isActionDown ? (binding == Binding.GAMEPAD_LEFT_THUMB_LEFT ? -val : val) : 0;
+        stateChanged = Float.compare(state.thumbLX, value) != 0;
+        state.thumbLX = value;
       } else if (binding == Binding.GAMEPAD_RIGHT_THUMB_UP
           || binding == Binding.GAMEPAD_RIGHT_THUMB_DOWN) {
         float val = (isActionDown && offset == 0) ? 1.0f : Math.abs(offset);
-        state.thumbRY = isActionDown ? (binding == Binding.GAMEPAD_RIGHT_THUMB_UP ? -val : val) : 0;
+        float value = isActionDown ? (binding == Binding.GAMEPAD_RIGHT_THUMB_UP ? -val : val) : 0;
+        stateChanged = Float.compare(state.thumbRY, value) != 0;
+        state.thumbRY = value;
       } else if (binding == Binding.GAMEPAD_RIGHT_THUMB_LEFT
           || binding == Binding.GAMEPAD_RIGHT_THUMB_RIGHT) {
         float val = (isActionDown && offset == 0) ? 1.0f : Math.abs(offset);
-        state.thumbRX =
+        float value =
             isActionDown ? (binding == Binding.GAMEPAD_RIGHT_THUMB_LEFT ? -val : val) : 0;
+        stateChanged = Float.compare(state.thumbRX, value) != 0;
+        state.thumbRX = value;
       } else if (binding == Binding.GAMEPAD_DPAD_UP
           || binding == Binding.GAMEPAD_DPAD_RIGHT
           || binding == Binding.GAMEPAD_DPAD_DOWN
           || binding == Binding.GAMEPAD_DPAD_LEFT) {
-        state.dpad[binding.ordinal() - Binding.GAMEPAD_DPAD_UP.ordinal()] = isActionDown;
+        int dpadIndex = binding.ordinal() - Binding.GAMEPAD_DPAD_UP.ordinal();
+        stateChanged = state.dpad[dpadIndex] != isActionDown;
+        state.dpad[dpadIndex] = isActionDown;
       }
 
-      if (winHandler != null && sendUpdate) {
+      if (winHandler != null && sendUpdate && stateChanged) {
         if (controller != null) winHandler.sendGamepadState(controller);
         else winHandler.sendGamepadState();
       }

--- a/app/src/main/runtime/input/ui/TouchpadView.kt
+++ b/app/src/main/runtime/input/ui/TouchpadView.kt
@@ -187,6 +187,7 @@ class TouchpadView(
     }
 
     private fun resetTouchscreenTimeout() {
+        if (!preferences.getBoolean("touchscreen_timeout_enabled", false)) return
         if (timeoutHandler != null && hideControlsRunnable != null) {
             timeoutHandler.removeCallbacks(hideControlsRunnable)
             timeoutHandler.postDelayed(hideControlsRunnable, 5000)

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -1160,10 +1160,14 @@ public abstract class WineUtils {
         if (selection == 1) {
           if (servicesList.contains(service)
               && !name.equals("winebus")
-              && !name.equals("winehid")) {
+              && !name.equals("winehid")
+              && !name.equals("PlugPlay")) {
             value = 4;
           }
-        } else if (selection == 2 && !name.equals("winebus") && !name.equals("winehid")) {
+        } else if (selection == 2
+            && !name.equals("winebus")
+            && !name.equals("winehid")
+            && !name.equals("PlugPlay")) {
           value = 4;
         }
         registryEditor.setDwordValue(


### PR DESCRIPTION
- This syncs the remaining controller and touchscreen-control fixes from `palazos/controller-detection-fix` into the current runtime/refactor layout.
- The local tree had dropped parts of the upstream fix path, including controller pre-assignment before Wine startup, fake evdev vibration support, fakeinput identity and EV_FF filtering, shortcut-level controller-count persistence, session access to controller assignment/vibration, and virtual gamepad state flushing when the on-screen controls are shown or hidden.
- Physical controller behavior is updated in the Wine/runtime path so connected pads are assigned earlier, hotplugged pads get slotted correctly, fake evdev slots expose stable per-slot identity, rumble events do not leak back as input, and PlugPlay stays available in the restrictive service modes used by these controller setups.
- Touchscreen and OSC behavior is aligned by restoring the missing virtual-gamepad flush on overlay show/hide and by wiring the shortcut settings path back to the controller-count value that the session startup path still consumes.
- The user impact is that physical controllers, virtual gamepad profiles, and touchscreen-control transitions now follow the same intended behavior as the upstream fix branch instead of depending on stale slot state or missing shortcut/session settings.
- Validation used for this change:
- `./gradlew.bat :app:assembleStandardDebug`
- `./gradlew.bat :app:assembleLudashiDebug`