### PR TITLE
Keep FPS monitor drawer section collapsed by default

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -272,7 +272,7 @@ public class XServerDisplayActivity extends AppCompatActivity {
     private float hudScale = 1.0f;
     private boolean[] hudElements = new boolean[]{true, true, true, true, true, true};
     private boolean dualSeriesBattery = false;
-    private boolean hudCardExpanded = true;
+    private boolean hudCardExpanded = false;
     private XServerDrawerStateHolder drawerStateHolder;
     private XServerDrawerActionListener drawerActionListener;
 
@@ -612,6 +612,15 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 super.onDrawerOpened(drawerView);
                 renderDrawerMenu();
                 navigationComposeView.requestFocus();
+            }
+
+            @Override
+            public void onDrawerClosed(View drawerView) {
+                super.onDrawerClosed(drawerView);
+                if (hudCardExpanded) {
+                    hudCardExpanded = false;
+                    renderDrawerMenu();
+                }
             }
         });
 
@@ -2333,7 +2342,6 @@ public class XServerDisplayActivity extends AppCompatActivity {
                 boolean becomingVisible = !isFpsVisible;
                 frameRating.setVisibility(becomingVisible ? View.VISIBLE : View.GONE);
                 if (becomingVisible) {
-                    hudCardExpanded = true;
                     syncFrameRatingWithExistingWindows();
                     applyHUDSettings();
                 }


### PR DESCRIPTION
## What changed
- Keep the FPS monitor drawer section collapsed by default.
- Stop auto-expanding it when the FPS monitor is toggled on.
- Collapse it again whenever the left drawer is closed.

## Why
Opening the in-game left swipe menu should not automatically expose the FPS monitor controls. The section should only expand after an explicit user tap.

## Impact
Users now get a stable closed state for the FPS monitor section whenever the drawer opens or reopens.

## Validation
- Ran `./gradlew :app:compileStandardDebugJavaWithJavac`
