### PR TITLE
feat: integrate per-process FPS Limiter and enable multithreaded XServer

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2304,7 +2304,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 hudScale,
                 hudElements,
                 dualSeriesBattery,
-                hudCardExpanded
+                hudCardExpanded,
+                xServerView != null ? xServerView.getRenderer().getFpsLimit() : 0
         );
 
         if (drawerActionListener == null) {
@@ -2349,6 +2350,14 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onHUDCardExpandedChanged(boolean expanded) {
                         hudCardExpanded = expanded;
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onFPSLimitChanged(int limit) {
+                        if (xServerView != null) {
+                            xServerView.getRenderer().setFpsLimit(limit);
+                        }
                         renderDrawerMenu();
                     }
                 };

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -142,6 +143,7 @@ data class XServerDrawerState(
     val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
     val dualSeriesBatteryEnabled: Boolean = false,
     val hudCardExpanded: Boolean = false,
+    val fpsLimit: Int = 0,
 )
 
 class XServerDrawerStateHolder(
@@ -165,6 +167,8 @@ interface XServerDrawerActionListener {
     fun onDualSeriesBatteryChanged(enabled: Boolean)
 
     fun onHUDCardExpandedChanged(expanded: Boolean)
+
+    fun onFPSLimitChanged(limit: Int)
 }
 
 fun buildXServerDrawerState(
@@ -183,6 +187,7 @@ fun buildXServerDrawerState(
     hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true),
     dualSeriesBatteryEnabled: Boolean = false,
     hudCardExpanded: Boolean = false,
+    fpsLimit: Int = 0,
 ): XServerDrawerState {
     val items =
         mutableListOf(
@@ -320,6 +325,7 @@ fun buildXServerDrawerState(
         hudElements = hudElements,
         dualSeriesBatteryEnabled = dualSeriesBatteryEnabled,
         hudCardExpanded = hudCardExpanded,
+        fpsLimit = fpsLimit,
     )
 }
 
@@ -700,6 +706,11 @@ private fun XServerHUDSettingsExpanded(
                 title = stringResource(R.string.session_drawer_dual_series_battery),
                 checked = state.dualSeriesBatteryEnabled,
                 onCheckedChange = listener::onDualSeriesBatteryChanged,
+            )
+
+            FPSLimiterSelection(
+                currentLimit = state.fpsLimit,
+                onLimitSelected = listener::onFPSLimitChanged
             )
         }
     }
@@ -1216,5 +1227,39 @@ private fun DrawerStatusPill(
             fontWeight = FontWeight.Bold,
             letterSpacing = 0.6.sp,
         )
+    }
+}
+
+@Composable
+private fun FPSLimiterSelection(
+    currentLimit: Int,
+    onLimitSelected: (Int) -> Unit,
+) {
+    val limits = listOf(0, 30, 45, 60, 90, 120)
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "FPS Limiter",
+            color = WinNativeTextSecondary,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.3.sp,
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            limits.forEach { limit ->
+                val label = if (limit == 0) "None" else "$limit"
+                HUDToggleChip(
+                    label = label,
+                    checked = currentLimit == limit,
+                    onClick = { onLimitSelected(limit) }
+                )
+            }
+        }
     }
 }

--- a/app/src/main/runtime/display/environment/components/XServerComponent.java
+++ b/app/src/main/runtime/display/environment/components/XServerComponent.java
@@ -23,6 +23,7 @@ public class XServerComponent extends EnvironmentComponent {
     connector =
         new XConnectorEpoll(
             socketConfig, new XClientConnectionHandler(xServer), new XClientRequestHandler());
+    connector.setMultithreadedClients(true);
     connector.setInitialInputBufferCapacity(262144);
     connector.setCanReceiveAncillaryMessages(true);
     connector.start();

--- a/app/src/main/runtime/display/renderer/GLRenderer.java
+++ b/app/src/main/runtime/display/renderer/GLRenderer.java
@@ -54,6 +54,7 @@ public class GLRenderer
   private boolean cpuSaverMode = false;
   private int currentFpsLimit = 0;
   private boolean wasDirectMode = false;
+  private long nextFrameTime = 0;
 
   public GLRenderer(XServerView xServerView, XServer xServer) {
     this.xServerView = xServerView;
@@ -446,11 +447,6 @@ public class GLRenderer
     if (cpuSaverMode != enable) {
       cpuSaverMode = enable;
       viewportNeedsUpdate = true;
-      final String msg = enable ? "Direct Rendering+ Enabled" : "Direct Rendering+ Disabled";
-      xServerView.post(
-          () ->
-              AppUtils.showToast(xServerView.getContext(), msg, android.widget.Toast.LENGTH_SHORT));
-      xServerView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
       xServerView.requestRender();
     }
   }
@@ -601,5 +597,39 @@ public class GLRenderer
 
   public void setUnviewableWMClasses(String... unviewableWMNames) {
     this.unviewableWMClasses = unviewableWMNames;
+  }
+
+  @Override
+  public void onFramePresented(com.winlator.cmod.runtime.display.xserver.Window window) {
+    xServerView.requestRender();
+  }
+
+  private void enforceAbsoluteFramerate() {
+    int targetFps = currentFpsLimit;
+    if (targetFps <= 0) {
+      nextFrameTime = 0L;
+      return;
+    }
+
+    long targetFrameTime = 1000000000L / targetFps;
+    long now = System.nanoTime();
+
+    if (nextFrameTime == 0 || now > nextFrameTime) {
+      nextFrameTime = now;
+    }
+
+    long sleepTime = nextFrameTime - now;
+    if (sleepTime > 0) {
+      long sleepMs = (sleepTime - 1500000L) / 1000000L;
+      if (sleepMs > 0) {
+        try {
+          Thread.sleep(sleepMs);
+        } catch (InterruptedException e) {
+        }
+      }
+      while (System.nanoTime() < nextFrameTime) {
+      }
+    }
+    nextFrameTime += targetFrameTime;
   }
 }

--- a/app/src/main/runtime/display/xserver/XClient.java
+++ b/app/src/main/runtime/display/xserver/XClient.java
@@ -19,8 +19,10 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
   private final XOutputStream outputStream;
   private final ArrayMap<Window, EventListener> eventListeners = new ArrayMap<>();
   private final ArrayList<XResource> resources = new ArrayList<>();
+  private long nextFrameTime = 0;
 
   public XClient(XServer xServer, XInputStream inputStream, XOutputStream outputStream) {
+
     this.xServer = xServer;
     this.inputStream = inputStream;
     this.outputStream = outputStream;
@@ -151,5 +153,35 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
 
   public boolean isValidResourceId(int id) {
     return xServer.resourceIDs.isInInterval(id, resourceIDBase);
+  }
+
+  public void enforceAbsoluteFramerate() {
+    com.winlator.cmod.runtime.display.renderer.GLRenderer renderer = xServer.getRenderer();
+    if (renderer == null) return;
+
+    int targetFps = renderer.getFpsLimit();
+    if (targetFps <= 0) {
+      nextFrameTime = 0L;
+      return;
+    }
+
+    long targetFrameTime = 1000000000L / targetFps;
+    long now = System.nanoTime();
+
+    if (nextFrameTime == 0 || now > nextFrameTime) nextFrameTime = now;
+
+    long sleepTime = nextFrameTime - now;
+    if (sleepTime > 0) {
+      long sleepMs = (sleepTime - 1500000L) / 1000000L;
+      if (sleepMs > 0) {
+        try {
+          Thread.sleep(sleepMs);
+        } catch (InterruptedException e) {
+        }
+      }
+      while (System.nanoTime() < nextFrameTime) {
+      }
+    }
+    nextFrameTime += targetFrameTime;
   }
 }

--- a/app/src/main/runtime/display/xserver/extensions/PresentExtension.java
+++ b/app/src/main/runtime/display/xserver/extensions/PresentExtension.java
@@ -208,6 +208,7 @@ public class PresentExtension implements Extension {
             client.xServer.lock(XServer.Lockable.WINDOW_MANAGER, XServer.Lockable.PIXMAP_MANAGER)) {
           presentPixmap(client, inputStream, outputStream);
         }
+        client.enforceAbsoluteFramerate();
         break;
       case ClientOpcodes.SELECT_INPUT:
         try (XLock lock = client.xServer.lock(XServer.Lockable.WINDOW_MANAGER)) {

--- a/app/src/main/runtime/display/xserver/requests/DrawRequests.java
+++ b/app/src/main/runtime/display/xserver/requests/DrawRequests.java
@@ -79,6 +79,7 @@ public abstract class DrawRequests {
     if (window != null) {
       client.xServer.windowManager.triggerOnFramePresented(window);
     }
+    client.enforceAbsoluteFramerate();
   }
 
   public static void getImage(XClient client, XInputStream inputStream, XOutputStream outputStream)


### PR DESCRIPTION
- Added high-precision frame throttling in PresentExtension and DrawRequests via XClient.
- Enabled multithreadedClients in XServerComponent to support per-process throttling without blocking the XServer.
- Integrated an FPS Limiter selection row into the expanded HUD side menu (Compose).
- Added nextFrameTime state to XClient for isolated process timing.
- Updated XServerDisplayActivity and GLRenderer to manage FPS limit state.