### PR TITLE
Respect DXVK and VKD3D selections

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -322,6 +322,7 @@ interface GameSettingsCallbacks {
     fun onUpdateWinComponent(isDirectX: Boolean, index: Int, newValue: Int)
     fun onSelectExe() {}
     fun onGfxDriverVersionChanged(versionIndex: Int) {}
+    fun onDxvkVersionChanged(versionIndex: Int) {}
     fun onDxvkVkd3dVersionChanged(versionIndex: Int) {}
     fun onContainerChanged(containerIndex: Int) {}
     fun onEmulatorChanged() {}
@@ -1501,7 +1502,10 @@ private fun DXVKConfigCard(
                     label = stringResource(R.string.container_wine_dxvk_version),
                     entries = state.dxvkVersionEntries.value,
                     selectedIndex = state.dxvkSelectedVersion.intValue,
-                    onSelected = { state.dxvkSelectedVersion.intValue = it }
+                    onSelected = {
+                        state.dxvkSelectedVersion.intValue = it
+                        callbacks.onDxvkVersionChanged(it)
+                    }
                 )
 
                 // Async toggle - greyed out when version doesn't support it

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -215,6 +215,10 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 state.graphicsDriverVersion.value = versions.getOrElse(versionIndex) { "" }
             }
 
+            override fun onDxvkVersionChanged(versionIndex: Int) {
+                handleDxvkVersionChanged(versionIndex)
+            }
+
             override fun onDxvkVkd3dVersionChanged(versionIndex: Int) {
                 handleDxvkVkd3dVersionChanged(versionIndex)
             }
@@ -1020,10 +1024,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         selectByIdentifier(state.dxvkVkd3dFeatureLevelEntries.value, config.get("vkd3dLevel"), state.dxvkSelectedVkd3dFeatureLevel)
         selectByIdentifier(state.dxvkDdrawWrapperEntries.value, config.get("ddrawrapper"), state.dxvkSelectedDdrawWrapper)
         selectByIdentifier(state.dxvkFramerateEntries.value, config.get("framerate"), state.dxvkSelectedFramerate)
-        val selectedVersion = state.dxvkVersionEntries.value.getOrElse(state.dxvkSelectedVersion.intValue) { DefaultVersion.DXVK }
-        val asyncCapable = selectedVersion.contains("async", ignoreCase = true)
-        state.dxvkAsync.value = config.get("async")?.let { it == "1" } ?: asyncCapable
-        state.dxvkAsyncCache.value = config.get("asyncCache")?.let { it == "1" } ?: asyncCapable
+        state.dxvkAsync.value = config.get("async") == "1"
+        state.dxvkAsyncCache.value = config.get("asyncCache") == "1"
     }
 
     private fun loadDxvkVersions() {
@@ -1161,6 +1163,17 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         } else {
             loadDxvkVersions()
         }
+    }
+
+    private fun handleDxvkVersionChanged(versionIndex: Int) {
+        val dxvkEntries = state.dxvkVersionEntries.value
+        val selectedDxvk = dxvkEntries.getOrElse(versionIndex) { "" }
+        val normalized = selectedDxvk.lowercase()
+        val isGplAsync = normalized.contains("gplasync")
+        val isAsync = normalized.contains("async") || isGplAsync
+
+        state.dxvkAsync.value = isAsync
+        state.dxvkAsyncCache.value = isGplAsync
     }
 
     private fun selectScreenSize(screenSize: String) {

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -219,6 +219,10 @@ class ShortcutSettingsComposeDialog private constructor(
                 state.graphicsDriverVersion.value = versions.getOrElse(versionIndex) { "" }
             }
 
+            override fun onDxvkVersionChanged(versionIndex: Int) {
+                handleDxvkVersionChanged(versionIndex)
+            }
+
             override fun onDxvkVkd3dVersionChanged(versionIndex: Int) {
                 handleDxvkVkd3dVersionChanged(versionIndex)
             }
@@ -1530,10 +1534,8 @@ class ShortcutSettingsComposeDialog private constructor(
         selectByIdentifier(state.dxvkDdrawWrapperEntries.value, config.get("ddrawrapper"), state.dxvkSelectedDdrawWrapper)
         selectByIdentifier(state.dxvkFramerateEntries.value, config.get("framerate"), state.dxvkSelectedFramerate)
 
-        val selectedVersion = state.dxvkVersionEntries.value.getOrElse(state.dxvkSelectedVersion.intValue) { DefaultVersion.DXVK }
-        val asyncCapable = selectedVersion.contains("async", ignoreCase = true)
-        state.dxvkAsync.value = config.get("async")?.let { it == "1" } ?: asyncCapable
-        state.dxvkAsyncCache.value = config.get("asyncCache")?.let { it == "1" } ?: asyncCapable
+        state.dxvkAsync.value = config.get("async") == "1"
+        state.dxvkAsyncCache.value = config.get("asyncCache") == "1"
     }
 
     private fun loadDxvkVersions(container: Container = shortcut.container) {
@@ -1623,6 +1625,17 @@ class ShortcutSettingsComposeDialog private constructor(
             // Reload all DXVK versions
             loadDxvkVersions()
         }
+    }
+
+    private fun handleDxvkVersionChanged(versionIndex: Int) {
+        val dxvkEntries = state.dxvkVersionEntries.value
+        val selectedDxvk = dxvkEntries.getOrElse(versionIndex) { "" }
+        val normalized = selectedDxvk.lowercase()
+        val isGplAsync = normalized.contains("gplasync")
+        val isAsync = normalized.contains("async") || isGplAsync
+
+        state.dxvkAsync.value = isAsync
+        state.dxvkAsyncCache.value = isGplAsync
     }
 
     private fun handleContainerChanged(containerIndex: Int) {

--- a/app/src/main/runtime/container/Container.java
+++ b/app/src/main/runtime/container/Container.java
@@ -27,7 +27,7 @@ public class Container {
     public static final String DEFAULT_EMULATOR = "FEXCore";
     public static final String DEFAULT_EMULATOR64 = "FEXCore";
     public static final String DEFAULT_DXWRAPPER = "dxvk+vkd3d";
-    public static final String DEFAULT_DXWRAPPERCONFIG = "version=" + DefaultVersion.DXVK + ",framerate=0,async=1,asyncCache=1" + ",vkd3dVersion=" + DefaultVersion.VKD3D + ",vkd3dLevel=12_1" + ",ddrawrapper=" + Container.DEFAULT_DDRAWRAPPER + ",csmt=3" + ",gpuName=NVIDIA GeForce GTX 480" + ",videoMemorySize=2048" + ",strict_shader_math=1" + ",OffscreenRenderingMode=fbo" + ",renderer=gl";
+    public static final String DEFAULT_DXWRAPPERCONFIG = "version=" + DefaultVersion.DXVK + ",framerate=0,async=0,asyncCache=0" + ",vkd3dVersion=" + DefaultVersion.VKD3D + ",vkd3dLevel=12_1" + ",ddrawrapper=" + Container.DEFAULT_DDRAWRAPPER + ",csmt=3" + ",gpuName=NVIDIA GeForce GTX 480" + ",videoMemorySize=2048" + ",strict_shader_math=1" + ",OffscreenRenderingMode=fbo" + ",renderer=gl";
     public static final String DEFAULT_GRAPHICSDRIVERCONFIG =
             "vulkanVersion=1.3" + ";version=" + ";blacklistedExtensions=" + ";maxDeviceMemory=0" + ";presentMode=mailbox" + ";syncFrame=0" + ";disablePresentWait=1" + ";resourceType=auto" + ";bcnEmulation=none" + ";bcnEmulationType=compute" + ";bcnEmulationCache=0" + ";gpuName=Device";
     public static final String DEFAULT_DDRAWRAPPER = "none";

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3208,18 +3208,6 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 config.put("vkd3dVersion", normalizedVkd3d);
                 changed = true;
             }
-        } else if ("None".equalsIgnoreCase(vkd3dVersion) && this.dxwrapper != null && this.dxwrapper.contains("vkd3d")) {
-            // DXWrapper requests VKD3D but version is None — auto-resolve to best available
-            String resolvedVkd3d = resolveInstalledGraphicsComponentVersion(
-                    DefaultVersion.VKD3D,
-                    ContentProfile.ContentType.CONTENT_TYPE_VKD3D,
-                    isArm64EC
-            );
-            if (resolvedVkd3d != null && !resolvedVkd3d.isEmpty() && !"None".equalsIgnoreCase(resolvedVkd3d)) {
-                config.put("vkd3dVersion", resolvedVkd3d);
-                changed = true;
-                Log.d("XServerDisplayActivity", "VKD3D auto-resolved from 'None' to '" + resolvedVkd3d + "' because dxwrapper=" + this.dxwrapper);
-            }
         }
 
         Log.d("XServerDisplayActivity", "normalizeDxwrapperConfigForCurrentWine input='" + dxwrapperConfig +
@@ -3239,24 +3227,14 @@ public class XServerDisplayActivity extends AppCompatActivity {
 
         ContentProfile currentProfile = resolveInstalledGraphicsProfileByToken(type, currentVersion);
         if (currentProfile != null) {
-            String resolvedToken = getContentVersionToken(currentProfile);
-            if (isArm64ComponentVersion(resolvedToken) == isArm64EC) {
-                Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep current type=" + type +
-                        " current='" + currentVersion + "' resolvedToken='" + resolvedToken +
-                        "' arm64ec=" + isArm64EC);
-                return currentVersion;
-            }
+            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep installed type=" + type +
+                    " current='" + currentVersion + "' arm64ec=" + isArm64EC);
+            return currentVersion;
+        }
 
-            String sameVersionVariant = findBestInstalledGraphicsToken(type, isArm64EC, currentProfile.verName);
-            if (!sameVersionVariant.isEmpty()) {
-                Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion switched same-name variant type=" + type +
-                        " current='" + currentVersion + "' to='" + sameVersionVariant + "' arm64ec=" + isArm64EC);
-                return sameVersionVariant;
-            }
-        } else if (isArm64ComponentVersion(currentVersion) == isArm64EC) {
-            // Keep user-selected values (including built-in/default versions) untouched.
-            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep user token type=" + type +
-                    " current='" + currentVersion + "' arm64ec=" + isArm64EC + " (no installed profile match)");
+        if (hasBundledGraphicsComponent(type, currentVersion)) {
+            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep bundled type=" + type +
+                    " current='" + currentVersion + "' arm64ec=" + isArm64EC);
             return currentVersion;
         }
 
@@ -3296,6 +3274,28 @@ public class XServerDisplayActivity extends AppCompatActivity {
         Log.d("XServerDisplayActivity", "resolveInstalledGraphicsProfileByToken no match type=" + type +
                 " token='" + versionToken + "'");
         return null;
+    }
+
+    private boolean hasBundledGraphicsComponent(
+            ContentProfile.ContentType type,
+            String versionToken
+    ) {
+        if (versionToken == null || versionToken.isEmpty()) return false;
+
+        final String assetPath;
+        if (type == ContentProfile.ContentType.CONTENT_TYPE_DXVK) {
+            assetPath = "dxwrapper/dxvk-" + versionToken + ".tzst";
+        } else if (type == ContentProfile.ContentType.CONTENT_TYPE_VKD3D) {
+            assetPath = "dxwrapper/vkd3d-" + versionToken + ".tzst";
+        } else {
+            return false;
+        }
+
+        try (InputStream ignored = getAssets().open(assetPath)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     private String findBestInstalledGraphicsToken(


### PR DESCRIPTION
## What changed
- stop rewriting explicit DXVK and VKD3D selections at launch when the chosen token already exists as an installed profile or bundled asset
- remove VKD3D auto-resolution from `None` so launch behavior follows the saved config
- change default DXVK config values to `async=0` and `asyncCache=0`
- load DXVK async toggles directly from saved config instead of inferring them from version capability
- auto-toggle the DXVK async UI when switching versions so async builds default on in the UI while plain builds default off

## Why
- the fork could show one DXVK selection in settings and silently launch a different one at runtime, especially for arm64ec Wine builds
- async flags could appear enabled by default even when the selected version was plain DXVK
- the goal here is to align behavior with Ludashi: the saved config should be the source of truth, with fallback only when a selected component is actually unavailable

## Impact
- plain DXVK selections such as `2.3.1` are preserved when available
- VKD3D `None` remains `None` instead of being silently replaced
- async and async cache defaults are now off until explicitly chosen or auto-selected through an async-capable DXVK choice in the UI
- users can still manually turn those toggles back off before saving

## Validation
- ran `./gradlew.bat :app:compileLudashiDebugJavaWithJavac`
