### PR TITLE
Lock app font scaling and default font overrides

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -187,6 +187,7 @@ import com.winlator.cmod.runtime.input.ControllerHelper
 import com.winlator.cmod.runtime.wine.PeIconExtractor
 import com.winlator.cmod.shared.android.ActivityResultHost
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity
 import com.winlator.cmod.shared.android.RefreshRateUtils
 import com.winlator.cmod.shared.io.StorageUtils
 import com.winlator.cmod.shared.ui.CarouselView
@@ -197,6 +198,7 @@ import com.winlator.cmod.shared.ui.JoystickListScroll
 import com.winlator.cmod.shared.ui.ListView
 import com.winlator.cmod.shared.ui.outlinedSwitchColors
 import com.winlator.cmod.shared.ui.widget.chasingBorder
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.dragonbra.javasteam.enums.EPersonaState
 import kotlinx.coroutines.Dispatchers
@@ -248,7 +250,7 @@ enum class LibraryLayoutMode {
 
 @AndroidEntryPoint
 class UnifiedActivity :
-    AppCompatActivity(),
+    FixedFontScaleAppCompatActivity(),
     ActivityResultHost {
     @Inject lateinit var db: PluviaDatabase
 
@@ -770,7 +772,7 @@ class UnifiedActivity :
                 }
             }
 
-            MaterialTheme(
+            WinNativeTheme(
                 colorScheme =
                     darkColorScheme(
                         primary = Accent,

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -39,6 +39,7 @@ import com.winlator.cmod.runtime.wine.DefaultVersion
 import com.winlator.cmod.runtime.wine.EnvVars
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.util.KeyValueSet
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.ui.dialog.PreloaderDialog
 import com.winlator.cmod.shared.util.StringUtils
 import com.winlator.cmod.runtime.wine.WineInfo
@@ -157,7 +158,9 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             setViewTreeLifecycleOwner(activity as LifecycleOwner)
             setViewTreeSavedStateRegistryOwner(activity as SavedStateRegistryOwner)
             setContent {
-                GameSettingsContent(state = state, callbacks = createCallbacks())
+                WinNativeTheme {
+                    GameSettingsContent(state = state, callbacks = createCallbacks())
+                }
             }
         }
         dialog.setContentView(composeView)

--- a/app/src/main/feature/settings/containers/ContainersFragment.kt
+++ b/app/src/main/feature/settings/containers/ContainersFragment.kt
@@ -29,6 +29,7 @@ import com.winlator.cmod.runtime.display.environment.ImageFs
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.ui.dialog.PreloaderDialog
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import java.io.File
 import kotlin.math.roundToInt
 
@@ -53,7 +54,7 @@ class ContainersFragment : Fragment() {
         ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/contents/ContentsFragment.kt
+++ b/app/src/main/feature/settings/contents/ContentsFragment.kt
@@ -30,6 +30,7 @@ import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.io.StorageUtils
 import com.winlator.cmod.shared.ui.dialog.ContentDialog
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -94,7 +95,7 @@ class ContentsFragment : Fragment() {
         return ComposeView(ctx).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/debug/DebugFragment.kt
+++ b/app/src/main/feature/settings/debug/DebugFragment.kt
@@ -25,6 +25,7 @@ import com.winlator.cmod.app.config.SettingsConfig
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.io.AssetPaths
 import com.winlator.cmod.shared.io.FileUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.util.ArrayUtils
 import org.json.JSONArray
 import java.io.File
@@ -50,7 +51,7 @@ class DebugFragment : Fragment() {
         return ComposeView(ctx).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/drivers/DriversFragment.kt
+++ b/app/src/main/feature/settings/drivers/DriversFragment.kt
@@ -23,6 +23,7 @@ import com.winlator.cmod.feature.setup.SetupWizardActivity
 import com.winlator.cmod.runtime.content.AdrenotoolsManager
 import com.winlator.cmod.runtime.content.Downloader
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -83,7 +84,7 @@ class DriversFragment : Fragment() {
         return ComposeView(ctx).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/input/InputControlsFragment.kt
+++ b/app/src/main/feature/settings/input/InputControlsFragment.kt
@@ -41,6 +41,7 @@ import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.io.HttpUtils
 import com.winlator.cmod.shared.math.Mathf
 import com.winlator.cmod.shared.ui.dialog.ContentDialog
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import org.json.JSONObject
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -136,7 +137,7 @@ class InputControlsFragment : Fragment() {
         ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -36,6 +36,7 @@ import com.winlator.cmod.shared.android.RefreshRateUtils
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.ui.dialog.ContentDialog
 import com.winlator.cmod.shared.ui.dialog.PreloaderDialog
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import java.io.File
 
 class OtherSettingsFragment : Fragment() {
@@ -92,7 +93,7 @@ class OtherSettingsFragment : Fragment() {
         return ComposeView(ctx).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/presets/PresetsFragment.kt
+++ b/app/src/main/feature/settings/presets/PresetsFragment.kt
@@ -27,6 +27,7 @@ import com.winlator.cmod.runtime.wine.EnvVars
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.io.AssetPaths
 import com.winlator.cmod.shared.io.FileUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.util.StringUtils
 import org.json.JSONArray
 import java.util.Locale
@@ -113,7 +114,7 @@ class PresetsFragment : Fragment() {
         return ComposeView(ctx).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/settings/stores/StoresFragment.kt
+++ b/app/src/main/feature/settings/stores/StoresFragment.kt
@@ -28,6 +28,7 @@ import com.winlator.cmod.feature.stores.steam.service.SteamService
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.shared.io.AssetPaths
 import com.winlator.cmod.shared.io.FileUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -147,7 +148,7 @@ class StoresFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                MaterialTheme(
+                WinNativeTheme(
                     colorScheme =
                         darkColorScheme(
                             primary = Color(0xFF1A9FFF),

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -109,10 +109,12 @@ import com.winlator.cmod.runtime.display.environment.ImageFsInstaller
 import com.winlator.cmod.runtime.wine.DefaultVersion
 import com.winlator.cmod.runtime.wine.WineInfo
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.android.FixedFontScaleFragmentActivity
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.io.TarCompressorUtils
 import com.winlator.cmod.shared.io.TarCompressorUtils.Type
 import com.winlator.cmod.shared.ui.widget.chasingBorder
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.util.OnExtractFileListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -140,7 +142,7 @@ private data class TabInfo(
     val highlight: Boolean = false,
 )
 
-class SetupWizardActivity : FragmentActivity() {
+class SetupWizardActivity : FixedFontScaleFragmentActivity() {
     companion object {
         private const val PREFS_NAME = "winnative_setup"
         private const val EXTRA_FORCE_SHOW = "force_show"
@@ -561,7 +563,7 @@ class SetupWizardActivity : FragmentActivity() {
         loadAdvancedProfiles()
 
         setContent {
-            MaterialTheme(
+            WinNativeTheme(
                 colorScheme =
                     darkColorScheme(
                         primary = Color(0xFF57CBDE),

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -48,6 +48,7 @@ import com.winlator.cmod.runtime.wine.EnvVars
 import com.winlator.cmod.shared.io.FileUtils
 import com.winlator.cmod.shared.util.KeyValueSet
 import com.winlator.cmod.shared.android.RefreshRateUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.util.StringUtils
 import com.winlator.cmod.runtime.wine.WineInfo
 import com.winlator.cmod.runtime.compat.fexcore.FEXCoreManager
@@ -155,10 +156,12 @@ class ShortcutSettingsComposeDialog private constructor(
             setViewTreeLifecycleOwner(activity as LifecycleOwner)
             setViewTreeSavedStateRegistryOwner(activity as SavedStateRegistryOwner)
             setContent {
-                GameSettingsContent(
-                    state = state,
-                    callbacks = createCallbacks()
-                )
+                WinNativeTheme {
+                    GameSettingsContent(
+                        state = state,
+                        callbacks = createCallbacks()
+                    )
+                }
             }
         }
         dialog.setContentView(composeView)

--- a/app/src/main/feature/stores/epic/ui/auth/EpicOAuthActivity.kt
+++ b/app/src/main/feature/stores/epic/ui/auth/EpicOAuthActivity.kt
@@ -6,11 +6,12 @@ import android.os.Bundle
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import com.winlator.cmod.feature.stores.epic.service.EpicConstants
 import com.winlator.cmod.feature.stores.epic.ui.component.dialog.AuthWebViewDialog
 import com.winlator.cmod.feature.stores.steam.utils.redactUrlForLogging
+import com.winlator.cmod.shared.android.FixedFontScaleComponentActivity
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import timber.log.Timber
 
 /**
@@ -19,7 +20,7 @@ import timber.log.Timber
  * ({"authorizationCode":"...", ...}), not in the URL – so we read the body via JS.
  * Uses a per-session state parameter for CSRF protection.
  */
-class EpicOAuthActivity : ComponentActivity() {
+class EpicOAuthActivity : FixedFontScaleComponentActivity() {
     companion object {
         const val EXTRA_AUTH_CODE = "auth_code"
         const val EXTRA_ERROR = "error"
@@ -63,7 +64,7 @@ class EpicOAuthActivity : ComponentActivity() {
         initialAuthUrl = authUrl
 
         setContent {
-            MaterialTheme(colorScheme = darkColorScheme()) {
+            WinNativeTheme(colorScheme = darkColorScheme()) {
                 AuthWebViewDialog(
                     isVisible = true,
                     url = authUrl,

--- a/app/src/main/feature/stores/epic/ui/component/dialog/AuthWebViewDialog.kt
+++ b/app/src/main/feature/stores/epic/ui/component/dialog/AuthWebViewDialog.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.winlator.cmod.R
 import com.winlator.cmod.feature.stores.steam.utils.redactUrlForLogging
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -212,7 +213,7 @@ fun AuthWebViewDialog(
 @Preview
 @Composable
 private fun Preview_AuthWebView() {
-    MaterialTheme(colorScheme = darkColorScheme()) {
+    WinNativeTheme(colorScheme = darkColorScheme()) {
         AuthWebViewDialog(
             isVisible = true,
             url = "https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=galaxy",

--- a/app/src/main/feature/stores/gog/ui/auth/GOGOAuthActivity.kt
+++ b/app/src/main/feature/stores/gog/ui/auth/GOGOAuthActivity.kt
@@ -5,11 +5,12 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import com.winlator.cmod.feature.stores.epic.ui.component.dialog.AuthWebViewDialog
 import com.winlator.cmod.feature.stores.gog.service.GOGConstants
 import com.winlator.cmod.feature.stores.steam.utils.redactUrlForLogging
+import com.winlator.cmod.shared.android.FixedFontScaleComponentActivity
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import timber.log.Timber
 
 /**
@@ -17,7 +18,7 @@ import timber.log.Timber
  * the authorization code when GOG redirects to the success URL (aligns with gog-support).
  * Uses a per-session state parameter for CSRF protection.
  */
-class GOGOAuthActivity : ComponentActivity() {
+class GOGOAuthActivity : FixedFontScaleComponentActivity() {
     companion object {
         const val EXTRA_AUTH_CODE = "auth_code"
         const val EXTRA_ERROR = "error"
@@ -53,7 +54,7 @@ class GOGOAuthActivity : ComponentActivity() {
         initialAuthUrl = authUrl
 
         setContent {
-            MaterialTheme(colorScheme = darkColorScheme()) {
+            WinNativeTheme(colorScheme = darkColorScheme()) {
                 AuthWebViewDialog(
                     isVisible = true,
                     url = authUrl,

--- a/app/src/main/feature/stores/steam/SteamLoginActivity.kt
+++ b/app/src/main/feature/stores/steam/SteamLoginActivity.kt
@@ -48,6 +48,8 @@ import com.winlator.cmod.feature.stores.steam.enums.LoginScreen
 import com.winlator.cmod.feature.stores.steam.ui.SteamLoginViewModel
 import com.winlator.cmod.feature.stores.steam.ui.components.QrCodeImage
 import com.winlator.cmod.feature.stores.steam.ui.data.UserLoginState
+import com.winlator.cmod.shared.android.FixedFontScaleComponentActivity
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.ui.outlinedSwitchColors
 import timber.log.Timber
 
@@ -61,7 +63,7 @@ private val TextPrimary = Color(0xFFF0F4FF)
 private val TextSecondary = Color(0xFF7A8FA8)
 private val DangerRed = Color(0xFFFF7A88)
 
-class SteamLoginActivity : ComponentActivity() {
+class SteamLoginActivity : FixedFontScaleComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -74,7 +76,7 @@ class SteamLoginActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
-            MaterialTheme(
+            WinNativeTheme(
                 colorScheme =
                     darkColorScheme(
                         primary = Accent,

--- a/app/src/main/feature/stores/steam/ui/SteamClientDownloadFailureDialog.kt
+++ b/app/src/main/feature/stores/steam/ui/SteamClientDownloadFailureDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.winlator.cmod.shared.theme.WinNativeTheme
 
 object SteamClientDownloadFailureDialog {
     @JvmStatic
@@ -63,7 +64,7 @@ object SteamClientDownloadFailureDialog {
                     setViewTreeSavedStateRegistryOwner(it)
                 }
                 setContent {
-                    MaterialTheme(
+                    WinNativeTheme(
                         colorScheme =
                             darkColorScheme(
                                 primary = Color(0xFF57CBDE),

--- a/app/src/main/feature/sync/CloudSyncConflictDialog.kt
+++ b/app/src/main/feature/sync/CloudSyncConflictDialog.kt
@@ -45,12 +45,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.winlator.cmod.shared.theme.WinNativeTheme
 
 data class CloudSyncConflictTimestamps(
     val localTimestampLabel: String,
@@ -91,7 +91,7 @@ object CloudSyncConflictDialog {
                     setViewTreeSavedStateRegistryOwner(it)
                 }
                 setContent {
-                    MaterialTheme(
+                    WinNativeTheme(
                         colorScheme =
                             darkColorScheme(
                                 primary = Color(0xFF57CBDE),
@@ -223,7 +223,6 @@ private fun CloudSyncConflictDialogContent(
                                     style = MaterialTheme.typography.labelLarge,
                                     color = Color(0xFF8FA7C1),
                                     fontWeight = FontWeight.Medium,
-                                    fontFamily = FontFamily.Default,
                                 )
                                 Text(
                                     text = "Local save\n${timestamps.localTimestampLabel}",

--- a/app/src/main/feature/sync/google/GoogleFragment.kt
+++ b/app/src/main/feature/sync/google/GoogleFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import com.winlator.cmod.shared.theme.WinNativeTheme
 
 class GoogleFragment : Fragment() {
     override fun onCreateView(
@@ -17,7 +18,9 @@ class GoogleFragment : Fragment() {
         ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                GoogleScreen()
+                WinNativeTheme {
+                    GoogleScreen()
+                }
             }
         }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,8 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="android:windowBackground">@color/window_background_color</item>
         <item name="android:colorBackground">@color/window_background_color</item>
+        <item name="android:fontFamily">@font/inter</item>
+        <item name="fontFamily">@font/inter</item>
         <item name="android:textViewStyle">@style/TextView</item>
         <item name="android:checkboxStyle">@style/CheckBox</item>
         <item name="android:listPopupWindowStyle">@style/ListPopupWindow</item>
@@ -26,6 +28,8 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDarkModeDark</item>
         <item name="android:windowBackground">@color/window_background_color_dark</item>
         <item name="android:colorBackground">@color/window_background_color_dark</item>
+        <item name="android:fontFamily">@font/inter</item>
+        <item name="fontFamily">@font/inter</item>
         <item name="android:textViewStyle">@style/TextView.Dark</item>
         <item name="android:checkboxStyle">@style/CheckBox.Dark</item>
         <item name="android:listPopupWindowStyle">@style/ListPopupWindow.Dark</item>
@@ -85,6 +89,7 @@
 
     <style name="SpinnerDropDownItem" parent="Widget.AppCompat.DropDownItem.Spinner">
         <item name="android:textColor">#000000</item>
+        <item name="android:fontFamily">@font/inter</item>
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
     </style>
@@ -165,6 +170,7 @@
     <style name="EditText">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">42dp</item>
+        <item name="android:fontFamily">@font/inter</item>
         <item name="android:textSize">16sp</item>
         <item name="android:gravity">left|center_vertical</item>
         <item name="android:paddingLeft">12dp</item>
@@ -183,6 +189,7 @@
 
     <!-- TextView Styles -->
     <style name="TextView" parent="@android:style/Widget.TextView">
+        <item name="android:fontFamily">@font/inter</item>
         <item name="android:textSize">16sp</item>
     </style>
 
@@ -195,6 +202,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:textColorSecondary">@color/colorPrimary</item>
         <item name="android:textColor">#000000</item>
+        <item name="android:fontFamily">@font/inter</item>
         <item name="android:textSize">16sp</item>
     </style>
 
@@ -211,6 +219,7 @@
         <item name="android:layout_height">42dp</item>
         <item name="android:focusable">true</item>
         <item name="android:clickable">true</item>
+        <item name="android:fontFamily">@font/inter</item>
         <item name="android:textSize">16sp</item>
         <item name="android:lines">1</item>
         <item name="android:gravity">center</item>

--- a/app/src/main/runtime/display/ScreenEffectDialog.kt
+++ b/app/src/main/runtime/display/ScreenEffectDialog.kt
@@ -19,6 +19,7 @@ import com.winlator.cmod.runtime.display.renderer.effects.FXAAEffect
 import com.winlator.cmod.runtime.display.renderer.effects.NTSCCombinedEffect
 import com.winlator.cmod.runtime.display.renderer.effects.ToonEffect
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import com.winlator.cmod.shared.ui.dialog.ContentDialog
 import com.winlator.cmod.shared.util.KeyValueSet
 
@@ -82,33 +83,35 @@ class ScreenEffectDialog(
                 setViewTreeLifecycleOwner(activity)
                 setViewTreeSavedStateRegistryOwner(activity)
                 setContent {
-                    ScreenEffectDialogContent(
-                        state =
-                            ScreenEffectState(
-                                brightness = brightness.floatValue,
-                                contrast = contrast.floatValue,
-                                gamma = gamma.floatValue,
-                                enableFXAA = enableFXAA.value,
-                                enableCRT = enableCRT.value,
-                                enableToon = enableToon.value,
-                                enableNTSC = enableNTSC.value,
-                                profileNames = profileNames.value,
-                                selectedProfileIndex = selectedProfileIndex.intValue,
-                            ),
-                        onBrightnessChange = { brightness.floatValue = it },
-                        onContrastChange = { contrast.floatValue = it },
-                        onGammaChange = { gamma.floatValue = it },
-                        onFXAAChange = { enableFXAA.value = it },
-                        onCRTChange = { enableCRT.value = it },
-                        onToonChange = { enableToon.value = it },
-                        onNTSCChange = { enableNTSC.value = it },
-                        onProfileSelected = { onProfileSelected(it) },
-                        onAddProfile = { promptAddProfile() },
-                        onRemoveProfile = { promptDeleteProfile() },
-                        onReset = { resetSettings() },
-                        onCancel = { dismiss() },
-                        onConfirm = { onConfirm() },
-                    )
+                    WinNativeTheme {
+                        ScreenEffectDialogContent(
+                            state =
+                                ScreenEffectState(
+                                    brightness = brightness.floatValue,
+                                    contrast = contrast.floatValue,
+                                    gamma = gamma.floatValue,
+                                    enableFXAA = enableFXAA.value,
+                                    enableCRT = enableCRT.value,
+                                    enableToon = enableToon.value,
+                                    enableNTSC = enableNTSC.value,
+                                    profileNames = profileNames.value,
+                                    selectedProfileIndex = selectedProfileIndex.intValue,
+                                ),
+                            onBrightnessChange = { brightness.floatValue = it },
+                            onContrastChange = { contrast.floatValue = it },
+                            onGammaChange = { gamma.floatValue = it },
+                            onFXAAChange = { enableFXAA.value = it },
+                            onCRTChange = { enableCRT.value = it },
+                            onToonChange = { enableToon.value = it },
+                            onNTSCChange = { enableNTSC.value = it },
+                            onProfileSelected = { onProfileSelected(it) },
+                            onAddProfile = { promptAddProfile() },
+                            onRemoveProfile = { promptDeleteProfile() },
+                            onReset = { resetSettings() },
+                            onCancel = { dismiss() },
+                            onConfirm = { onConfirm() },
+                        )
+                    }
                 }
             }
         dialog.setContentView(composeView)

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -118,6 +118,7 @@ import com.winlator.cmod.runtime.display.renderer.GLRenderer;
 import com.winlator.cmod.runtime.display.ui.FrameRating;
 import com.winlator.cmod.runtime.display.ui.MagnifierView;
 import com.winlator.cmod.runtime.display.ui.XServerView;
+import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity;
 import com.winlator.cmod.runtime.input.ui.InputControlsView;
 import com.winlator.cmod.runtime.input.ui.TouchpadView;
 import com.winlator.cmod.runtime.system.ui.LogView;
@@ -168,7 +169,7 @@ import java.util.regex.Pattern;
 
 import cn.sherlock.com.sun.media.sound.SF2Soundbank;
 
-public class XServerDisplayActivity extends AppCompatActivity {
+public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     public static String NOTIFICATION_CHANNEL_ID = "Winlator";
     public static int NOTIFICATION_ID = -1;
     private static final long STEAM_TERMINATION_GRACE_MS = 10000L;

--- a/app/src/main/runtime/input/ControlsEditorActivity.java
+++ b/app/src/main/runtime/input/ControlsEditorActivity.java
@@ -20,7 +20,6 @@ import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
-import androidx.appcompat.app.AppCompatActivity;
 import com.winlator.cmod.R;
 import com.winlator.cmod.runtime.input.controls.Binding;
 import com.winlator.cmod.runtime.input.controls.ControlElement;
@@ -28,6 +27,7 @@ import com.winlator.cmod.runtime.input.controls.ControlsProfile;
 import com.winlator.cmod.runtime.input.controls.InputControlsManager;
 import com.winlator.cmod.runtime.input.ui.InputControlsView;
 import com.winlator.cmod.shared.android.AppUtils;
+import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity;
 import com.winlator.cmod.shared.io.FileUtils;
 import com.winlator.cmod.shared.math.Mathf;
 import com.winlator.cmod.shared.ui.widget.NumberPicker;
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-public class ControlsEditorActivity extends AppCompatActivity implements View.OnClickListener {
+public class ControlsEditorActivity extends FixedFontScaleAppCompatActivity implements View.OnClickListener {
   private InputControlsView inputControlsView;
   private ControlsProfile profile;
 

--- a/app/src/main/shared/android/FixedFontScaleActivity.kt
+++ b/app/src/main/shared/android/FixedFontScaleActivity.kt
@@ -1,0 +1,52 @@
+package com.winlator.cmod.shared.android
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
+
+private const val LOCKED_APP_FONT_SCALE = 1f
+
+private fun lockFontScale(configuration: Configuration?): Configuration? =
+    configuration?.let {
+        Configuration(it).apply {
+            fontScale = LOCKED_APP_FONT_SCALE
+        }
+    }
+
+private fun lockFontScale(base: Context?): Context? {
+    if (base == null) return null
+    val configuration = lockFontScale(base.resources.configuration) ?: return base
+    return base.createConfigurationContext(configuration)
+}
+
+open class FixedFontScaleAppCompatActivity : AppCompatActivity() {
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(lockFontScale(newBase))
+    }
+
+    override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
+        super.applyOverrideConfiguration(lockFontScale(overrideConfiguration))
+    }
+}
+
+open class FixedFontScaleComponentActivity : ComponentActivity() {
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(lockFontScale(newBase))
+    }
+
+    override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
+        super.applyOverrideConfiguration(lockFontScale(overrideConfiguration))
+    }
+}
+
+open class FixedFontScaleFragmentActivity : FragmentActivity() {
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(lockFontScale(newBase))
+    }
+
+    override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
+        super.applyOverrideConfiguration(lockFontScale(overrideConfiguration))
+    }
+}

--- a/app/src/main/shared/theme/WinNativeTheme.kt
+++ b/app/src/main/shared/theme/WinNativeTheme.kt
@@ -1,8 +1,14 @@
 package com.winlator.cmod.shared.theme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.winlator.cmod.R
 
 val WinNativeBackground = Color(0xFF18181D)
 val WinNativeSurface = Color(0xFF1C1C2A)
@@ -23,10 +29,43 @@ private val WinNativeColorScheme =
         onBackground = WinNativeTextPrimary,
     )
 
+val WinNativeFontFamily =
+    FontFamily(
+        Font(R.font.inter_medium, FontWeight.Normal),
+        Font(R.font.inter_medium, FontWeight.Medium),
+        Font(R.font.inter_medium, FontWeight.SemiBold),
+        Font(R.font.inter_medium, FontWeight.Bold),
+    )
+
+private val BaseTypography = Typography()
+
+val WinNativeTypography =
+    Typography(
+        displayLarge = BaseTypography.displayLarge.copy(fontFamily = WinNativeFontFamily),
+        displayMedium = BaseTypography.displayMedium.copy(fontFamily = WinNativeFontFamily),
+        displaySmall = BaseTypography.displaySmall.copy(fontFamily = WinNativeFontFamily),
+        headlineLarge = BaseTypography.headlineLarge.copy(fontFamily = WinNativeFontFamily),
+        headlineMedium = BaseTypography.headlineMedium.copy(fontFamily = WinNativeFontFamily),
+        headlineSmall = BaseTypography.headlineSmall.copy(fontFamily = WinNativeFontFamily),
+        titleLarge = BaseTypography.titleLarge.copy(fontFamily = WinNativeFontFamily),
+        titleMedium = BaseTypography.titleMedium.copy(fontFamily = WinNativeFontFamily),
+        titleSmall = BaseTypography.titleSmall.copy(fontFamily = WinNativeFontFamily),
+        bodyLarge = BaseTypography.bodyLarge.copy(fontFamily = WinNativeFontFamily),
+        bodyMedium = BaseTypography.bodyMedium.copy(fontFamily = WinNativeFontFamily),
+        bodySmall = BaseTypography.bodySmall.copy(fontFamily = WinNativeFontFamily),
+        labelLarge = BaseTypography.labelLarge.copy(fontFamily = WinNativeFontFamily),
+        labelMedium = BaseTypography.labelMedium.copy(fontFamily = WinNativeFontFamily),
+        labelSmall = BaseTypography.labelSmall.copy(fontFamily = WinNativeFontFamily),
+    )
+
 @Composable
-fun WinNativeTheme(content: @Composable () -> Unit) {
+fun WinNativeTheme(
+    colorScheme: ColorScheme = WinNativeColorScheme,
+    content: @Composable () -> Unit,
+) {
     MaterialTheme(
-        colorScheme = WinNativeColorScheme,
+        colorScheme = colorScheme,
+        typography = WinNativeTypography,
         content = content,
     )
 }

--- a/app/src/main/shared/ui/dialog/PreloaderDialogContent.kt
+++ b/app/src/main/shared/ui/dialog/PreloaderDialogContent.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.winlator.cmod.R
+import com.winlator.cmod.shared.theme.WinNativeTheme
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -529,6 +530,8 @@ fun setupPreloaderComposeView(
         composeView.setViewTreeSavedStateRegistryOwner(activity)
     }
     composeView.setContent {
-        PreloaderDialogContent(state)
+        WinNativeTheme {
+            PreloaderDialogContent(state)
+        }
     }
 }


### PR DESCRIPTION
- lock app font scaling to the authored sizes by forcing `fontScale = 1f` in the main activity hosts
- pin default XML and Compose typography to bundled app fonts so phone-level custom fonts do not override them
- preserve screen-specific font choices by only changing defaults and fallback behavior
- validate with `./gradlew.bat :app:compileStandardDebugKotlin :app:compileStandardDebugJavaWithJavac`