### PR TITLE
Fix HUD tracking and remove DXVK fallback normalization

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3424,9 +3424,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         ContentProfile currentProfile = resolveInstalledGraphicsProfileByToken(type, currentVersion);
         if (currentProfile != null) {
-            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep installed type=" + type +
-                    " current='" + currentVersion + "' arm64ec=" + isArm64EC);
-            return currentVersion;
+            String normalizedToken = getContentVersionToken(currentProfile);
+            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion canonicalized installed type=" + type +
+                    " current='" + currentVersion + "' normalized='" + normalizedToken + "' arm64ec=" + isArm64EC);
+            return normalizedToken;
         }
 
         if (hasBundledGraphicsComponent(type, currentVersion)) {
@@ -3435,13 +3436,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             return currentVersion;
         }
 
-        String preferredProfileToken = findBestInstalledGraphicsToken(type, isArm64EC, null);
-        if (!preferredProfileToken.isEmpty()) {
-            Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion fallback preferred type=" + type +
-                    " current='" + currentVersion + "' to='" + preferredProfileToken + "' arm64ec=" + isArm64EC);
-            return preferredProfileToken;
-        }
-        Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep current (no fallback) type=" + type +
+        Log.d("XServerDisplayActivity", "resolveInstalledGraphicsComponentVersion keep current (no installed/bundled match) type=" + type +
                 " current='" + currentVersion + "' arm64ec=" + isArm64EC);
         return currentVersion;
     }
@@ -3495,59 +3490,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
     }
 
-    private String findBestInstalledGraphicsToken(
-            ContentProfile.ContentType type,
-            boolean isArm64EC,
-            @Nullable String preferredVersionName
-    ) {
-        ContentProfile preferredProfile = null;
-        String normalizedPreferredName = normalizeGraphicsVersionName(preferredVersionName);
-
-        for (ContentProfile profile : contentsManager.getProfiles(type)) {
-            if (!profile.isInstalled) continue;
-
-            String versionToken = getContentVersionToken(profile);
-            if (isArm64ComponentVersion(versionToken) != isArm64EC) continue;
-
-            if (normalizedPreferredName != null && !normalizedPreferredName.equals(profile.verName)) continue;
-
-            if (preferredProfile == null ||
-                    profile.verCode > preferredProfile.verCode ||
-                    (profile.verCode == preferredProfile.verCode &&
-                            profile.verName.compareToIgnoreCase(preferredProfile.verName) > 0)) {
-                preferredProfile = profile;
-            }
-        }
-
-        String selected = preferredProfile != null ? getContentVersionToken(preferredProfile) : "";
-        Log.d("XServerDisplayActivity", "findBestInstalledGraphicsToken type=" + type +
-                " preferredName='" + preferredVersionName + "' normalizedPreferredName='" + normalizedPreferredName +
-                "' arm64ec=" + isArm64EC + " selected='" + selected + "'");
-        return selected;
-    }
-
-    private String normalizeGraphicsVersionName(@Nullable String versionToken) {
-        if (versionToken == null || versionToken.isEmpty()) return null;
-        int lastDashIndex = versionToken.lastIndexOf('-');
-        if (lastDashIndex <= 0 || lastDashIndex == versionToken.length() - 1) return versionToken;
-
-        String suffix = versionToken.substring(lastDashIndex + 1);
-        for (int i = 0; i < suffix.length(); i++) {
-            if (!Character.isDigit(suffix.charAt(i))) {
-                return versionToken;
-            }
-        }
-        return versionToken.substring(0, lastDashIndex);
-    }
-
     private String getContentVersionToken(ContentProfile profile) {
         String entryName = ContentsManager.getEntryName(profile);
         int firstDashIndex = entryName.indexOf('-');
         return firstDashIndex >= 0 ? entryName.substring(firstDashIndex + 1) : profile.verName;
-    }
-
-    private boolean isArm64ComponentVersion(String version) {
-        return version != null && version.toLowerCase().contains("arm64ec");
     }
 
     private void ensureWinePrefixReady() {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -258,6 +258,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private short taskAffinityMask = 0;
     private short taskAffinityMaskWoW64 = 0;
     private int frameRatingWindowId = -1;
+    private int frameRatingOwnerWindowId = -1;
+    private long lastFrameRatingWindowPresentNano = 0L;
+    private int frameRatingPresentCandidateWindowId = -1;
+    private int frameRatingPresentCandidateHits = 0;
+    private long lastFrameRatingPresentCandidateNano = 0L;
     private boolean cursorLock; // Flag to track if pointer capture was requested
     private final float[] xform = XForm.getInstance();
     private ContentsManager contentsManager;
@@ -298,6 +303,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private Handler  timeoutHandler = new Handler(Looper.getMainLooper());
     private Runnable hideControlsRunnable;
     private final AtomicBoolean exitRequested = new AtomicBoolean(false);
+    private static final long FRAME_RATING_RENDERER_FALLBACK_DELAY_NANOS = 750_000_000L;
+    private static final long FRAME_RATING_PRESENT_CANDIDATE_TIMEOUT_NANOS = 250_000_000L;
+    private static final int FRAME_RATING_WINDOW_MIN_SCREEN_DIVISOR = 4;
+    private static final int FRAME_RATING_PRESENT_PROMOTION_HITS = 2;
     private final AtomicBoolean steamExitWatchRunning = new AtomicBoolean(false);
 
     private boolean isDarkMode;
@@ -1118,10 +1127,39 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     frameRating.update();
                 }
             }
+
+            @Override
+            public void onFramePresented(Window window) {
+                if (frameRating == null || !effectiveShowFPS) return;
+                long eventNano = System.nanoTime();
+                if (window != null) {
+                    maybePromoteFrameRatingWindowFromPresent(window, eventNano);
+                    if (frameRatingWindowId == -1 || frameRatingWindowId == window.id) {
+                        lastFrameRatingWindowPresentNano = eventNano;
+                        frameRating.update();
+                    }
+                    return;
+                }
+
+                if (frameRatingWindowId == -1
+                        || eventNano - lastFrameRatingWindowPresentNano >= FRAME_RATING_RENDERER_FALLBACK_DELAY_NANOS) {
+                    frameRating.update();
+                }
+            }
            
             @Override
             public void onMapWindow(Window window) {
                 assignTaskAffinity(window);
+                if (frameRating != null && effectiveShowFPS) {
+                    syncFrameRatingWithExistingWindows();
+                }
+            }
+
+            @Override
+            public void onUpdateWindowGeometry(Window window, boolean resized) {
+                if (frameRating != null && effectiveShowFPS && resized) {
+                    syncFrameRatingWithExistingWindows();
+                }
             }
 
             @Override
@@ -6947,12 +6985,99 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
     }
 
+    private boolean isFrameRatingCandidate(@Nullable Window window, @Nullable Window bestAppWindow) {
+        if (window == null || xServer == null) return false;
+        if (window.id == xServer.windowManager.rootWindow.id) return false;
+        if (!window.attributes.isMapped() || !window.isInputOutput()) return false;
+        if (bestAppWindow == null) return window.isApplicationWindow();
+        if (window.id == bestAppWindow.id) return true;
+
+        int screenArea = Math.max(1, xServer.screenInfo.width * xServer.screenInfo.height);
+        int windowArea = Math.max(1, window.getWidth()) * Math.max(1, window.getHeight());
+        if (windowArea * FRAME_RATING_WINDOW_MIN_SCREEN_DIVISOR < screenArea) return false;
+
+        int appProcessId = bestAppWindow.getProcessId();
+        int candidateProcessId = window.getProcessId();
+        if (appProcessId > 0 && candidateProcessId > 0 && appProcessId == candidateProcessId) {
+            return true;
+        }
+
+        String appClassName = bestAppWindow.getClassName();
+        String candidateClassName = window.getClassName();
+        return !appClassName.isEmpty() && appClassName.equals(candidateClassName);
+    }
+
+    @Nullable
+    private Window getFrameRatingOwnerWindow() {
+        if (xServer == null || frameRatingOwnerWindowId == -1) return null;
+        return xServer.windowManager.getWindow(frameRatingOwnerWindowId);
+    }
+
+    private void resetFrameRatingPresentCandidate() {
+        frameRatingPresentCandidateWindowId = -1;
+        frameRatingPresentCandidateHits = 0;
+        lastFrameRatingPresentCandidateNano = 0L;
+    }
+
+    private boolean isFrameRatingPresentPromotionCandidate(@Nullable Window window) {
+        if (window == null || xServer == null) return false;
+        if (window.id == xServer.windowManager.rootWindow.id) return false;
+        if (!window.attributes.isMapped() || !window.isInputOutput()) return false;
+        if (window.id == frameRatingWindowId) return false;
+
+        Window ownerWindow = getFrameRatingOwnerWindow();
+        if (ownerWindow == null || ownerWindow == window) return false;
+
+        int screenArea = Math.max(1, xServer.screenInfo.width * xServer.screenInfo.height);
+        int windowArea = Math.max(1, window.getWidth()) * Math.max(1, window.getHeight());
+        if (windowArea * FRAME_RATING_WINDOW_MIN_SCREEN_DIVISOR < screenArea) return false;
+
+        if (ownerWindow.isAncestorOf(window)) return true;
+
+        int ownerProcessId = ownerWindow.getProcessId();
+        int candidateProcessId = window.getProcessId();
+        if (ownerProcessId > 0 && candidateProcessId > 0 && ownerProcessId == candidateProcessId) {
+            return true;
+        }
+
+        String ownerClassName = ownerWindow.getClassName();
+        String candidateClassName = window.getClassName();
+        return !ownerClassName.isEmpty() && ownerClassName.equals(candidateClassName);
+    }
+
+    private void maybePromoteFrameRatingWindowFromPresent(@Nullable Window window, long eventNano) {
+        if (!isFrameRatingPresentPromotionCandidate(window)) {
+            if (frameRatingPresentCandidateWindowId == (window != null ? window.id : -1)) {
+                resetFrameRatingPresentCandidate();
+            }
+            return;
+        }
+
+        if (frameRatingPresentCandidateWindowId != window.id
+                || eventNano - lastFrameRatingPresentCandidateNano > FRAME_RATING_PRESENT_CANDIDATE_TIMEOUT_NANOS) {
+            frameRatingPresentCandidateWindowId = window.id;
+            frameRatingPresentCandidateHits = 1;
+        } else {
+            frameRatingPresentCandidateHits++;
+        }
+        lastFrameRatingPresentCandidateNano = eventNano;
+
+        if (frameRatingPresentCandidateHits >= FRAME_RATING_PRESENT_PROMOTION_HITS) {
+            frameRatingWindowId = window.id;
+            lastFrameRatingWindowPresentNano = eventNano;
+            resetFrameRatingPresentCandidate();
+        }
+    }
+
     private void changeFrameRatingVisibility(Window window, Property property) {
         if (property != null) {
             String propName = property.nameAsString();
             boolean isRendererProp = propName.contains("_MESA_DRV_ENGINE_NAME") || propName.contains("_UTIL_LAYER") || propName.contains("_MESA_DRV_RENDERER");
+            boolean affectsFrameRatingWindow = "WM_CLASS".equals(propName)
+                    || "WM_HINTS".equals(propName)
+                    || "_NET_WM_PID".equals(propName);
 
-            if (isRendererProp || propName.contains("_MESA_DRV_GPU_NAME")) {
+            if (isRendererProp || propName.contains("_MESA_DRV_GPU_NAME") || affectsFrameRatingWindow) {
                 syncFrameRatingWithExistingWindows();
                 return;
             }
@@ -6981,42 +7106,86 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     private void syncFrameRatingWithExistingWindows() {
         if (xServer == null || frameRating == null) return;
-        Window bestWindow = null;
+        int previousWindowId = frameRatingWindowId;
+        int previousOwnerWindowId = frameRatingOwnerWindowId;
+        Window bestAppWindow = null;
+        int bestAppArea = -1;
+        Window bestFrameRatingWindow = null;
+        int bestFrameRatingArea = -1;
+        Window bestRendererWindow = null;
         String bestRenderer = null;
         String bestGpu = null;
 
         for (Window window : xServer.windowManager.getWindows()) {
             if (window.id == xServer.windowManager.rootWindow.id) continue;
+            if (!window.attributes.isMapped()) continue;
+
+            int area = Math.max(1, window.getWidth()) * Math.max(1, window.getHeight());
+            if (window.isApplicationWindow() && area > bestAppArea) {
+                bestAppWindow = window;
+                bestAppArea = area;
+            }
 
             Property prop = window.getProperty(Atom.getId("_MESA_DRV_ENGINE_NAME"));
             if (prop == null) prop = window.getProperty(Atom.getId("_MESA_DRV_RENDERER"));
             if (prop == null) prop = window.getProperty(Atom.getId("_UTIL_LAYER"));
 
             if (prop != null) {
-                boolean isApp = window.isApplicationWindow();
-                boolean isMapped = window.attributes.isMapped();
-                
-                if (bestWindow == null || 
-                   (isApp && !bestWindow.isApplicationWindow()) ||
-                   (isMapped && !bestWindow.attributes.isMapped() && (isApp || !bestWindow.isApplicationWindow()))) {
-                    bestWindow = window;
+                if (bestRendererWindow == null ||
+                   (window.isApplicationWindow() && !bestRendererWindow.isApplicationWindow()) ||
+                   (window.isApplicationWindow() == bestRendererWindow.isApplicationWindow()
+                           && area > (Math.max(1, bestRendererWindow.getWidth()) * Math.max(1, bestRendererWindow.getHeight())))) {
+                    bestRendererWindow = window;
                     bestRenderer = prop.toString();
                     Property gpuProp = window.getProperty(Atom.getId("_MESA_DRV_GPU_NAME"));
                     bestGpu = gpuProp != null ? gpuProp.toString() : null;
                 }
-                
-                if (isApp && isMapped) break;
             }
         }
 
-        if (bestWindow != null) {
-            lastRendererName = bestRenderer;
-            lastGpuName = bestGpu;
-            frameRatingWindowId = bestWindow.id;
+        for (Window window : xServer.windowManager.getWindows()) {
+            if (!isFrameRatingCandidate(window, bestAppWindow)) continue;
+
+            int area = Math.max(1, window.getWidth()) * Math.max(1, window.getHeight());
+            if (area > bestFrameRatingArea) {
+                bestFrameRatingWindow = window;
+                bestFrameRatingArea = area;
+            }
+        }
+
+        if (bestAppWindow != null) {
+            frameRatingOwnerWindowId = bestAppWindow.id;
+        } else if (bestFrameRatingWindow != null) {
+            frameRatingOwnerWindowId = bestFrameRatingWindow.id;
+        } else if (bestRendererWindow != null) {
+            frameRatingOwnerWindowId = bestRendererWindow.id;
         } else {
-            lastRendererName = "OpenGL";
-            lastGpuName = null;
+            frameRatingOwnerWindowId = -1;
+        }
+
+        if (bestFrameRatingWindow != null) {
+            frameRatingWindowId = bestFrameRatingWindow.id;
+        } else if (bestRendererWindow != null) {
+            frameRatingWindowId = bestRendererWindow.id;
+        } else {
             frameRatingWindowId = -1;
+        }
+
+        if (frameRatingOwnerWindowId != previousOwnerWindowId) {
+            resetFrameRatingPresentCandidate();
+        }
+
+        if (frameRatingWindowId != previousWindowId) {
+            lastFrameRatingWindowPresentNano = frameRatingWindowId == -1 ? 0L : System.nanoTime();
+            resetFrameRatingPresentCandidate();
+        }
+
+        if (bestRendererWindow != null) {
+            lastRendererName = resolveHudRendererName(bestRenderer);
+            lastGpuName = bestGpu;
+        } else {
+            lastRendererName = resolveHudRendererName(null);
+            lastGpuName = null;
         }
 
         runOnUiThread(() -> {
@@ -7024,6 +7193,28 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             frameRating.setGpuName(lastGpuName);
             updateHUDRenderMode();
         });
+    }
+
+    private String resolveHudRendererName(@Nullable String rendererName) {
+        String raw = rendererName != null ? rendererName.trim() : "";
+        String lower = raw.toLowerCase(Locale.US);
+
+        if (lower.contains("vkd3d") || lower.contains("dxvk")) {
+            return raw;
+        }
+
+        String activeDxWrapper = dxwrapper != null ? dxwrapper.toLowerCase(Locale.US) : "";
+        if (activeDxWrapper.contains("dxvk")) {
+            // When DXVK is active, Mesa helper windows can still expose "zink" or
+            // other backend names. Report the user-facing D3D wrapper instead.
+            return "DXVK";
+        }
+
+        if (activeDxWrapper.contains("wined3d")) {
+            return !raw.isEmpty() ? raw : "WineD3D";
+        }
+
+        return !raw.isEmpty() ? raw : "OpenGL";
     }
 
     private void updateHUDRenderMode() {

--- a/app/src/main/runtime/display/ui/FrameRating.java
+++ b/app/src/main/runtime/display/ui/FrameRating.java
@@ -79,6 +79,7 @@ public class FrameRating extends LinearLayout implements Runnable {
   private long lastFrameNano;
   private long lastGraphRedraw;
   private long lastTime;
+  private long lastUpdateEventNano;
   private volatile String ramText;
   private String rendererName;
   private String gpuName;
@@ -127,6 +128,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.lastTime = 0L;
     this.lastGraphRedraw = 0L;
     this.lastFrameNano = 0L;
+    this.lastUpdateEventNano = 0L;
     this.frameCount = 0;
     this.lastFPS = 0.0f;
     this.currentMs = 0.0f;
@@ -165,6 +167,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.isNativeActive = this.preferences.getBoolean("use_dri3", true);
     this.batteryManager = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
     setOrientation(LinearLayout.HORIZONTAL);
+    setBaselineAligned(false);
     setLayoutParams(
         new ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
@@ -458,10 +461,12 @@ public class FrameRating extends LinearLayout implements Runnable {
         if (v == graphContainer) {
           lp.width = graphW;
           lp.height = graphH;
+          lp.gravity = android.view.Gravity.CENTER_VERTICAL;
           lp.setMargins(horizontal ? 4 : 0, horizontal ? 0 : 4, 0, 0);
         } else {
           lp.width = LayoutParams.WRAP_CONTENT;
           lp.height = LayoutParams.WRAP_CONTENT;
+          lp.gravity = horizontal ? android.view.Gravity.CENTER_VERTICAL : android.view.Gravity.START;
           lp.setMargins(0, 0, 0, 0);
         }
         v.setLayoutParams(lp);
@@ -594,6 +599,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.frameCount = 0;
     this.lastTime = 0L;
     this.lastFrameNano = 0L;
+    this.lastUpdateEventNano = 0L;
     this.lastFPS = 0.0f;
     this.currentMs = 0.0f;
     post(this);
@@ -703,6 +709,15 @@ public class FrameRating extends LinearLayout implements Runnable {
     if (getVisibility() != View.VISIBLE) {
       return;
     }
+    long eventNano = System.nanoTime();
+    // The same displayed frame can trigger both X11/present callbacks and
+    // the renderer's frame-present callback. Ignore events that land almost
+    // back-to-back so the HUD reflects displayed FPS instead of callback count.
+    if (lastUpdateEventNano != 0L && eventNano - lastUpdateEventNano < 1_000_000L) {
+      return;
+    }
+    lastUpdateEventNano = eventNano;
+
     if (this.lastTime == 0) {
       this.lastTime = SystemClock.elapsedRealtime();
     }
@@ -714,12 +729,11 @@ public class FrameRating extends LinearLayout implements Runnable {
       this.frameCount = 0;
     }
     this.frameCount++;
-    long nowNano = System.nanoTime();
     if (this.lastFrameNano == 0) {
-      this.lastFrameNano = nowNano;
+      this.lastFrameNano = eventNano;
     }
-    float ms = (nowNano - this.lastFrameNano) / 1000000.0f;
-    this.lastFrameNano = nowNano;
+    float ms = (eventNano - this.lastFrameNano) / 1000000.0f;
+    this.lastFrameNano = eventNano;
     if (this.enableGraph && ms > 0.0f && ms < 500.0f) {
       this.currentMs = ms;
       if (time - this.lastGraphRedraw >= 50) {
@@ -965,6 +979,7 @@ public class FrameRating extends LinearLayout implements Runnable {
 
   private class FrametimeGraphView extends View {
     private final int MAX_SAMPLES = 60;
+    private static final float GRAPH_MAX_VISIBLE_MS = 66.6f;
     private final float[] history = new float[MAX_SAMPLES];
     private int historyIndex = 0;
     private int historySize = 0;
@@ -982,9 +997,14 @@ public class FrameRating extends LinearLayout implements Runnable {
     }
 
     public void addFrame(float ms) {
-      this.history[this.historyIndex] = Math.min(ms, 66.6f);
+      this.history[this.historyIndex] = Math.min(ms, GRAPH_MAX_VISIBLE_MS);
       this.historyIndex = (this.historyIndex + 1) % MAX_SAMPLES;
       if (this.historySize < MAX_SAMPLES) this.historySize++;
+    }
+
+    private float mapFrameMsToY(float ms, float height) {
+      float normalized = Math.min(ms, GRAPH_MAX_VISIBLE_MS) / GRAPH_MAX_VISIBLE_MS;
+      return Math.max(0.0f, (height * 0.5f) - (normalized * height * 0.5f));
     }
 
     @Override
@@ -996,11 +1016,11 @@ public class FrameRating extends LinearLayout implements Runnable {
       float step = w / (MAX_SAMPLES - 1);
       this.path.reset();
       int start = (this.historyIndex - this.historySize + MAX_SAMPLES) % MAX_SAMPLES;
-      float yStart = h - ((this.history[start] / 40.0f) * h);
+      float yStart = mapFrameMsToY(this.history[start], h);
       this.path.moveTo(0.0f, Math.max(0.0f, yStart));
       for (int i = 1; i < this.historySize; i++) {
         int idx = (start + i) % MAX_SAMPLES;
-        float y = h - ((this.history[idx] / 40.0f) * h);
+        float y = mapFrameMsToY(this.history[idx], h);
         this.path.lineTo(i * step, Math.max(0.0f, y));
       }
       canvas.drawPath(this.path, this.paintLine);


### PR DESCRIPTION
- Fix HUD tracking behavior in `FrameRating`
- Stop `normalizeDxwrapperConfigForCurrentWine` from silently falling back to installed DXVK/VKD3D variants during launch
- Verified with `./gradlew.bat :app:compileStandardDebugJavaWithJavac`