### PR TITLE
Fix Google sync startup and snapshot cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="true"
         android:appCategory="game"
         android:isGame="true"
         android:allowBackup="false"
@@ -167,7 +168,11 @@
             android:value="@string/play_games_app_id" />
         <meta-data
             android:name="com.google.android.gms.games.should_auto_sign_in"
-            android:value="true" />
+            android:value="false" />
+
+        <provider
+            android:name="com.google.android.gms.games.provider.PlayGamesInitProvider"
+            tools:node="remove" />
 
     </application>
 </manifest>

--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -3,7 +3,6 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
-import com.google.android.gms.games.PlayGamesSdk
 import com.winlator.cmod.app.service.DownloadService
 import com.winlator.cmod.app.update.UpdateChecker
 import com.winlator.cmod.feature.setup.SetupWizardActivity
@@ -27,9 +26,6 @@ class PluviaApp : Application() {
     override fun onCreate() {
         super.onCreate()
         instance = this
-
-        // Initialize Play Games Services SDK (v2)
-        PlayGamesSdk.initialize(this)
 
         registerRefreshRateLifecycleCallbacks()
 

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -126,7 +126,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -177,7 +176,6 @@ import com.winlator.cmod.feature.stores.steam.events.EventDispatcher
 import com.winlator.cmod.feature.stores.steam.service.SteamService
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.feature.stores.steam.utils.getAvatarURL
-import com.winlator.cmod.feature.sync.google.CloudSyncManager
 import com.winlator.cmod.feature.sync.google.GameSaveBackupManager
 import com.winlator.cmod.runtime.container.ContainerManager
 import com.winlator.cmod.runtime.container.Shortcut
@@ -279,7 +277,6 @@ class UnifiedActivity :
 
     // Trigger to refresh library when activity resumes from another container
     var libraryRefreshSignal by mutableIntStateOf(0)
-    private var hasBootstrappedGoogleRestoreOnHome = false
 
     // Freezes the library/store card chasing borders while any full-screen
     // dialog is open, so the ~120 Hz animation cost isn't paid for content
@@ -541,15 +538,6 @@ class UnifiedActivity :
         // (Re)start the background update loop (checks hourly + on first tick)
         UpdateChecker.startBackgroundLoop(this)
 
-        lifecycleScope.launch {
-            bootstrapGoogleRestoreOnFirstHomeArrival()
-        }
-    }
-
-    private suspend fun bootstrapGoogleRestoreOnFirstHomeArrival() {
-        if (hasBootstrappedGoogleRestoreOnHome) return
-        hasBootstrappedGoogleRestoreOnHome = true
-        CloudSyncManager.bootstrapOnHomeScreenArrival(this)
     }
 
     override fun dispatchGenericMotionEvent(event: android.view.MotionEvent): Boolean {

--- a/app/src/main/feature/sync/google/CloudSyncManager.kt
+++ b/app/src/main/feature/sync/google/CloudSyncManager.kt
@@ -1,13 +1,14 @@
 package com.winlator.cmod.feature.sync.google
 import android.app.Activity
 import android.content.Context
-import android.os.SystemClock
+import android.os.ParcelFileDescriptor
 import android.util.Log
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.games.PlayGames
 import com.google.android.gms.games.SnapshotsClient
 import com.google.android.gms.games.snapshot.Snapshot
+import com.google.android.gms.games.snapshot.SnapshotContents
 import com.google.android.gms.games.snapshot.SnapshotMetadataChange
 import com.google.android.gms.tasks.Tasks
 import com.winlator.cmod.R
@@ -48,8 +49,6 @@ object CloudSyncManager {
     private const val SNAPSHOT_NAME = "store_logins_v1"
     private const val AUTH_SESSION_RETRY_COUNT = 5
     private const val AUTH_SESSION_RETRY_DELAY_MS = 750L
-    private const val HOME_BOOTSTRAP_TIMEOUT_MS = 15000L
-    private const val HOME_BOOTSTRAP_POLL_DELAY_MS = 1000L
     private const val ZIP_MANIFEST = "manifest.json"
     private const val ZIP_STEAM = "stores/steam.json"
     private const val ZIP_EPIC = "stores/epic_credentials.json"
@@ -137,6 +136,7 @@ object CloudSyncManager {
         activity: Activity,
         callback: (Boolean, String) -> Unit,
     ) {
+        PlayGamesBootstrap.ensureInitialized(activity)
         val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
         Log.i(TAG, "Starting Google Play Games sign-in for store login sync")
         Timber.tag(TAG).i("Starting Google Play Games sign-in for store login sync")
@@ -160,40 +160,40 @@ object CloudSyncManager {
         scope.launch {
             prefs(activity).edit().putBoolean(KEY_GOOGLE_SYNC_ENABLED, true).apply()
 
-            if (!awaitAuthenticatedSession(activity)) {
-                callback(
-                    false,
-                    activity.getString(R.string.google_cloud_sign_in_finishing),
-                )
-                return@launch
-            }
-
-            Timber.tag(TAG).i("Play Games session ready; checking Saved Games state and auto-restoring missing store tokens")
-            val message =
-                runCatching {
-                    val summary = autoRestoreMissingStoresFromCloud(activity, reason = "manual_sign_in")
-                    val state = readStateInternal(activity, authenticated = true)
-                    when {
-                        summary.restoredStores.isNotEmpty() -> {
-                            summary.message(activity)
-                        }
-
-                        state.cloudStores.isNotEmpty() && state.cloudStores != state.localStores -> {
-                            activity.getString(R.string.google_cloud_connected_restore_available, state.cloudStores.joinToString())
-                        }
-
-                        state.localStores.isNotEmpty() -> {
-                            activity.getString(R.string.google_cloud_connected_tap_backup, state.localStores.joinToString())
-                        }
-
-                        else -> {
-                            activity.getString(R.string.google_cloud_connected_ready)
-                        }
+            val result =
+                withContext(Dispatchers.IO) {
+                    if (!awaitAuthenticatedSession(activity)) {
+                        return@withContext false to activity.getString(R.string.google_cloud_sign_in_finishing)
                     }
-                }.getOrElse { error ->
-                    rememberSyncError(activity, error)
+
+                    Timber.tag(TAG).i("Play Games session ready; checking Saved Games state and auto-restoring missing store tokens")
+                    val message =
+                        runCatching {
+                            val summary = autoRestoreMissingStoresFromCloud(activity, reason = "manual_sign_in")
+                            val state = readStateInternal(activity, authenticated = true)
+                            when {
+                                summary.restoredStores.isNotEmpty() -> {
+                                    summary.message(activity)
+                                }
+
+                                state.cloudStores.isNotEmpty() && state.cloudStores != state.localStores -> {
+                                    activity.getString(R.string.google_cloud_connected_restore_available, state.cloudStores.joinToString())
+                                }
+
+                                state.localStores.isNotEmpty() -> {
+                                    activity.getString(R.string.google_cloud_connected_tap_backup, state.localStores.joinToString())
+                                }
+
+                                else -> {
+                                    activity.getString(R.string.google_cloud_connected_ready)
+                                }
+                            }
+                        }.getOrElse { error ->
+                            rememberSyncError(activity, error)
+                        }
+                    true to message
                 }
-            callback(true, message)
+            callback(result.first, result.second)
         }
     }
 
@@ -216,6 +216,7 @@ object CloudSyncManager {
         activity: Activity,
         callback: (Boolean) -> Unit,
     ) {
+        PlayGamesBootstrap.ensureInitialized(activity)
         val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
         gamesSignInClient.isAuthenticated.addOnCompleteListener { task ->
             val authenticated = task.isSuccessful && task.result?.isAuthenticated == true
@@ -244,45 +245,6 @@ object CloudSyncManager {
                 entryReason = "google_screen_opened",
             ).state
         }
-
-    suspend fun bootstrapOnHomeScreenArrival(activity: Activity): String? {
-        return withContext(Dispatchers.IO) {
-            val shouldRetrySessionAdoption = !prefs(activity).contains(KEY_GOOGLE_SYNC_ENABLED)
-            val timeoutAt = SystemClock.elapsedRealtime() + HOME_BOOTSTRAP_TIMEOUT_MS
-            var attempt = 0
-
-            while (SystemClock.elapsedRealtime() < timeoutAt) {
-                val entryReason =
-                    if (attempt == 0) {
-                        "home_screen_bootstrap"
-                    } else {
-                        "home_screen_bootstrap_retry_$attempt"
-                    }
-                val entry =
-                    readSyncEntryState(
-                        activity = activity,
-                        entryReason = entryReason,
-                    )
-                val restoredToastMessage =
-                    entry.autoRestoreSummary
-                        ?.takeIf { it.restoredStores.isNotEmpty() }
-                        ?.message(activity)
-                if (restoredToastMessage != null) {
-                    return@withContext restoredToastMessage
-                }
-
-                if (!shouldRetrySessionAdoption || entry.state.googleSignedIn) {
-                    return@withContext null
-                }
-
-                attempt += 1
-                delay(HOME_BOOTSTRAP_POLL_DELAY_MS)
-            }
-
-            Timber.tag(TAG).i("Home screen Google bootstrap timed out waiting for Play Games auto sign-in")
-            null
-        }
-    }
 
     suspend fun readStoreLoginState(activity: Activity): StoreLoginSyncState {
         return withContext(Dispatchers.IO) {
@@ -533,6 +495,7 @@ object CloudSyncManager {
         Log.i(TAG, "Opening snapshot for backup: $SNAPSHOT_NAME")
         Timber.tag(TAG).i("Opening snapshot for backup: %s", SNAPSHOT_NAME)
         val snapshot = openSnapshot(activity, client, createIfMissing = true) ?: return emptySet()
+        val snapshotFileDescriptor = snapshotParcelFileDescriptor(snapshot.snapshotContents)
         try {
             val bytes = payloadToZip(payload)
             Timber.tag(TAG).i("Writing %d bytes to snapshot for stores=%s", bytes.size, payload.stores.keys)
@@ -562,6 +525,8 @@ object CloudSyncManager {
             Timber.tag(TAG).e(error, "Snapshot backup failed for stores=%s", payload.stores.keys)
             runCatching { Tasks.await(client.discardAndClose(snapshot)) }
             throw error
+        } finally {
+            closeQuietly(snapshotFileDescriptor)
         }
     }
 
@@ -569,6 +534,7 @@ object CloudSyncManager {
         val client = freshSnapshotsClient(activity) ?: return SnapshotReadResult(null, null)
         Timber.tag(TAG).d("Opening snapshot for read: %s", SNAPSHOT_NAME)
         val snapshot = openSnapshot(activity, client, createIfMissing = false) ?: return SnapshotReadResult(null, null)
+        val snapshotFileDescriptor = snapshotParcelFileDescriptor(snapshot.snapshotContents)
         return try {
             val bytes = snapshot.snapshotContents.readFully()
             val payload = if (bytes.isNotEmpty()) zipToPayload(bytes) else null
@@ -586,6 +552,8 @@ object CloudSyncManager {
             Timber.tag(TAG).e(error, "Snapshot read failed")
             runCatching { Tasks.await(client.discardAndClose(snapshot)) }
             throw error
+        } finally {
+            closeQuietly(snapshotFileDescriptor)
         }
     }
 
@@ -611,12 +579,12 @@ object CloudSyncManager {
                             SnapshotsClient.RESOLUTION_POLICY_MOST_RECENTLY_MODIFIED,
                         ),
                     )
-                if (result.isConflict) {
-                    Timber.tag(TAG).w("Snapshot conflict detected for %s", SNAPSHOT_NAME)
-                } else {
+                if (!result.isConflict) {
                     Timber.tag(TAG).d("Snapshot open returned without conflict")
+                    return result.data
                 }
-                return result.data ?: result.conflict?.snapshot ?: result.conflict?.conflictingSnapshot
+                val snapshot = resolveSnapshotConflict(client, result.conflict) ?: return null
+                return snapshot
             } catch (error: Exception) {
                 if (!createIfMissing && isMissingSnapshotError(error)) {
                     Timber.tag(TAG).d("No existing store login snapshot found: ${error.message}")
@@ -639,7 +607,74 @@ object CloudSyncManager {
         return null
     }
 
-    private suspend fun freshSnapshotsClient(activity: Activity): SnapshotsClient? = PlayGames.getSnapshotsClient(activity)
+    private suspend fun resolveSnapshotConflict(
+        client: SnapshotsClient,
+        conflict: SnapshotsClient.SnapshotConflict?,
+    ): Snapshot? {
+        if (conflict == null) return null
+
+        var pendingConflict: SnapshotsClient.SnapshotConflict? = conflict
+        while (pendingConflict != null) {
+            val candidates =
+                listOfNotNull(
+                    pendingConflict.snapshot,
+                    pendingConflict.conflictingSnapshot,
+                )
+            if (candidates.isEmpty()) {
+                return null
+            }
+
+            val chosen =
+                candidates.maxByOrNull { snapshot ->
+                    snapshot.metadata.lastModifiedTimestamp
+                } ?: return null
+
+            Log.w(TAG, "Snapshot conflict detected for $SNAPSHOT_NAME; resolving with most recent snapshot")
+            Timber.tag(TAG).w(
+                "Snapshot conflict detected for %s; resolving with lastModified=%d",
+                SNAPSHOT_NAME,
+                chosen.metadata.lastModifiedTimestamp,
+            )
+
+            val resolved =
+                Tasks.await(
+                    client.resolveConflict(
+                        pendingConflict.conflictId,
+                        chosen,
+                    ),
+                )
+
+            if (!resolved.isConflict) {
+                Timber.tag(TAG).i(
+                    "Resolved snapshot conflict for %s with lastModified=%d",
+                    SNAPSHOT_NAME,
+                    chosen.metadata.lastModifiedTimestamp,
+                )
+                return resolved.data
+            }
+
+            pendingConflict = resolved.conflict
+        }
+
+        return null
+    }
+
+    private suspend fun freshSnapshotsClient(activity: Activity): SnapshotsClient? {
+        PlayGamesBootstrap.ensureInitialized(activity)
+        return PlayGames.getSnapshotsClient(activity)
+    }
+
+    private fun snapshotParcelFileDescriptor(contents: SnapshotContents?): ParcelFileDescriptor? =
+        runCatching {
+            contents?.parcelFileDescriptor
+        }.getOrNull()
+
+    private fun closeQuietly(descriptor: ParcelFileDescriptor?) {
+        try {
+            descriptor?.close()
+        } catch (_: Exception) {
+        }
+    }
 
     fun onSavedGamesPermissionResult(activity: Activity) {
         Timber.tag(TAG).w(
@@ -1189,6 +1224,7 @@ object CloudSyncManager {
     }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
                 return true
@@ -1225,6 +1261,7 @@ object CloudSyncManager {
 
     private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
         try {
+            PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
                 withContext(Dispatchers.IO) {

--- a/app/src/main/feature/sync/google/ContainerBackupManager.java
+++ b/app/src/main/feature/sync/google/ContainerBackupManager.java
@@ -278,6 +278,7 @@ public final class ContainerBackupManager {
   }
 
   private static boolean awaitAuthenticatedSession(Activity activity) throws InterruptedException {
+    PlayGamesBootstrap.ensureInitialized(activity);
     for (int attempt = 0; attempt < AUTH_SESSION_RETRY_COUNT; attempt++) {
       if (isAuthenticatedBlocking(activity)) {
         return true;
@@ -291,6 +292,7 @@ public final class ContainerBackupManager {
 
   private static boolean isAuthenticatedBlocking(Activity activity) {
     try {
+      PlayGamesBootstrap.ensureInitialized(activity);
       Object result =
           Tasks.await(
               PlayGames.getGamesSignInClient(activity).isAuthenticated(), 10, TimeUnit.SECONDS);

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -664,6 +664,7 @@ object GameSaveBackupManager {
 
     private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
         try {
+            PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
                 withContext(Dispatchers.IO) {
@@ -681,6 +682,7 @@ object GameSaveBackupManager {
         }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
                 return true

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -227,8 +227,8 @@ fun GoogleScreen() {
                                     autoBackupEnabled = true
                                     autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
                                 } else {
-                                    autoBackupEnabled = true
-                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
+                                    autoBackupEnabled = false
+                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", false).apply()
                                 }
                             } catch (e: Exception) {
                                 AppUtils.showToast(context, "Drive authorization failed: ${e.message}")

--- a/app/src/main/feature/sync/google/PlayGamesBootstrap.kt
+++ b/app/src/main/feature/sync/google/PlayGamesBootstrap.kt
@@ -1,0 +1,24 @@
+package com.winlator.cmod.feature.sync.google
+
+import android.content.Context
+import com.google.android.gms.games.PlayGamesSdk
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+
+object PlayGamesBootstrap {
+    private const val TAG = "PlayGamesBootstrap"
+    private val initialized = AtomicBoolean(false)
+
+    @JvmStatic
+    fun ensureInitialized(context: Context) {
+        if (initialized.get()) return
+
+        synchronized(this) {
+            if (initialized.get()) return
+
+            PlayGamesSdk.initialize(context.applicationContext)
+            initialized.set(true)
+            Timber.tag(TAG).i("Initialized Play Games SDK")
+        }
+    }
+}

--- a/app/src/main/runtime/system/LogManager.kt
+++ b/app/src/main/runtime/system/LogManager.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import com.winlator.cmod.app.config.SettingsConfig
 import com.winlator.cmod.shared.io.FileUtils
+import java.io.Closeable
 import java.io.File
 
 object LogManager {
@@ -95,11 +96,12 @@ object LogManager {
 
         try {
             stopLogcat()
-            Runtime.getRuntime().exec("logcat -c").waitFor()
+            runBlockingLogcatCommand(arrayOf("logcat", "-c"))
             logcatProcess =
                 Runtime.getRuntime().exec(
                     arrayOf("logcat", "-f", logFile.absolutePath, "*:D"),
                 )
+            closeProcessStdin(logcatProcess)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start logcat: ${e.message}")
         }
@@ -112,7 +114,7 @@ object LogManager {
 
     private fun stopLogcat() {
         try {
-            logcatProcess?.destroy()
+            logcatProcess?.let(::destroyProcess)
             logcatProcess = null
         } catch (e: Exception) {
             Log.e(TAG, "Failed to stop logcat: ${e.message}")
@@ -147,6 +149,7 @@ object LogManager {
                 Runtime.getRuntime().exec(
                     arrayOf("logcat", "-f", logFile.absolutePath, "--pid=$pid", "*:W"),
                 )
+            closeProcessStdin(appLogProcess)
             Log.i(TAG, "Application debug logging started (PID=$pid)")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start application logging: ${e.message}")
@@ -156,10 +159,37 @@ object LogManager {
     @JvmStatic
     fun stopAppLogging() {
         try {
-            appLogProcess?.destroy()
+            appLogProcess?.let(::destroyProcess)
             appLogProcess = null
         } catch (e: Exception) {
             Log.e(TAG, "Failed to stop application logging: ${e.message}")
+        }
+    }
+
+    private fun runBlockingLogcatCommand(command: Array<String>) {
+        val process = Runtime.getRuntime().exec(command)
+        try {
+            process.waitFor()
+        } finally {
+            destroyProcess(process)
+        }
+    }
+
+    private fun destroyProcess(process: Process) {
+        closeProcessStdin(process)
+        closeQuietly(process.inputStream)
+        closeQuietly(process.errorStream)
+        process.destroy()
+    }
+
+    private fun closeProcessStdin(process: Process?) {
+        closeQuietly(process?.outputStream)
+    }
+
+    private fun closeQuietly(closeable: Closeable?) {
+        try {
+            closeable?.close()
+        } catch (_: Exception) {
         }
     }
 


### PR DESCRIPTION
- Stop bootstrapping Google Play Games and store-login restore on app launch.
- Initialize Play Games lazily when sync flows are actually used and disable Play Games auto sign-in startup wiring.
- Move Saved Games session work off the main thread, resolve snapshot conflicts, and explicitly close snapshot file descriptors to avoid resource-leak warnings.
- Keep Google Drive auto backup disabled until authorization actually succeeds.
- Close logcat process streams explicitly to avoid leaked process resource warnings.
- Validated with `./gradlew.bat :app:assembleStandardDebug :app:assembleLudashiDebug`.