### PR TITLE
fix: ignore fingerprint sensors and uinput devices as game controllers

### DIFF
--- a/app/src/main/runtime/input/ControllerHelper.kt
+++ b/app/src/main/runtime/input/ControllerHelper.kt
@@ -8,6 +8,10 @@ object ControllerHelper {
         val deviceIds = InputDevice.getDeviceIds()
         for (deviceId in deviceIds) {
             val device = InputDevice.getDevice(deviceId) ?: continue
+            val name = device.name?.lowercase() ?: ""
+            if (name.contains("uinput-fpc") || name.contains("goodix_fp") || name.contains("uinput-")) {
+                continue
+            }
             val sources = device.sources
             if (!device.isVirtual &&
                 (

--- a/app/src/main/runtime/input/controls/ExternalController.java
+++ b/app/src/main/runtime/input/controls/ExternalController.java
@@ -446,6 +446,13 @@ public class ExternalController {
     if (device == null) {
       return false;
     }
+    String name = device.getName();
+    if (name != null) {
+      String lowerName = name.toLowerCase();
+      if (lowerName.contains("uinput-fpc") || lowerName.contains("goodix_fp") || lowerName.contains("uinput-")) {
+        return false;
+      }
+    }
     int sources = device.getSources();
     if (device.isVirtual()) {
       return false;


### PR DESCRIPTION
- Added name-based filtering in `ExternalController.java` and `ControllerHelper.kt`.
- Blocks common internal hardware sensors (`uinput-fpc`, `goodix_fp`, `uinput-`) from being incorrectly identified and assigned as physical gamepads.