### PR TITLE
feat: kill app process on swipe-away to prevent zombie Wine/socket state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,6 +104,17 @@
             </intent-filter>
         </receiver>
 
+        <!-- App-wide teardown service started from PluviaApp.onCreate. On
+             swipe-away from Recents, its onTaskRemoved runs full teardown
+             (kill Wine/child processes, release sockets) and terminates the
+             process so the app fully closes and relaunch starts clean.
+             Deliberately NOT stopWithTask — Android silently skips
+             onTaskRemoved when stopWithTask=true. -->
+        <service
+            android:name="com.winlator.cmod.runtime.display.SessionTeardownService"
+            android:enabled="true"
+            android:exported="false" />
+
         <service
             android:name="com.winlator.cmod.feature.stores.steam.service.SteamService"
             android:enabled="true"

--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -28,6 +28,17 @@ class PluviaApp : Application() {
         super.onCreate()
         instance = this
 
+        // Start the app-wide teardown service early so it's alive to receive
+        // onTaskRemoved from the very first swipe-away, regardless of which
+        // Activity the user is in. Wrapped in try/catch because background
+        // startService can throw IllegalStateException on API 26+ in some
+        // app-init paths (ContentProvider-triggered Application starts).
+        try {
+            startService(android.content.Intent(this, com.winlator.cmod.runtime.display.SessionTeardownService::class.java))
+        } catch (t: Throwable) {
+            Log.w("PluviaApp", "Failed to start SessionTeardownService", t)
+        }
+
         // Initialize Play Games Services SDK (v2)
         PlayGamesSdk.initialize(this)
 
@@ -74,14 +85,25 @@ class PluviaApp : Application() {
             SteamService.repairInstalledMetadataFromDisk()
         }
 
-        // Start SteamService only if setup is complete to avoid premature permission popups
+        // Start SteamService only if setup is complete to avoid premature permission popups.
+        // Guard each start: if the service is already alive (e.g. Android kept the process
+        // hot across a quick swipe+relaunch), skip the redundant startForegroundService so
+        // we don't re-enter its init path and fire a spurious null-intent onStartCommand.
         try {
             if (SetupWizardActivity.isSetupComplete(this)) {
-                val intent = android.content.Intent(this, com.winlator.cmod.feature.stores.steam.service.SteamService::class.java)
-                startForegroundService(intent)
+                if (!SteamService.isRunning) {
+                    val intent = android.content.Intent(this, com.winlator.cmod.feature.stores.steam.service.SteamService::class.java)
+                    startForegroundService(intent)
+                } else {
+                    Log.d("PluviaApp", "SteamService already running — skipping startForegroundService")
+                }
                 if (GOGAuthManager.isLoggedIn(this)) {
-                    val gogIntent = android.content.Intent(this, GOGService::class.java)
-                    startForegroundService(gogIntent)
+                    if (!GOGService.isRunning) {
+                        val gogIntent = android.content.Intent(this, GOGService::class.java)
+                        startForegroundService(gogIntent)
+                    } else {
+                        Log.d("PluviaApp", "GOGService already running — skipping startForegroundService")
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -1482,7 +1482,14 @@ class UnifiedActivity :
                             // Exit button
                             Button(
                                 onClick = {
-                                    // Kill all WinNative processes and close fully
+                                    // Kill native child processes (Wine/box64/wineserver/
+                                    // etc.) BEFORE killing the JVM, otherwise they become
+                                    // orphans reparented to init and leak until the next
+                                    // launch reaps them.
+                                    try {
+                                        com.winlator.cmod.runtime.system.ProcessHelper
+                                            .terminateSessionProcessesAndWait(500, true)
+                                    } catch (_: Throwable) {}
                                     finishAffinity()
                                     Process.killProcess(Process.myPid())
                                 },

--- a/app/src/main/feature/stores/epic/service/EpicService.kt
+++ b/app/src/main/feature/stores/epic/service/EpicService.kt
@@ -843,5 +843,14 @@ class EpicService : Service() {
         instance = null
     }
 
+    // Fires on swipe-away from Recents. Per user policy, swipe = full app
+    // close. SessionTeardownService also kills the process; this stopSelf is
+    // defense-in-depth in case the service's kill path fails.
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Timber.tag("EPIC").i("Task removed — stopping self")
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 }

--- a/app/src/main/feature/stores/gog/service/GOGService.kt
+++ b/app/src/main/feature/stores/gog/service/GOGService.kt
@@ -911,5 +911,14 @@ class GOGService : Service() {
         instance = null
     }
 
+    // Fires on swipe-away from Recents. Per user policy, swipe = full app
+    // close. SessionTeardownService also kills the process; this stopSelf is
+    // defense-in-depth in case the service's kill path fails.
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Timber.i("[GOGService] Task removed — stopping self")
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 }

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -5042,6 +5042,19 @@ class SteamService :
         scope.launch { stop() }
     }
 
+    // Fires on swipe-away from Recents. Per user policy, swipe = full app
+    // close — no download protection. Persist progress snapshots so a resume
+    // is possible next launch, then stop. (SessionTeardownService also kills
+    // the process, which takes us down regardless; this is defense-in-depth.)
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        downloadJobs.values.forEach { info ->
+            try { info.persistProgressSnapshot(force = true) } catch (_: Throwable) {}
+        }
+        Timber.i("[SteamService] Task removed — stopping self")
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun connectToSteam() {

--- a/app/src/main/runtime/display/SessionTeardownService.kt
+++ b/app/src/main/runtime/display/SessionTeardownService.kt
@@ -1,0 +1,75 @@
+package com.winlator.cmod.runtime.display
+
+import android.app.Service
+import android.content.Intent
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import com.winlator.cmod.runtime.system.ProcessHelper
+
+/**
+ * App-wide teardown service. Started by PluviaApp.onCreate, lives for the
+ * whole process lifetime. Its sole purpose is to receive onTaskRemoved when
+ * the user swipes the app away from Recents, do synchronous cleanup of
+ * native child processes (Wine/box64/wineserver/etc.), and terminate the JVM
+ * so the app fully closes and the next launch starts from a clean slate.
+ *
+ * Deliberately NOT declared with android:stopWithTask="true" — the Android
+ * framework silently skips onTaskRemoved when that flag is set, which would
+ * defeat the entire mechanism.
+ */
+class SessionTeardownService : Service() {
+    companion object {
+        private const val TAG = "SessionTeardown"
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(TAG, "Service created — ready to handle task removal")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(TAG, "onStartCommand received")
+        // START_NOT_STICKY: we don't want Android to restart us after our own
+        // Process.killProcess (it would just respawn a zombie service in a
+        // process we're trying to kill).
+        return START_NOT_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.w(TAG, "Task removed — tearing down app")
+
+        // Release any game-session-owned sockets and SIGKILL Wine children if
+        // a game was active. Null-safe if no active session.
+        try {
+            XServerDisplayActivity.emergencyTeardown("onTaskRemoved")
+        } catch (t: Throwable) {
+            Log.e(TAG, "emergencyTeardown threw", t)
+        }
+
+        // Also kill any lingering Wine/box64/wineserver processes even when no
+        // game session was active (stale children from a prior crashed run).
+        // Tight timeout: the app is dying anyway, kernel will reap the rest.
+        try {
+            ProcessHelper.terminateSessionProcessesAndWait(500, true)
+            ProcessHelper.drainDeadChildren("SessionTeardown onTaskRemoved")
+        } catch (t: Throwable) {
+            Log.e(TAG, "Wine process kill threw", t)
+        }
+
+        super.onTaskRemoved(rootIntent)
+        stopSelf()
+
+        // Kill the JVM after a short delay so Android finishes task
+        // bookkeeping and any pending log lines flush. Bypasses onDestroy on
+        // other components — that's intended: we want the process gone so
+        // bound sockets are released and relaunch is clean.
+        Handler(Looper.getMainLooper()).postDelayed({
+            Log.w(TAG, "Killing process ${android.os.Process.myPid()}")
+            android.os.Process.killProcess(android.os.Process.myPid())
+        }, 150)
+    }
+}

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -300,6 +300,46 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private final AtomicBoolean exitRequested = new AtomicBoolean(false);
     private final AtomicBoolean steamExitWatchRunning = new AtomicBoolean(false);
 
+    /**
+     * Reference to the live session Activity, consulted by
+     * SessionTeardownService.onTaskRemoved when the user swipes the app away
+     * mid-game. Only non-null between onCreate and onDestroy. Never touch from
+     * background threads without copying to a local first — the field is
+     * volatile, individual reads are atomic, but the instance it points to
+     * can be destroyed concurrently.
+     */
+    private static volatile XServerDisplayActivity currentInstance = null;
+
+    /**
+     * Synchronous emergency teardown callable from SessionTeardownService on
+     * swipe-away. Releases the game-session sockets if a game was active.
+     * Best-effort: tolerates nulls, catches each step. Safe to call when no
+     * session is active — it just skips the handler stops. Wine process kill
+     * is done by SessionTeardownService itself (unconditional, not tied to
+     * session state) so stale children from crashed prior runs also die.
+     */
+    public static void emergencyTeardown(String reason) {
+        XServerDisplayActivity instance = currentInstance;
+        Log.w("XServerDisplayActivity", "emergencyTeardown(" + reason + "): activeSession=" + (instance != null));
+        if (instance == null) return;
+
+        try {
+            if (instance.winHandler != null) instance.winHandler.stop();
+        } catch (Throwable t) {
+            Log.e("XServerDisplayActivity", "emergencyTeardown: winHandler.stop failed", t);
+        }
+        try {
+            if (instance.wineRequestHandler != null) instance.wineRequestHandler.stop();
+        } catch (Throwable t) {
+            Log.e("XServerDisplayActivity", "emergencyTeardown: wineRequestHandler.stop failed", t);
+        }
+        try {
+            if (instance.midiHandler != null) instance.midiHandler.stop();
+        } catch (Throwable t) {
+            Log.e("XServerDisplayActivity", "emergencyTeardown: midiHandler.stop failed", t);
+        }
+    }
+
     private boolean isDarkMode;
     private boolean enableLogsMenu;
 
@@ -496,6 +536,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Clean up any shared debug logs and prepare for fresh session logging
         DebugFragment.Companion.cleanupSharedLogs();
         com.winlator.cmod.runtime.system.LogManager.prepareForNewSession(this);
+
+        // Register as the current live instance so SessionTeardownService can
+        // find us on swipe-away for synchronous handler cleanup. The service
+        // itself is started from PluviaApp.onCreate (app-wide lifetime).
+        currentInstance = this;
 
         // Initialize preferences early so pickHighestRefreshRate can read global override
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
@@ -2172,6 +2217,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        // Clear the static reference FIRST so a concurrent
+        // SessionTeardownService.onTaskRemoved becomes a no-op rather than
+        // racing with the normal teardown below. Do NOT stopService here —
+        // SessionTeardownService is app-wide, not session-scoped.
+        if (currentInstance == this) currentInstance = null;
         super.onDestroy();
         // Schedule a deferred update check 10 s after game exit
         UpdateChecker.INSTANCE.schedulePostGameCheck(this);

--- a/app/src/main/runtime/display/steampipeserver/SteamPipeServer.java
+++ b/app/src/main/runtime/display/steampipeserver/SteamPipeServer.java
@@ -21,6 +21,7 @@ public class SteamPipeServer {
 
   private ServerSocket serverSocket;
   private volatile boolean running;
+  private Thread serverThread;
 
   private int readNetworkInt(DataInputStream input) throws IOException {
     return Integer.reverseBytes(input.readInt());
@@ -32,7 +33,8 @@ public class SteamPipeServer {
 
   public void start() {
     running = true;
-    new Thread(
+    serverThread =
+        new Thread(
             () -> {
               try {
                 serverSocket = new ServerSocket();
@@ -59,8 +61,8 @@ public class SteamPipeServer {
                 Log.d(TAG, "Server thread exiting");
               }
             },
-            "SteamPipeServer")
-        .start();
+            "SteamPipeServer");
+    serverThread.start();
   }
 
   private void handleClient(Socket clientSocket) {
@@ -136,6 +138,16 @@ public class SteamPipeServer {
       }
     } catch (IOException e) {
       Log.e(TAG, "Error stopping server", e);
+    }
+    // Wait for the accept loop to exit so port 34865 is fully released before
+    // stop() returns. Prevents EADDRINUSE on a quick relaunch.
+    if (serverThread != null) {
+      try {
+        serverThread.join(1000);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+      serverThread = null;
     }
   }
 }

--- a/app/src/main/runtime/wine/WineRequestHandler.java
+++ b/app/src/main/runtime/wine/WineRequestHandler.java
@@ -9,13 +9,18 @@ import android.util.Log;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class WineRequestHandler {
+
+  private static final String TAG = "WineRequestHandler";
+  private static final int PORT = 20000;
 
   abstract class RequestCodes {
     static final int OPEN_URL = 1;
@@ -25,6 +30,7 @@ public class WineRequestHandler {
 
   private Context context;
   private ServerSocket serverSocket;
+  private ExecutorService executor;
 
   public ServerSocket getServerSocket() {
     return serverSocket;
@@ -35,12 +41,16 @@ public class WineRequestHandler {
   }
 
   public void start() {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor = Executors.newSingleThreadExecutor();
     executor.execute(
         () -> {
           try {
-            serverSocket = new ServerSocket(20000);
-            while (true) {
+            // SO_REUSEADDR lets us rebind quickly after a fast relaunch even
+            // if the previous socket is still in TIME_WAIT on port 20000.
+            serverSocket = new ServerSocket();
+            serverSocket.setReuseAddress(true);
+            serverSocket.bind(new InetSocketAddress(PORT));
+            while (!Thread.currentThread().isInterrupted()) {
               Socket socket = serverSocket.accept();
               DataInputStream inputStream = new DataInputStream(socket.getInputStream());
               DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
@@ -53,11 +63,24 @@ public class WineRequestHandler {
   }
 
   public void stop() {
+    // Close the socket first so any blocking accept() unwinds with
+    // SocketException and the executor thread can exit.
     if (serverSocket != null) {
       try {
         serverSocket.close();
       } catch (IOException e) {
       }
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+      try {
+        if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+          Log.w(TAG, "Executor did not terminate within 1s");
+        }
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+      executor = null;
     }
   }
 


### PR DESCRIPTION
Adds SessionTeardownService, a no-notification app-wide service started from PluviaApp.onCreate. On swipe-away from Recents its onTaskRemoved runs full teardown (close handler sockets, SIGKILL Wine/box64/wineserver children via ProcessHelper, stopSelf, then Process.killProcess). This ensures a clean process death so bound ports (20000, 34865, 7947, 7942, abstract 'winlator_vibration' LocalServerSocket) are fully released and stale Wine processes don't block the next launch.

Key details:
- Manifest deliberately does NOT set android:stopWithTask on the teardown service. With that flag, Android silently skips onTaskRemoved and just stops the service, defeating the callback.
- Store services (Steam/GOG/Epic) get unconditional stopSelf in onTaskRemoved as defense-in-depth; per policy swipe always fully closes the app.
- UnifiedActivity's Exit button now runs terminateSessionProcessesAndWait before Process.killProcess so Wine children don't orphan to init.
- WineRequestHandler uses SO_REUSEADDR + awaitTermination on its executor; SteamPipeServer joins its accept thread in stop() — both prevent EADDRINUSE on fast relaunch.
- PluviaApp guards redundant startForegroundService calls for already-running Steam/GOG services.