### PR TITLE
feat: keep Epic session alive + auto-push fresh tokens to Google snap…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,6 +219,8 @@ dependencies {
 
     implementation libs.playServicesGamesV2
     implementation libs.playServicesAuth
+
+    implementation libs.workRuntimeKtx
 }
 
 spotless {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="true"
         android:appCategory="game"
         android:isGame="true"
         android:allowBackup="false"

--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -28,7 +28,7 @@ class PluviaApp : Application() {
         super.onCreate()
         instance = this
 
-        // Initialize Play Games Services SDK (v2)
+        // Initialize Play Games Services SDK (v2) eagerly so auto sign-in fires at app launch.
         PlayGamesSdk.initialize(this)
 
         registerRefreshRateLifecycleCallbacks()

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -735,25 +735,32 @@ class UnifiedActivity :
             com.winlator.cmod.feature.sync.google.CloudSyncManager.flushPendingAutoBackup(this@UnifiedActivity)
         }
 
-        // Surface store-session events (e.g. Epic refresh-token death) as toasts.
+        // Surface store-session events (e.g. Epic refresh-token death, cloud restore) as toasts.
         lifecycleScope.launch {
             com.winlator.cmod.feature.stores.common.StoreSessionBus.events.collect { event ->
+                val label =
+                    when (event.store) {
+                        com.winlator.cmod.feature.stores.common.Store.EPIC -> "Epic"
+                        com.winlator.cmod.feature.stores.common.Store.GOG -> "GOG"
+                        com.winlator.cmod.feature.stores.common.Store.STEAM -> "Steam"
+                    }
                 when (event) {
                     is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionExpired -> {
-                        val label =
-                            when (event.store) {
-                                com.winlator.cmod.feature.stores.common.Store.EPIC -> "Epic"
-                                com.winlator.cmod.feature.stores.common.Store.GOG -> "GOG"
-                                com.winlator.cmod.feature.stores.common.Store.STEAM -> "Steam"
-                            }
                         com.winlator.cmod.shared.android.AppUtils.showToast(
                             this@UnifiedActivity,
                             "$label session expired — please sign in again",
                             android.widget.Toast.LENGTH_LONG,
                         )
                     }
+                    is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRestored -> {
+                        com.winlator.cmod.shared.android.AppUtils.showToast(
+                            this@UnifiedActivity,
+                            "$label session restored from cloud",
+                            android.widget.Toast.LENGTH_SHORT,
+                        )
+                    }
                     is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRefreshed -> {
-                        // informational — no UI surface yet
+                        // informational — no UI surface
                     }
                 }
             }

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -280,7 +280,6 @@ class UnifiedActivity :
 
     // Trigger to refresh library when activity resumes from another container
     var libraryRefreshSignal by mutableIntStateOf(0)
-    private var hasBootstrappedGoogleRestoreOnHome = false
 
     // Freezes the library/store card chasing borders while any full-screen
     // dialog is open, so the ~120 Hz animation cost isn't paid for content
@@ -326,6 +325,10 @@ class UnifiedActivity :
         fun refreshLibrary() {
             instance?.let { it.libraryRefreshSignal++ }
         }
+
+        /** Currently attached Activity (or null if the app is fully backgrounded/killed). */
+        @JvmStatic
+        fun currentActivity(): UnifiedActivity? = instance
     }
 
     private val wallpaperImagePickerLauncher =
@@ -541,16 +544,6 @@ class UnifiedActivity :
 
         // (Re)start the background update loop (checks hourly + on first tick)
         UpdateChecker.startBackgroundLoop(this)
-
-        lifecycleScope.launch {
-            bootstrapGoogleRestoreOnFirstHomeArrival()
-        }
-    }
-
-    private suspend fun bootstrapGoogleRestoreOnFirstHomeArrival() {
-        if (hasBootstrappedGoogleRestoreOnHome) return
-        hasBootstrappedGoogleRestoreOnHome = true
-        CloudSyncManager.bootstrapOnHomeScreenArrival(this)
     }
 
     override fun dispatchGenericMotionEvent(event: android.view.MotionEvent): Boolean {
@@ -727,6 +720,43 @@ class UnifiedActivity :
         // Start EpicService if user is logged in
         if (EpicService.hasStoredCredentials(this)) {
             EpicService.start(this)
+            // Proactively refresh the access token on app start; runs outside the 15-minute
+            // sync throttle so we extend the ~8h Epic refresh window every time the user
+            // opens the app.
+            lifecycleScope.launch {
+                EpicAuthManager.getStoredCredentials(this@UnifiedActivity)
+            }
+            // Make sure the background refresh worker is scheduled (idempotent).
+            com.winlator.cmod.feature.stores.epic.service.EpicTokenRefreshWorker.schedule(this)
+        }
+
+        // If the refresh worker fired while the app was killed, push the latest tokens to Google now.
+        lifecycleScope.launch {
+            com.winlator.cmod.feature.sync.google.CloudSyncManager.flushPendingAutoBackup(this@UnifiedActivity)
+        }
+
+        // Surface store-session events (e.g. Epic refresh-token death) as toasts.
+        lifecycleScope.launch {
+            com.winlator.cmod.feature.stores.common.StoreSessionBus.events.collect { event ->
+                when (event) {
+                    is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionExpired -> {
+                        val label =
+                            when (event.store) {
+                                com.winlator.cmod.feature.stores.common.Store.EPIC -> "Epic"
+                                com.winlator.cmod.feature.stores.common.Store.GOG -> "GOG"
+                                com.winlator.cmod.feature.stores.common.Store.STEAM -> "Steam"
+                            }
+                        com.winlator.cmod.shared.android.AppUtils.showToast(
+                            this@UnifiedActivity,
+                            "$label session expired — please sign in again",
+                            android.widget.Toast.LENGTH_LONG,
+                        )
+                    }
+                    is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRefreshed -> {
+                        // informational — no UI surface yet
+                    }
+                }
+            }
         }
 
         // Start SteamService if user is logged in

--- a/app/src/main/feature/stores/common/StoreAuthStatus.kt
+++ b/app/src/main/feature/stores/common/StoreAuthStatus.kt
@@ -1,0 +1,25 @@
+package com.winlator.cmod.feature.stores.common
+
+/**
+ * Uniform auth lifecycle state for a game-store integration.
+ *
+ * - [LOGGED_OUT]   no credentials on disk
+ * - [ACTIVE]       access token is valid (within a small safety buffer)
+ * - [REFRESHABLE]  access token is stale but the refresh token is plausibly still alive
+ * - [EXPIRED]      refresh token is past its known lifetime — full re-auth required
+ * - [UNKNOWN]      credentials exist but no refresh-window metadata is available
+ *                  (e.g. legacy on-disk format). Treat as REFRESHABLE for UI purposes
+ *                  and probe the server on the next API call.
+ */
+enum class StoreAuthStatus {
+    LOGGED_OUT,
+    ACTIVE,
+    REFRESHABLE,
+    EXPIRED,
+    UNKNOWN,
+    ;
+
+    /** True if the UI should treat the user as signed in (session may still need a refresh call). */
+    val isLoggedInForUi: Boolean
+        get() = this == ACTIVE || this == REFRESHABLE || this == UNKNOWN
+}

--- a/app/src/main/feature/stores/common/StoreSessionBus.kt
+++ b/app/src/main/feature/stores/common/StoreSessionBus.kt
@@ -1,0 +1,24 @@
+package com.winlator.cmod.feature.stores.common
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Process-wide bus for [StoreSessionEvent]s. Stores emit events here when they detect
+ * expired credentials or successful background refreshes; the shell observes this flow
+ * and surfaces them in the UI (toasts, banners, etc.).
+ */
+object StoreSessionBus {
+    private val _events =
+        MutableSharedFlow<StoreSessionEvent>(
+            replay = 0,
+            extraBufferCapacity = 8,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    val events = _events.asSharedFlow()
+
+    fun emit(event: StoreSessionEvent) {
+        _events.tryEmit(event)
+    }
+}

--- a/app/src/main/feature/stores/common/StoreSessionEvent.kt
+++ b/app/src/main/feature/stores/common/StoreSessionEvent.kt
@@ -17,8 +17,17 @@ sealed class StoreSessionEvent {
         val reason: String,
     ) : StoreSessionEvent()
 
-    /** A silent token refresh just succeeded — purely informational. */
+    /** A silent token refresh just succeeded — purely informational (no UI). */
     data class SessionRefreshed(
+        override val store: Store,
+    ) : StoreSessionEvent()
+
+    /**
+     * Credentials were just restored from a Google Play Games cloud snapshot —
+     * user-visible so it's clear why they went from "signed out" to "signed in"
+     * without an explicit login prompt.
+     */
+    data class SessionRestored(
         override val store: Store,
     ) : StoreSessionEvent()
 }

--- a/app/src/main/feature/stores/common/StoreSessionEvent.kt
+++ b/app/src/main/feature/stores/common/StoreSessionEvent.kt
@@ -1,0 +1,24 @@
+package com.winlator.cmod.feature.stores.common
+
+/** Identifies which store emitted a session event. */
+enum class Store {
+    EPIC,
+    GOG,
+    STEAM,
+}
+
+/** Session-lifecycle events that can surface from any store integration to the UI. */
+sealed class StoreSessionEvent {
+    abstract val store: Store
+
+    /** Stored refresh credentials are dead — user must sign in again. */
+    data class SessionExpired(
+        override val store: Store,
+        val reason: String,
+    ) : StoreSessionEvent()
+
+    /** A silent token refresh just succeeded — purely informational. */
+    data class SessionRefreshed(
+        override val store: Store,
+    ) : StoreSessionEvent()
+}

--- a/app/src/main/feature/stores/epic/data/EpicGame.kt
+++ b/app/src/main/feature/stores/epic/data/EpicGame.kt
@@ -148,6 +148,8 @@ data class EpicCredentials(
     val accountId: String,
     val displayName: String,
     val expiresAt: Long = 0,
+    /** Epoch millis when the refresh token dies. 0 if unknown (legacy on-disk format). */
+    val refreshExpiresAt: Long = 0,
 )
 
 /**

--- a/app/src/main/feature/stores/epic/service/EpicAuthClient.kt
+++ b/app/src/main/feature/stores/epic/service/EpicAuthClient.kt
@@ -20,6 +20,8 @@ data class EpicAuthResponse(
     val displayName: String,
     val expiresAt: Long,
     val expiresIn: Int,
+    /** Epoch millis when the refresh token itself expires. 0 if the server did not return it. */
+    val refreshExpiresAt: Long = 0,
 )
 
 /**
@@ -82,6 +84,7 @@ object EpicAuthClient {
                         displayName = json.optString("displayName", ""),
                         expiresAt = parseExpiresAt(json),
                         expiresIn = json.getInt("expires_in"),
+                        refreshExpiresAt = parseRefreshExpiresAt(json),
                     )
 
                 Timber.i("Successfully authenticated with Epic")
@@ -144,6 +147,7 @@ object EpicAuthClient {
                         displayName = json.optString("displayName", ""),
                         expiresAt = parseExpiresAt(json),
                         expiresIn = json.getInt("expires_in"),
+                        refreshExpiresAt = parseRefreshExpiresAt(json),
                     )
 
                 Timber.i("Successfully refreshed Epic token")
@@ -267,4 +271,27 @@ object EpicAuthClient {
                 System.currentTimeMillis() + (expiresIn * 1000L)
             }
         }
+
+    /**
+     * Parse `refresh_expires_at` (ISO-8601 string) or `refresh_expires` (seconds) from an
+     * Epic OAuth response. Returns 0 if neither field is present.
+     *
+     * Epic's eg1 refresh token is ~8 hours as of 2026; we keep it conservative rather than
+     * defaulting to a fictional value when the server doesn't tell us.
+     */
+    private fun parseRefreshExpiresAt(json: JSONObject): Long {
+        val isoString = json.optString("refresh_expires_at", "")
+        if (isoString.isNotEmpty()) {
+            try {
+                return Instant.parse(isoString).toEpochMilli()
+            } catch (_: Exception) {
+                // fall through to refresh_expires
+            }
+        }
+        val refreshExpires = json.optInt("refresh_expires", -1)
+        if (refreshExpires > 0) {
+            return System.currentTimeMillis() + (refreshExpires * 1000L)
+        }
+        return 0L
+    }
 }

--- a/app/src/main/feature/stores/epic/service/EpicAuthManager.kt
+++ b/app/src/main/feature/stores/epic/service/EpicAuthManager.kt
@@ -1,5 +1,9 @@
 package com.winlator.cmod.feature.stores.epic.service
 import android.content.Context
+import com.winlator.cmod.feature.stores.common.Store
+import com.winlator.cmod.feature.stores.common.StoreAuthStatus
+import com.winlator.cmod.feature.stores.common.StoreSessionBus
+import com.winlator.cmod.feature.stores.common.StoreSessionEvent
 import com.winlator.cmod.feature.stores.epic.data.EpicCredentials
 import com.winlator.cmod.feature.stores.epic.data.EpicGameToken
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,8 +36,47 @@ object EpicAuthManager {
         return credentialsFile.exists()
     }
 
+    /**
+     * Classify the current on-disk Epic credentials. If the refresh token's known expiry is
+     * already in the past, the credentials file is cleared and a [StoreSessionEvent.SessionExpired]
+     * is emitted on [StoreSessionBus].
+     *
+     * Safe to call from any thread — touches only local disk.
+     */
+    fun getAuthStatus(context: Context): StoreAuthStatus {
+        if (!hasStoredCredentials(context)) return StoreAuthStatus.LOGGED_OUT
+        val credentials =
+            loadCredentials(context) ?: run {
+                clearStoredCredentials(context)
+                return StoreAuthStatus.LOGGED_OUT
+            }
+
+        val now = System.currentTimeMillis()
+        val accessBuffer = 5L * 60 * 1000 // 5 minutes
+        val refreshBuffer = 60L * 1000 // 1 minute
+
+        if (credentials.refreshExpiresAt > 0 && now >= credentials.refreshExpiresAt - refreshBuffer) {
+            Timber.i("Epic refresh token expired (refreshExpiresAt=${credentials.refreshExpiresAt}), clearing credentials")
+            clearStoredCredentials(context)
+            // No SessionExpired emit here — getAuthStatus is called during startup before the
+            // bus collector is active. The UI already transitions to "logged out" via
+            // isLoggedInFlow. The emit-on-refresh-failure path covers mid-session death.
+            return StoreAuthStatus.EXPIRED
+        }
+
+        return when {
+            credentials.expiresAt > 0 && now < credentials.expiresAt - accessBuffer ->
+                StoreAuthStatus.ACTIVE
+            credentials.refreshExpiresAt > 0 ->
+                StoreAuthStatus.REFRESHABLE
+            else ->
+                // Legacy on-disk format without refresh_expires_at — probe on next use.
+                StoreAuthStatus.UNKNOWN
+        }
+    }
+
     @JvmStatic
-    fun isLoggedIn(context: Context): Boolean = hasStoredCredentials(context)
+    fun isLoggedIn(context: Context): Boolean = getAuthStatus(context).isLoggedInForUi
 
     /**
      * Clear stored credentials (logout)
@@ -47,6 +90,8 @@ object EpicAuthManager {
                 } else {
                     true
                 }
+            // Session is gone — no point running the periodic refresh worker.
+            EpicTokenRefreshWorker.cancel(context)
             updateLoginStatus(context)
             result
         } catch (e: Exception) {
@@ -112,6 +157,7 @@ object EpicAuthManager {
                     accountId = authResponse.accountId,
                     displayName = authResponse.displayName,
                     expiresAt = authResponse.expiresAt,
+                    refreshExpiresAt = authResponse.refreshExpiresAt,
                 )
 
             saveCredentials(context, credentials)
@@ -146,8 +192,13 @@ object EpicAuthManager {
                 val refreshResult = EpicAuthClient.refreshAccessToken(credentials.refreshToken)
 
                 if (refreshResult.isFailure) {
-                    Timber.e("Failed to refresh token")
-                    return Result.failure(Exception("Failed to refresh expired token: ${refreshResult.exceptionOrNull()?.message}"))
+                    val error = refreshResult.exceptionOrNull()
+                    Timber.e(error, "Failed to refresh Epic token — clearing credentials")
+                    clearStoredCredentials(context)
+                    StoreSessionBus.emit(
+                        StoreSessionEvent.SessionExpired(Store.EPIC, error?.message ?: "refresh_failed"),
+                    )
+                    return Result.failure(Exception("Epic session expired: ${error?.message}", error))
                 }
 
                 val authResponse = refreshResult.getOrNull()!!
@@ -158,9 +209,11 @@ object EpicAuthManager {
                         accountId = authResponse.accountId,
                         displayName = authResponse.displayName,
                         expiresAt = authResponse.expiresAt,
+                        refreshExpiresAt = authResponse.refreshExpiresAt,
                     )
 
                 saveCredentials(context, refreshedCredentials)
+                StoreSessionBus.emit(StoreSessionEvent.SessionRefreshed(Store.EPIC))
                 Timber.i("Access token refreshed successfully")
 
                 return Result.success(refreshedCredentials)
@@ -278,9 +331,16 @@ object EpicAuthManager {
             json.put("account_id", credentials.accountId)
             json.put("display_name", credentials.displayName)
             json.put("expires_at", credentials.expiresAt)
+            json.put("refresh_expires_at", credentials.refreshExpiresAt)
 
             authFile.writeText(json.toString())
             updateLoginStatus(context)
+            // Ensure the periodic refresh worker is running whenever creds exist on disk.
+            // Uses KEEP policy so this is a no-op when already scheduled.
+            EpicTokenRefreshWorker.schedule(context)
+            // Push the fresh token to Google Play Games so the cloud backup never holds a stale
+            // refresh token. Fires silently; no-op when sync is disabled or debounced.
+            com.winlator.cmod.feature.sync.google.CloudSyncManager.scheduleAutoBackup(context)
             Timber.d("Credentials saved to ${authFile.absolutePath}")
         } catch (e: Exception) {
             Timber.e(e, "Failed to save Epic credentials")
@@ -299,6 +359,7 @@ object EpicAuthManager {
                 accountId = json.getString("account_id"),
                 displayName = json.getString("display_name"),
                 expiresAt = json.getLong("expires_at"),
+                refreshExpiresAt = json.optLong("refresh_expires_at", 0L),
             )
         } catch (e: Exception) {
             Timber.e(e, "Failed to load credentials")

--- a/app/src/main/feature/stores/epic/service/EpicTokenRefreshWorker.kt
+++ b/app/src/main/feature/stores/epic/service/EpicTokenRefreshWorker.kt
@@ -1,0 +1,106 @@
+package com.winlator.cmod.feature.stores.epic.service
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.winlator.cmod.feature.stores.common.StoreAuthStatus
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodic background refresh for Epic's short-lived (~8h) refresh token.
+ *
+ * Each successful refresh resets the refresh window back to ~8h, so firing every 4h keeps the
+ * session alive indefinitely as long as the device has network reachability. The constraint
+ * [NetworkType.CONNECTED] means this worker simply waits when offline; WorkManager picks it
+ * back up automatically once connectivity returns. If the user goes offline long enough for
+ * the refresh token to die (>8h), the worker will hit a failed refresh on next run and
+ * [EpicAuthManager.getStoredCredentials] will clear credentials + emit a SessionExpired event.
+ *
+ * Why 4 hours: tokens die at +8h, firing at +4h gives a 4h cushion for a failed run. Matches
+ * the access-token natural lifetime (~14400s) so every run does meaningful work. Shorter
+ * intervals don't meaningfully improve robustness because transient failures are covered by
+ * WorkManager's exponential backoff ([Result.retry]).
+ */
+class EpicTokenRefreshWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val ctx = applicationContext
+        return try {
+            val status = EpicAuthManager.getAuthStatus(ctx)
+            when (status) {
+                StoreAuthStatus.LOGGED_OUT, StoreAuthStatus.EXPIRED -> {
+                    Timber.tag(TAG).i("No live Epic session (status=$status) — cancelling periodic refresh")
+                    cancel(ctx)
+                    Result.success()
+                }
+                StoreAuthStatus.ACTIVE, StoreAuthStatus.REFRESHABLE, StoreAuthStatus.UNKNOWN -> {
+                    val refreshResult = EpicAuthManager.getStoredCredentials(ctx)
+                    if (refreshResult.isSuccess) {
+                        Timber.tag(TAG).d("Epic background refresh succeeded (status was $status)")
+                        Result.success()
+                    } else {
+                        val err = refreshResult.exceptionOrNull()
+                        // If getStoredCredentials already cleared creds (e.g. invalid_grant), don't retry.
+                        if (!EpicAuthManager.hasStoredCredentials(ctx)) {
+                            Timber.tag(TAG).i("Epic creds cleared by refresh failure — stopping worker: ${err?.message}")
+                            cancel(ctx)
+                            Result.success()
+                        } else {
+                            Timber.tag(TAG).w(err, "Epic background refresh failed transiently — will retry with backoff")
+                            Result.retry()
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Unexpected error in EpicTokenRefreshWorker")
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val TAG = "EpicTokenRefreshWorker"
+        const val WORK_NAME = "epic_token_refresh"
+        private val REFRESH_INTERVAL_HOURS = 4L
+
+        fun schedule(context: Context) {
+            val constraints =
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
+            val request =
+                PeriodicWorkRequestBuilder<EpicTokenRefreshWorker>(
+                    repeatInterval = REFRESH_INTERVAL_HOURS,
+                    repeatIntervalTimeUnit = TimeUnit.HOURS,
+                ).setConstraints(constraints)
+                    .setInitialDelay(REFRESH_INTERVAL_HOURS, TimeUnit.HOURS)
+                    .build()
+
+            WorkManager
+                .getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    WORK_NAME,
+                    // KEEP: don't reset the schedule if we're already enqueued. The first-fire
+                    // delay resets only on REPLACE, which would keep pushing the next run out.
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+            Timber.tag(TAG).i("Scheduled periodic Epic token refresh (every ${REFRESH_INTERVAL_HOURS}h)")
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Timber.tag(TAG).i("Cancelled periodic Epic token refresh")
+        }
+    }
+}

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -49,6 +49,8 @@ import com.winlator.cmod.feature.stores.steam.enums.OS
 import com.winlator.cmod.feature.stores.steam.enums.OSArch
 import com.winlator.cmod.feature.stores.steam.enums.SaveLocation
 import com.winlator.cmod.feature.stores.steam.enums.SyncResult
+import com.auth0.android.jwt.JWT
+import com.winlator.cmod.feature.stores.common.StoreAuthStatus
 import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.feature.stores.steam.events.SteamEvent
 import com.winlator.cmod.feature.stores.steam.statsgen.StatType
@@ -716,12 +718,14 @@ class SteamService :
         private val _isConnectedFlow = MutableStateFlow(false)
         val isConnectedFlow = _isConnectedFlow.asStateFlow()
 
+        /**
+         * Pure getter over [isConnectedFlow]. Do not read `steamClient.isConnected` here —
+         * concurrent readers were mutating the flow as a side-effect, producing UI flicker
+         * during CM reconnect gaps. Callbacks (`onConnected` / `onDisconnected` / `clearValues`)
+         * are the only authoritative writers of the flow.
+         */
         var isConnected: Boolean
-            get() {
-                val real = (instance?.steamClient?.isConnected == true)
-                if (real != _isConnectedFlow.value) _isConnectedFlow.value = real
-                return real
-            }
+            get() = _isConnectedFlow.value
             private set(value) {
                 _isConnectedFlow.value = value
             }
@@ -734,34 +738,28 @@ class SteamService :
         private val _isLoggedInFlow = MutableStateFlow(false)
         val isLoggedInFlow = _isLoggedInFlow.asStateFlow()
 
+        /**
+         * Pure getter over [isLoggedInFlow]. Previously this read `steamClient.steamID.isValid`
+         * and wrote the flow as a side-effect, which caused UI flicker whenever any caller
+         * (StoresFragment.onResume, CloudSyncManager.rehydrateSteamSession, the 10s poll) read
+         * the value during a transient CM disconnect. The flow is now only mutated by
+         * authoritative sources: initLoginStatus(), onLoggedOn, onLoggedOff, logOut, clearValues.
+         */
         val isLoggedIn: Boolean
-            get() {
-                if (isLoggingOut) return false
-                val real = (instance?.steamClient?.steamID?.isValid == true)
-                // Only update flow if instance exists, to avoid overwriting
-                // the pre-seeded credential-based state before service starts
-                if (instance != null && real != _isLoggedInFlow.value) {
-                    _isLoggedInFlow.value = real
-                }
-                return real
-            }
+            get() = !isLoggingOut && _isLoggedInFlow.value
 
         var isWaitingForQRAuth: Boolean = false
             private set
 
+        /**
+         * Keeps [isConnectedFlow] in sync with the live socket state. Previously also wrote
+         * [isLoggedInFlow] from `steamID.isValid`, which flipped the UI to "signed out"
+         * whenever Valve's CM load-balanced us. The login flow is now purely callback-driven
+         * (see [isLoggedIn] docs), so this method only touches the connected flow.
+         */
         fun syncStates() {
             val connected = instance?.steamClient?.isConnected == true
             if (connected != _isConnectedFlow.value) _isConnectedFlow.value = connected
-
-            // Only update login state if the service instance exists (i.e. it has started).
-            // Before that, the flow may be pre-seeded from stored credentials and we
-            // don't want to overwrite it with false.
-            if (instance != null) {
-                val loggedIn = !isLoggingOut && (instance?.steamClient?.steamID?.isValid == true)
-                if (loggedIn != _isLoggedInFlow.value) {
-                    _isLoggedInFlow.value = loggedIn
-                }
-            }
         }
 
         /**
@@ -771,6 +769,36 @@ class SteamService :
         fun hasStoredCredentials(context: Context): Boolean {
             PrefManager.init(context)
             return PrefManager.refreshToken.isNotBlank()
+        }
+
+        /**
+         * Classifies the current Steam session using the same [StoreAuthStatus] model Epic
+         * uses. Lets the UI distinguish "reconnecting" / "token expired" / "no login" rather
+         * than painting every non-ACTIVE state as "signed out."
+         *
+         * - LOGGED_OUT: no stored refresh token.
+         * - EXPIRED:    refresh-token JWT's `exp` claim is in the past (~200 days old).
+         * - ACTIVE:     [isLoggedInFlow] is true (JavaSteam callback confirmed login).
+         * - REFRESHABLE: have a valid-looking refresh token but not yet logged on — the
+         *                 service is still connecting, or we're mid-reconnect after a CM bounce.
+         * - UNKNOWN:    refresh token exists but can't be parsed as a JWT.
+         */
+        fun getAuthStatus(context: Context): StoreAuthStatus {
+            PrefManager.init(context)
+            val refreshToken = PrefManager.refreshToken
+            if (refreshToken.isBlank()) return StoreAuthStatus.LOGGED_OUT
+
+            val jwtExpired: Boolean? =
+                try {
+                    JWT(refreshToken).isExpired(0)
+                } catch (_: Exception) {
+                    null
+                }
+            if (jwtExpired == true) return StoreAuthStatus.EXPIRED
+
+            if (!isLoggingOut && _isLoggedInFlow.value) return StoreAuthStatus.ACTIVE
+
+            return if (jwtExpired == null) StoreAuthStatus.UNKNOWN else StoreAuthStatus.REFRESHABLE
         }
 
         /**

--- a/app/src/main/feature/sync/google/CloudSyncManager.kt
+++ b/app/src/main/feature/sync/google/CloudSyncManager.kt
@@ -13,6 +13,9 @@ import com.google.android.gms.games.snapshot.SnapshotContents
 import com.google.android.gms.games.snapshot.SnapshotMetadataChange
 import com.google.android.gms.tasks.Tasks
 import com.winlator.cmod.R
+import com.winlator.cmod.feature.stores.common.Store
+import com.winlator.cmod.feature.stores.common.StoreSessionBus
+import com.winlator.cmod.feature.stores.common.StoreSessionEvent
 import com.winlator.cmod.feature.stores.epic.service.EpicAuthManager
 import com.winlator.cmod.feature.stores.epic.service.EpicService
 import com.winlator.cmod.feature.stores.gog.service.GOGAuthManager
@@ -969,6 +972,7 @@ object CloudSyncManager {
             PrefManager.clientId = json.optLong("clientId", 0L)
             SteamService.initLoginStatus(context)
             SteamService.start(context)
+            StoreSessionBus.emit(StoreSessionEvent.SessionRestored(Store.STEAM))
             true
         }.getOrElse { error ->
             Timber.tag(TAG).e(error, "Failed to restore Steam login tokens")
@@ -986,6 +990,7 @@ object CloudSyncManager {
             file.writeBytes(bytes)
             EpicAuthManager.updateLoginStatus(context)
             EpicService.start(context)
+            StoreSessionBus.emit(StoreSessionEvent.SessionRestored(Store.EPIC))
             true
         }.getOrElse { error ->
             Timber.tag(TAG).e(error, "Failed to restore Epic login tokens")
@@ -1003,6 +1008,7 @@ object CloudSyncManager {
             file.writeBytes(bytes)
             GOGAuthManager.updateLoginStatus(context)
             GOGService.start(context)
+            StoreSessionBus.emit(StoreSessionEvent.SessionRestored(Store.GOG))
             true
         }.getOrElse { error ->
             Timber.tag(TAG).e(error, "Failed to restore GOG login tokens")

--- a/app/src/main/feature/sync/google/CloudSyncManager.kt
+++ b/app/src/main/feature/sync/google/CloudSyncManager.kt
@@ -1,6 +1,7 @@
 package com.winlator.cmod.feature.sync.google
 import android.app.Activity
 import android.content.Context
+import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.util.Log
 import com.google.android.gms.common.api.ApiException
@@ -8,6 +9,7 @@ import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.games.PlayGames
 import com.google.android.gms.games.SnapshotsClient
 import com.google.android.gms.games.snapshot.Snapshot
+import com.google.android.gms.games.snapshot.SnapshotContents
 import com.google.android.gms.games.snapshot.SnapshotMetadataChange
 import com.google.android.gms.tasks.Tasks
 import com.winlator.cmod.R
@@ -45,11 +47,12 @@ object CloudSyncManager {
     private const val KEY_GOOGLE_SYNC_ENABLED = "google_sync_enabled"
     private const val KEY_LAST_SYNC_TIME = "last_sync_time"
     private const val KEY_LAST_SYNC_ERROR = "last_sync_error"
+    private const val KEY_AUTO_BACKUP_PENDING = "auto_backup_pending"
+    private const val AUTO_BACKUP_MIN_INTERVAL_MS = 60_000L // debounce: at most one auto-upload per minute
+    @Volatile private var lastAutoBackupAttemptMs: Long = 0L
     private const val SNAPSHOT_NAME = "store_logins_v1"
     private const val AUTH_SESSION_RETRY_COUNT = 5
     private const val AUTH_SESSION_RETRY_DELAY_MS = 750L
-    private const val HOME_BOOTSTRAP_TIMEOUT_MS = 15000L
-    private const val HOME_BOOTSTRAP_POLL_DELAY_MS = 1000L
     private const val ZIP_MANIFEST = "manifest.json"
     private const val ZIP_STEAM = "stores/steam.json"
     private const val ZIP_EPIC = "stores/epic_credentials.json"
@@ -137,6 +140,7 @@ object CloudSyncManager {
         activity: Activity,
         callback: (Boolean, String) -> Unit,
     ) {
+        PlayGamesBootstrap.ensureInitialized(activity)
         val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
         Log.i(TAG, "Starting Google Play Games sign-in for store login sync")
         Timber.tag(TAG).i("Starting Google Play Games sign-in for store login sync")
@@ -160,40 +164,40 @@ object CloudSyncManager {
         scope.launch {
             prefs(activity).edit().putBoolean(KEY_GOOGLE_SYNC_ENABLED, true).apply()
 
-            if (!awaitAuthenticatedSession(activity)) {
-                callback(
-                    false,
-                    activity.getString(R.string.google_cloud_sign_in_finishing),
-                )
-                return@launch
-            }
-
-            Timber.tag(TAG).i("Play Games session ready; checking Saved Games state and auto-restoring missing store tokens")
-            val message =
-                runCatching {
-                    val summary = autoRestoreMissingStoresFromCloud(activity, reason = "manual_sign_in")
-                    val state = readStateInternal(activity, authenticated = true)
-                    when {
-                        summary.restoredStores.isNotEmpty() -> {
-                            summary.message(activity)
-                        }
-
-                        state.cloudStores.isNotEmpty() && state.cloudStores != state.localStores -> {
-                            activity.getString(R.string.google_cloud_connected_restore_available, state.cloudStores.joinToString())
-                        }
-
-                        state.localStores.isNotEmpty() -> {
-                            activity.getString(R.string.google_cloud_connected_tap_backup, state.localStores.joinToString())
-                        }
-
-                        else -> {
-                            activity.getString(R.string.google_cloud_connected_ready)
-                        }
+            val result =
+                withContext(Dispatchers.IO) {
+                    if (!awaitAuthenticatedSession(activity)) {
+                        return@withContext false to activity.getString(R.string.google_cloud_sign_in_finishing)
                     }
-                }.getOrElse { error ->
-                    rememberSyncError(activity, error)
+
+                    Timber.tag(TAG).i("Play Games session ready; checking Saved Games state and auto-restoring missing store tokens")
+                    val message =
+                        runCatching {
+                            val summary = autoRestoreMissingStoresFromCloud(activity, reason = "manual_sign_in")
+                            val state = readStateInternal(activity, authenticated = true)
+                            when {
+                                summary.restoredStores.isNotEmpty() -> {
+                                    summary.message(activity)
+                                }
+
+                                state.cloudStores.isNotEmpty() && state.cloudStores != state.localStores -> {
+                                    activity.getString(R.string.google_cloud_connected_restore_available, state.cloudStores.joinToString())
+                                }
+
+                                state.localStores.isNotEmpty() -> {
+                                    activity.getString(R.string.google_cloud_connected_tap_backup, state.localStores.joinToString())
+                                }
+
+                                else -> {
+                                    activity.getString(R.string.google_cloud_connected_ready)
+                                }
+                            }
+                        }.getOrElse { error ->
+                            rememberSyncError(activity, error)
+                        }
+                    true to message
                 }
-            callback(true, message)
+            callback(result.first, result.second)
         }
     }
 
@@ -216,6 +220,7 @@ object CloudSyncManager {
         activity: Activity,
         callback: (Boolean) -> Unit,
     ) {
+        PlayGamesBootstrap.ensureInitialized(activity)
         val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
         gamesSignInClient.isAuthenticated.addOnCompleteListener { task ->
             val authenticated = task.isSuccessful && task.result?.isAuthenticated == true
@@ -244,45 +249,6 @@ object CloudSyncManager {
                 entryReason = "google_screen_opened",
             ).state
         }
-
-    suspend fun bootstrapOnHomeScreenArrival(activity: Activity): String? {
-        return withContext(Dispatchers.IO) {
-            val shouldRetrySessionAdoption = !prefs(activity).contains(KEY_GOOGLE_SYNC_ENABLED)
-            val timeoutAt = SystemClock.elapsedRealtime() + HOME_BOOTSTRAP_TIMEOUT_MS
-            var attempt = 0
-
-            while (SystemClock.elapsedRealtime() < timeoutAt) {
-                val entryReason =
-                    if (attempt == 0) {
-                        "home_screen_bootstrap"
-                    } else {
-                        "home_screen_bootstrap_retry_$attempt"
-                    }
-                val entry =
-                    readSyncEntryState(
-                        activity = activity,
-                        entryReason = entryReason,
-                    )
-                val restoredToastMessage =
-                    entry.autoRestoreSummary
-                        ?.takeIf { it.restoredStores.isNotEmpty() }
-                        ?.message(activity)
-                if (restoredToastMessage != null) {
-                    return@withContext restoredToastMessage
-                }
-
-                if (!shouldRetrySessionAdoption || entry.state.googleSignedIn) {
-                    return@withContext null
-                }
-
-                attempt += 1
-                delay(HOME_BOOTSTRAP_POLL_DELAY_MS)
-            }
-
-            Timber.tag(TAG).i("Home screen Google bootstrap timed out waiting for Play Games auto sign-in")
-            null
-        }
-    }
 
     suspend fun readStoreLoginState(activity: Activity): StoreLoginSyncState {
         return withContext(Dispatchers.IO) {
@@ -452,6 +418,95 @@ object CloudSyncManager {
         }
     }
 
+    /**
+     * Fire-and-forget auto-backup of store-login tokens. Invoked from credential-save paths
+     * (login, token refresh, background worker) so the Google snapshot always holds the latest
+     * refresh token instead of a stale one.
+     *
+     * - No-op if Google sync is disabled.
+     * - No-op if an earlier attempt ran within the debounce window ([AUTO_BACKUP_MIN_INTERVAL_MS]).
+     * - If an [Activity] is currently attached (app is live), uploads immediately on the manager's scope.
+     * - Otherwise marks a pending flag that [flushPendingAutoBackup] will drain on next Activity resume.
+     *
+     * Silent on both success and failure — this runs alongside normal API calls and must not
+     * interrupt the user with toasts.
+     */
+    fun scheduleAutoBackup(context: Context) {
+        if (!isGoogleSyncEnabled(context)) return
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastAutoBackupAttemptMs < AUTO_BACKUP_MIN_INTERVAL_MS) {
+            Timber.tag(TAG).v("scheduleAutoBackup debounced (last attempt %d ms ago)", now - lastAutoBackupAttemptMs)
+            return
+        }
+        lastAutoBackupAttemptMs = now
+
+        val activity = com.winlator.cmod.app.shell.UnifiedActivity.currentActivity()
+        if (activity == null) {
+            Timber.tag(TAG).i("Auto-backup: no Activity attached, deferring until next foreground")
+            prefs(context).edit().putBoolean(KEY_AUTO_BACKUP_PENDING, true).apply()
+            return
+        }
+
+        scope.launch {
+            if (performAutoBackupUpload(activity)) {
+                Timber.tag(TAG).i("Auto-backup of store logins completed")
+                prefs(context).edit().putBoolean(KEY_AUTO_BACKUP_PENDING, false).apply()
+            } else {
+                // Could not upload (no Google auth yet, network error, etc.). Leave pending
+                // so the next app foreground or next credential change can retry.
+                prefs(context).edit().putBoolean(KEY_AUTO_BACKUP_PENDING, true).apply()
+            }
+        }
+    }
+
+    /**
+     * Called on Activity foreground — uploads the local payload if a previous [scheduleAutoBackup]
+     * was deferred (e.g. the refresh worker ran while the app was killed). No-op if no pending flag
+     * or sync disabled.
+     */
+    suspend fun flushPendingAutoBackup(activity: Activity) {
+        if (!prefs(activity).getBoolean(KEY_AUTO_BACKUP_PENDING, false)) return
+        if (!isGoogleSyncEnabled(activity)) {
+            prefs(activity).edit().putBoolean(KEY_AUTO_BACKUP_PENDING, false).apply()
+            return
+        }
+        Timber.tag(TAG).i("Flushing pending auto-backup of store logins")
+        if (performAutoBackupUpload(activity)) {
+            prefs(activity).edit().putBoolean(KEY_AUTO_BACKUP_PENDING, false).apply()
+            lastAutoBackupAttemptMs = SystemClock.elapsedRealtime()
+        }
+    }
+
+    /**
+     * Silent snapshot upload used by auto-backup paths. Returns true iff the upload ran to
+     * completion (including the no-op case where the remote payload already matches).
+     * Does not surface user-visible messages on failure.
+     */
+    private suspend fun performAutoBackupUpload(activity: Activity): Boolean =
+        withContext(Dispatchers.IO) {
+            if (!isAuthenticatedBlocking(activity)) {
+                Timber.tag(TAG).d("Auto-backup upload skipped: Google Play Games not authenticated")
+                return@withContext false
+            }
+            runCatching {
+                syncMutex.withLock {
+                    val localPayload = collectLocalPayload(activity)
+                    if (localPayload.stores.isEmpty()) return@withLock
+                    val remotePayload = readRemotePayload(activity).payload
+                    val shouldUpload = remotePayload == null || localPayload.fingerprint != remotePayload.fingerprint
+                    if (shouldUpload) {
+                        backupPayload(activity, localPayload)
+                    } else {
+                        Timber.tag(TAG).d("Auto-backup upload skipped: remote fingerprint already matches")
+                    }
+                }
+                true
+            }.getOrElse { err ->
+                Timber.tag(TAG).w(err, "Auto-backup upload failed")
+                false
+            }
+        }
+
     private suspend fun rehydrateRestoredStores(
         context: Context,
         restoredStores: Set<String>,
@@ -533,6 +588,7 @@ object CloudSyncManager {
         Log.i(TAG, "Opening snapshot for backup: $SNAPSHOT_NAME")
         Timber.tag(TAG).i("Opening snapshot for backup: %s", SNAPSHOT_NAME)
         val snapshot = openSnapshot(activity, client, createIfMissing = true) ?: return emptySet()
+        val snapshotFileDescriptor = snapshotParcelFileDescriptor(snapshot.snapshotContents)
         try {
             val bytes = payloadToZip(payload)
             Timber.tag(TAG).i("Writing %d bytes to snapshot for stores=%s", bytes.size, payload.stores.keys)
@@ -562,6 +618,8 @@ object CloudSyncManager {
             Timber.tag(TAG).e(error, "Snapshot backup failed for stores=%s", payload.stores.keys)
             runCatching { Tasks.await(client.discardAndClose(snapshot)) }
             throw error
+        } finally {
+            closeQuietly(snapshotFileDescriptor)
         }
     }
 
@@ -569,6 +627,7 @@ object CloudSyncManager {
         val client = freshSnapshotsClient(activity) ?: return SnapshotReadResult(null, null)
         Timber.tag(TAG).d("Opening snapshot for read: %s", SNAPSHOT_NAME)
         val snapshot = openSnapshot(activity, client, createIfMissing = false) ?: return SnapshotReadResult(null, null)
+        val snapshotFileDescriptor = snapshotParcelFileDescriptor(snapshot.snapshotContents)
         return try {
             val bytes = snapshot.snapshotContents.readFully()
             val payload = if (bytes.isNotEmpty()) zipToPayload(bytes) else null
@@ -586,6 +645,8 @@ object CloudSyncManager {
             Timber.tag(TAG).e(error, "Snapshot read failed")
             runCatching { Tasks.await(client.discardAndClose(snapshot)) }
             throw error
+        } finally {
+            closeQuietly(snapshotFileDescriptor)
         }
     }
 
@@ -611,12 +672,12 @@ object CloudSyncManager {
                             SnapshotsClient.RESOLUTION_POLICY_MOST_RECENTLY_MODIFIED,
                         ),
                     )
-                if (result.isConflict) {
-                    Timber.tag(TAG).w("Snapshot conflict detected for %s", SNAPSHOT_NAME)
-                } else {
+                if (!result.isConflict) {
                     Timber.tag(TAG).d("Snapshot open returned without conflict")
+                    return result.data
                 }
-                return result.data ?: result.conflict?.snapshot ?: result.conflict?.conflictingSnapshot
+                val snapshot = resolveSnapshotConflict(client, result.conflict) ?: return null
+                return snapshot
             } catch (error: Exception) {
                 if (!createIfMissing && isMissingSnapshotError(error)) {
                     Timber.tag(TAG).d("No existing store login snapshot found: ${error.message}")
@@ -639,7 +700,74 @@ object CloudSyncManager {
         return null
     }
 
-    private suspend fun freshSnapshotsClient(activity: Activity): SnapshotsClient? = PlayGames.getSnapshotsClient(activity)
+    private suspend fun resolveSnapshotConflict(
+        client: SnapshotsClient,
+        conflict: SnapshotsClient.SnapshotConflict?,
+    ): Snapshot? {
+        if (conflict == null) return null
+
+        var pendingConflict: SnapshotsClient.SnapshotConflict? = conflict
+        while (pendingConflict != null) {
+            val candidates =
+                listOfNotNull(
+                    pendingConflict.snapshot,
+                    pendingConflict.conflictingSnapshot,
+                )
+            if (candidates.isEmpty()) {
+                return null
+            }
+
+            val chosen =
+                candidates.maxByOrNull { snapshot ->
+                    snapshot.metadata.lastModifiedTimestamp
+                } ?: return null
+
+            Log.w(TAG, "Snapshot conflict detected for $SNAPSHOT_NAME; resolving with most recent snapshot")
+            Timber.tag(TAG).w(
+                "Snapshot conflict detected for %s; resolving with lastModified=%d",
+                SNAPSHOT_NAME,
+                chosen.metadata.lastModifiedTimestamp,
+            )
+
+            val resolved =
+                Tasks.await(
+                    client.resolveConflict(
+                        pendingConflict.conflictId,
+                        chosen,
+                    ),
+                )
+
+            if (!resolved.isConflict) {
+                Timber.tag(TAG).i(
+                    "Resolved snapshot conflict for %s with lastModified=%d",
+                    SNAPSHOT_NAME,
+                    chosen.metadata.lastModifiedTimestamp,
+                )
+                return resolved.data
+            }
+
+            pendingConflict = resolved.conflict
+        }
+
+        return null
+    }
+
+    private suspend fun freshSnapshotsClient(activity: Activity): SnapshotsClient? {
+        PlayGamesBootstrap.ensureInitialized(activity)
+        return PlayGames.getSnapshotsClient(activity)
+    }
+
+    private fun snapshotParcelFileDescriptor(contents: SnapshotContents?): ParcelFileDescriptor? =
+        runCatching {
+            contents?.parcelFileDescriptor
+        }.getOrNull()
+
+    private fun closeQuietly(descriptor: ParcelFileDescriptor?) {
+        try {
+            descriptor?.close()
+        } catch (_: Exception) {
+        }
+    }
 
     fun onSavedGamesPermissionResult(activity: Activity) {
         Timber.tag(TAG).w(
@@ -1189,6 +1317,7 @@ object CloudSyncManager {
     }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
                 return true
@@ -1225,6 +1354,7 @@ object CloudSyncManager {
 
     private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
         try {
+            PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
                 withContext(Dispatchers.IO) {

--- a/app/src/main/feature/sync/google/ContainerBackupManager.java
+++ b/app/src/main/feature/sync/google/ContainerBackupManager.java
@@ -278,6 +278,7 @@ public final class ContainerBackupManager {
   }
 
   private static boolean awaitAuthenticatedSession(Activity activity) throws InterruptedException {
+    PlayGamesBootstrap.ensureInitialized(activity);
     for (int attempt = 0; attempt < AUTH_SESSION_RETRY_COUNT; attempt++) {
       if (isAuthenticatedBlocking(activity)) {
         return true;
@@ -291,6 +292,7 @@ public final class ContainerBackupManager {
 
   private static boolean isAuthenticatedBlocking(Activity activity) {
     try {
+      PlayGamesBootstrap.ensureInitialized(activity);
       Object result =
           Tasks.await(
               PlayGames.getGamesSignInClient(activity).isAuthenticated(), 10, TimeUnit.SECONDS);

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -841,6 +841,7 @@ object GameSaveBackupManager {
 
     private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
         try {
+            PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
                 withContext(Dispatchers.IO) {
@@ -858,6 +859,7 @@ object GameSaveBackupManager {
         }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
                 return true

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -227,8 +227,8 @@ fun GoogleScreen() {
                                     autoBackupEnabled = true
                                     autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
                                 } else {
-                                    autoBackupEnabled = true
-                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", true).apply()
+                                    autoBackupEnabled = false
+                                    autoBackupPrefs.edit().putBoolean("cloud_sync_auto_backup", false).apply()
                                 }
                             } catch (e: Exception) {
                                 AppUtils.showToast(context, "Drive authorization failed: ${e.message}")

--- a/app/src/main/feature/sync/google/PlayGamesBootstrap.kt
+++ b/app/src/main/feature/sync/google/PlayGamesBootstrap.kt
@@ -1,0 +1,29 @@
+package com.winlator.cmod.feature.sync.google
+
+import android.content.Context
+import com.google.android.gms.games.PlayGamesSdk
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Lazy initializer for the Play Games v2 SDK. Called from every entry point that needs it
+ * (sign-in, snapshot client, auth check) instead of eagerly from [PluviaApp.onCreate] —
+ * keeps cold-start fast and avoids initializing Google libs for users who never touch cloud sync.
+ */
+object PlayGamesBootstrap {
+    private const val TAG = "PlayGamesBootstrap"
+    private val initialized = AtomicBoolean(false)
+
+    @JvmStatic
+    fun ensureInitialized(context: Context) {
+        if (initialized.get()) return
+
+        synchronized(this) {
+            if (initialized.get()) return
+
+            PlayGamesSdk.initialize(context.applicationContext)
+            initialized.set(true)
+            Timber.tag(TAG).i("Initialized Play Games SDK")
+        }
+    }
+}

--- a/app/src/main/runtime/system/LogManager.kt
+++ b/app/src/main/runtime/system/LogManager.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import com.winlator.cmod.app.config.SettingsConfig
 import com.winlator.cmod.shared.io.FileUtils
+import java.io.Closeable
 import java.io.File
 
 object LogManager {
@@ -95,11 +96,12 @@ object LogManager {
 
         try {
             stopLogcat()
-            Runtime.getRuntime().exec("logcat -c").waitFor()
+            runBlockingLogcatCommand(arrayOf("logcat", "-c"))
             logcatProcess =
                 Runtime.getRuntime().exec(
                     arrayOf("logcat", "-f", logFile.absolutePath, "*:D"),
                 )
+            closeProcessStdin(logcatProcess)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start logcat: ${e.message}")
         }
@@ -112,7 +114,7 @@ object LogManager {
 
     private fun stopLogcat() {
         try {
-            logcatProcess?.destroy()
+            logcatProcess?.let(::destroyProcess)
             logcatProcess = null
         } catch (e: Exception) {
             Log.e(TAG, "Failed to stop logcat: ${e.message}")
@@ -147,6 +149,7 @@ object LogManager {
                 Runtime.getRuntime().exec(
                     arrayOf("logcat", "-f", logFile.absolutePath, "--pid=$pid", "*:W"),
                 )
+            closeProcessStdin(appLogProcess)
             Log.i(TAG, "Application debug logging started (PID=$pid)")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start application logging: ${e.message}")
@@ -156,10 +159,37 @@ object LogManager {
     @JvmStatic
     fun stopAppLogging() {
         try {
-            appLogProcess?.destroy()
+            appLogProcess?.let(::destroyProcess)
             appLogProcess = null
         } catch (e: Exception) {
             Log.e(TAG, "Failed to stop application logging: ${e.message}")
+        }
+    }
+
+    private fun runBlockingLogcatCommand(command: Array<String>) {
+        val process = Runtime.getRuntime().exec(command)
+        try {
+            process.waitFor()
+        } finally {
+            destroyProcess(process)
+        }
+    }
+
+    private fun destroyProcess(process: Process) {
+        closeProcessStdin(process)
+        closeQuietly(process.inputStream)
+        closeQuietly(process.errorStream)
+        process.destroy()
+    }
+
+    private fun closeProcessStdin(process: Process?) {
+        closeQuietly(process?.outputStream)
+    }
+
+    private fun closeQuietly(closeable: Closeable?) {
+        try {
+            closeable?.close()
+        } catch (_: Exception) {
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ playServicesAuth = "21.3.0"
 xz = "1.7"
 commonsCompress = "1.26.1"
 spotless = "8.4.0"
+workManager = "2.10.0"
 
 [libraries]
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
@@ -88,6 +89,7 @@ javaSteamDepotDownloader = { module = "in.dragonbra:javasteam-depotdownloader", 
 playServicesGamesV2 = { module = "com.google.android.gms:play-services-games-v2", version.ref = "playGames" }
 playServicesAuth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 xz = { module = "org.tukaani:xz", version.ref = "xz" }
+workRuntimeKtx = { module = "androidx.work:work-runtime-ktx", version.ref = "workManager" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
…shot

- New EpicTokenRefreshWorker (WorkManager, 4h periodic, NetworkType.CONNECTED) keeps the Epic eg1 refresh token warm so users stop getting logged out every day.
- EpicAuthManager now persists refresh_expires_at, exposes a truthful getAuthStatus, clears creds + emits StoreSessionBus.SessionExpired on refresh failure instead of silently showing an empty library.
- Shared stores/common package (StoreAuthStatus, StoreSessionEvent, StoreSessionBus) lays the groundwork for GOG/Steam to use the same session-lifecycle model.
- CloudSyncManager.scheduleAutoBackup fires after every Epic save so the Google Play Games snapshot always holds the freshest refresh token instead of a stale one. Defers via pending flag + flushPendingAutoBackup when app is backgrounded.
- Proactive refresh on UnifiedActivity.onCreate so every app open extends the 8h refresh window.

Fold in PR #213 fixes while here:
- Snapshot conflict resolution via client.resolveConflict loop (not the naive "pick either side" fallback).
- ParcelFileDescriptor cleanup in finally blocks for backupPayload/readRemotePayload.
- Sign-in callback body moved off main thread (withContext(Dispatchers.IO)).
- GoogleScreen: auto-backup toggle no longer force-enables on Drive auth failure.
- LogManager: close stdin/stdout/stderr around Runtime.exec logcat processes.
- New PlayGamesBootstrap defense-in-depth initializer (no-op when eager init runs).

Kept eager PlayGamesSdk.initialize + should_auto_sign_in=true per user preference (so sign-in still fires at app launch rather than lazy).