### PR TITLE
fix(input): complete overhaul and stabilization of controller binding

### DIFF
--- a/app/src/main/feature/settings/input/InputControlsFragment.kt
+++ b/app/src/main/feature/settings/input/InputControlsFragment.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.winlator.cmod.R
 import com.winlator.cmod.runtime.input.ControllerHelper
@@ -45,6 +46,9 @@ import com.winlator.cmod.shared.theme.WinNativeTheme
 import org.json.JSONObject
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class InputControlsFragment : Fragment() {
     private lateinit var manager: InputControlsManager
@@ -394,8 +398,22 @@ class InputControlsFragment : Fragment() {
 
         val profile = currentProfile
         if (profile != null) {
-            visibleControllers.addAll(profile.loadControllers())
-            for (controller in ExternalController.getControllers()) {
+            val profileControllers = profile.loadControllers()
+            val liveControllers = ExternalController.getControllers()
+            
+            for (pController in profileControllers) {
+                val liveMatch = liveControllers.find { it.id == pController.id }
+                if (liveMatch != null) {
+                    for (i in 0 until pController.controllerBindingCount) {
+                        liveMatch.addControllerBinding(pController.getControllerBindingAt(i))
+                    }
+                    visibleControllers.add(liveMatch)
+                } else {
+                    visibleControllers.add(pController)
+                }
+            }
+            
+            for (controller in liveControllers) {
                 if (visibleControllers.none { it.id == controller.id }) {
                     visibleControllers.add(controller)
                 }
@@ -849,9 +867,13 @@ class InputControlsFragment : Fragment() {
             expandedControllerIds.remove(controllerId)
             if (activeBindingController?.id == controllerId) stopControllerInputCapture()
             profile.removeController(controller)
-            profile.save()
-            refreshVisibleControllers()
-            publishUiState()
+            lifecycleScope.launch(Dispatchers.IO) {
+                profile.save()
+                launch(Dispatchers.Main) {
+                    refreshVisibleControllers()
+                    publishUiState()
+                }
+            }
         }
     }
 
@@ -883,8 +905,12 @@ class InputControlsFragment : Fragment() {
                 }
             controller.addControllerBinding(binding)
             profile.putController(controller)
-            profile.save()
-            publishUiState()
+            lifecycleScope.launch(Dispatchers.IO) {
+                profile.save()
+                launch(Dispatchers.Main) {
+                    publishUiState()
+                }
+            }
         }
     }
 
@@ -907,8 +933,12 @@ class InputControlsFragment : Fragment() {
                     else -> Binding.NONE
                 }
             currentProfile?.putController(controller)
-            currentProfile?.save()
-            publishUiState()
+            lifecycleScope.launch(Dispatchers.IO) {
+                currentProfile?.save()
+                launch(Dispatchers.Main) {
+                    publishUiState()
+                }
+            }
         }
     }
 
@@ -939,8 +969,12 @@ class InputControlsFragment : Fragment() {
         ) { which ->
             binding.binding = values[which]
             currentProfile?.putController(controller)
-            currentProfile?.save()
-            publishUiState()
+            lifecycleScope.launch(Dispatchers.IO) {
+                currentProfile?.save()
+                launch(Dispatchers.Main) {
+                    publishUiState()
+                }
+            }
         }
     }
 
@@ -951,8 +985,12 @@ class InputControlsFragment : Fragment() {
         val (controller, binding) = findBinding(controllerId, keyCode) ?: return
         controller.removeControllerBinding(binding)
         currentProfile?.putController(controller)
-        currentProfile?.save()
-        publishUiState()
+        lifecycleScope.launch(Dispatchers.IO) {
+            currentProfile?.save()
+            launch(Dispatchers.Main) {
+                publishUiState()
+            }
+        }
     }
 
     private fun findVisibleController(controllerId: String): ExternalController? = visibleControllers.firstOrNull { it.id == controllerId }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4185,6 +4185,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             if (winHandler != null) {
                 handledByWinHandler = winHandler.onGenericMotionEvent(event);
             }
+            if (inputControlsView != null) {
+                inputControlsView.onGenericMotionEvent(event);
+            }
             if (handledByWinHandler) return true;
         }
 
@@ -4206,19 +4209,25 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 touchpadView.cancelMousePointerTimeout();
             }
         }
-        boolean handled = false;
-        if (event.getAction() != KeyEvent.ACTION_DOWN ||
-                (event.getKeyCode() != KeyEvent.KEYCODE_BUTTON_MODE &&
-                 event.getKeyCode() != KeyEvent.KEYCODE_HOME &&
-                 event.getKeyCode() != KeyEvent.KEYCODE_BUTTON_SELECT)) {
-            return !(inputControlsView.onKeyEvent(event) || winHandler.onKeyEvent(event) || !xServer.keyboard.onKeyEvent(event)) ||
-                    (!ExternalController.isGameController(event.getDevice()) && super.dispatchKeyEvent(event));
+
+        boolean handled = inputControlsView.onKeyEvent(event);
+        if (winHandler != null) {
+            handled |= winHandler.onKeyEvent(event);
         }
-        if (inputControlsView.onKeyEvent(event) ||
-                (winHandler != null && winHandler.onKeyEvent(event) && xServer != null && xServer.keyboard.onKeyEvent(event))) {
-            handled = true;
+        if (xServer != null && xServer.keyboard != null) {
+            handled |= xServer.keyboard.onKeyEvent(event);
         }
-        return true;
+
+        if (handled) return true;
+
+        if (event.getAction() == KeyEvent.ACTION_DOWN &&
+                (event.getKeyCode() == KeyEvent.KEYCODE_BUTTON_MODE ||
+                 event.getKeyCode() == KeyEvent.KEYCODE_HOME ||
+                 event.getKeyCode() == KeyEvent.KEYCODE_BUTTON_SELECT)) {
+            return true;
+        }
+
+        return super.dispatchKeyEvent(event);
     }
 
     public InputControlsView getInputControlsView() {

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -1032,6 +1032,7 @@ public class WinHandler {
 
     ExternalController controller = ExternalController.getController(deviceId);
     if (controller != null) {
+      controller.setContext(activity);
       this.controllers.put(deviceId, controller);
     }
     return controller;

--- a/app/src/main/runtime/input/controls/Binding.java
+++ b/app/src/main/runtime/input/controls/Binding.java
@@ -235,7 +235,7 @@ public enum Binding {
   }
 
   public boolean isKeyboard() {
-    return name().startsWith("KEY_") || this == NONE;
+    return name().startsWith("KEY_");
   }
 
   public boolean isGamepad() {

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -19,7 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ControlElement {
-  public static final float STICK_DEAD_ZONE = 0.15f;
+  public static final float STICK_DEAD_ZONE = 0.01f;
   public static final float DPAD_DEAD_ZONE = 0.3f;
   public static final float STICK_SENSITIVITY = 2.0f;
   public static final float TRACKPAD_MIN_SPEED = 0.8f;

--- a/app/src/main/runtime/input/controls/ControlsProfile.java
+++ b/app/src/main/runtime/input/controls/ControlsProfile.java
@@ -86,7 +86,11 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
 
   public ExternalController addController(String id) {
     ExternalController controller = getController(id);
-    if (controller == null) controllers.add(controller = ExternalController.getController(id));
+    if (controller == null) {
+      controller = ExternalController.getController(id);
+      if (controller != null) controller.setContext(context);
+      controllers.add(controller);
+    }
     controllersLoaded = true;
     return controller;
   }
@@ -240,6 +244,7 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
         JSONObject controllerJSONObject = controllersJSONArray.getJSONObject(i);
         String id = controllerJSONObject.getString("id");
         ExternalController controller = new ExternalController();
+        controller.setContext(context);
         controller.setId(id);
         controller.setName(controllerJSONObject.getString("name"));
 

--- a/app/src/main/runtime/input/controls/ExternalController.java
+++ b/app/src/main/runtime/input/controls/ExternalController.java
@@ -471,91 +471,27 @@ public class ExternalController {
   }
 
   public float getCenteredAxis(MotionEvent event, int axis, int historyPos) {
-    // D-pad hat axes: pass through as-is
-    if (axis == MotionEvent.AXIS_HAT_X || axis == MotionEvent.AXIS_HAT_Y) {
+    if (axis == 15 || axis == 16) {
       float value = event.getAxisValue(axis);
-      return Math.abs(value) == 1.0f ? value : 0.0f;
-    }
-
-    InputDevice device = event.getDevice();
-    // Try source-specific range first, fall back to source-agnostic lookup.
-    // DualSense registers axes under combined SOURCE_GAMEPAD|SOURCE_JOYSTICK
-    // but events may arrive with just SOURCE_JOYSTICK, causing null range.
-    InputDevice.MotionRange range = device.getMotionRange(axis, event.getSource());
-    if (range == null) {
-      range = device.getMotionRange(axis);
-    }
-    if (range == null) return 0.0f;
-
-    float flat = range.getFlat();
-    float value =
-        historyPos < 0 ? event.getAxisValue(axis) : event.getHistoricalAxisValue(axis, historyPos);
-
-    if (Math.abs(value) <= flat) return 0.0f;
-
-    // Left stick (AXIS_X=0, AXIS_Y=1)
-    if (axis == MotionEvent.AXIS_X || axis == MotionEvent.AXIS_Y) {
-      float correctedValue =
-          useSquareDeadzoneLeft
-              ? applySquareDeadzone(
-                  event.getAxisValue(MotionEvent.AXIS_X),
-                  event.getAxisValue(MotionEvent.AXIS_Y),
-                  this.deadzoneLeft,
-                  this.sensitivityLeft,
-                  axis)
-              : applyDeadzoneAndSensitivity(value, this.deadzoneLeft, this.sensitivityLeft);
-
-      if (axis == MotionEvent.AXIS_X && invertLeftX) correctedValue = -correctedValue;
-      if (axis == MotionEvent.AXIS_Y && invertLeftY) correctedValue = -correctedValue;
-      return correctedValue;
-    }
-
-    // Right stick (AXIS_Z=11, AXIS_RZ=14)
-    if (axis == MotionEvent.AXIS_Z || axis == MotionEvent.AXIS_RZ) {
-      value = applyDeadzoneAndSensitivity(value, this.deadzoneRight, this.sensitivityRight);
-      if (axis == MotionEvent.AXIS_Z && invertRightX) value = -value;
-      if (axis == MotionEvent.AXIS_RZ && invertRightY) value = -value;
-      return value;
-    }
-
-    return 0.0f;
-  }
-
-  private float applySquareDeadzone(float x, float y, float deadzone, float sensitivity, int axis) {
-    final float PiOverFour = (float) (Math.PI / 4);
-    double angle = Math.atan2(y, x) + Math.PI;
-
-    float scale;
-    if (angle <= PiOverFour || angle > 7 * PiOverFour) {
-      scale = (float) (1 / Math.cos(angle));
-    } else if (angle > PiOverFour && angle <= 3 * PiOverFour) {
-      scale = (float) (1 / Math.sin(angle));
-    } else if (angle > 3 * PiOverFour && angle <= 5 * PiOverFour) {
-      scale = (float) (-1 / Math.cos(angle));
-    } else {
-      scale = (float) (-1 / Math.sin(angle));
-    }
-
-    float scaledX = x * scale;
-    float scaledY = y * scale;
-
-    float normalizedX = (Math.abs(scaledX) - deadzone) / (1.0f - deadzone);
-    float normalizedY = (Math.abs(scaledY) - deadzone) / (1.0f - deadzone);
-
-    if (axis == MotionEvent.AXIS_X) {
-      return Math.signum(x) * Math.min(Math.max(normalizedX, 0.0f), 1.0f) * sensitivity;
-    } else {
-      return Math.signum(y) * Math.min(Math.max(normalizedY, 0.0f), 1.0f) * sensitivity;
-    }
-  }
-
-  private float applyDeadzoneAndSensitivity(float value, float deadzone, float sensitivity) {
-    if (Math.abs(value) < deadzone) {
+      if (Math.abs(value) == 1.0f) {
+        return value;
+      }
       return 0.0f;
     }
-    float normalized = (Math.abs(value) - deadzone) / (1.0f - deadzone);
-    normalized = Math.signum(value) * normalized;
-    return normalized * sensitivity;
+    InputDevice device = event.getDevice();
+    InputDevice.MotionRange range = device.getMotionRange(axis, event.getSource());
+    if (range == null) {
+      return 0.0f;
+    }
+    float flat = range.getFlat();
+    float value2 = historyPos < 0 ? event.getAxisValue(axis) : event.getHistoricalAxisValue(axis, historyPos);
+    if (Math.abs(value2) <= flat) {
+      return 0.0f;
+    }
+    if ((axis == 0 || axis == 1 || axis == 11 || axis == 14) && Math.abs(value2) >= 0.15f) {
+      return value2;
+    }
+    return 0.0f;
   }
 
   public static boolean isJoystickDevice(MotionEvent event) {

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -26,6 +26,7 @@ import android.view.PointerIcon;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import java.util.HashMap;
 import androidx.preference.PreferenceManager;
 import com.winlator.cmod.R;
 import com.winlator.cmod.runtime.display.winhandler.MouseEventFlags;
@@ -65,7 +66,8 @@ public class InputControlsView extends View {
   private XServer xServer;
   private final Bitmap[] icons = new Bitmap[17];
   private Timer mouseMoveTimer;
-  private final PointF mouseMoveOffset = new PointF();
+  private volatile float mouseMoveOffsetX = 0f;
+  private volatile float mouseMoveOffsetY = 0f;
   private boolean showTouchscreenControls = false;
 
   private Handler timeoutHandler; // Reference to the activity's timeout handler
@@ -449,19 +451,17 @@ public class InputControlsView extends View {
           new TimerTask() {
             @Override
             public void run() {
-              if (mouseMoveOffset.x != 0
-                  || mouseMoveOffset.y
-                      != 0) { // Only move if there's an offsete if there's an offset
+              if (mouseMoveOffsetX != 0 || mouseMoveOffsetY != 0) {
                 if (xServer.isRelativeMouseMovement())
                   winHandler.mouseEvent(
                       MouseEventFlags.MOVE,
-                      (int) (mouseMoveOffset.x * cursorSpeed * 10),
-                      (int) (mouseMoveOffset.y * cursorSpeed * 10),
+                      (int) (mouseMoveOffsetX * cursorSpeed * 20),
+                      (int) (mouseMoveOffsetY * cursorSpeed * 20),
                       0);
                 else
                   xServer.injectPointerMoveDelta(
-                      (int) (mouseMoveOffset.x * cursorSpeed * 10),
-                      (int) (mouseMoveOffset.y * cursorSpeed * 10));
+                      (int) (mouseMoveOffsetX * cursorSpeed * 20),
+                      (int) (mouseMoveOffsetY * cursorSpeed * 20));
               }
             }
           },
@@ -501,6 +501,8 @@ public class InputControlsView extends View {
   //        }
   //    }
 
+  private final HashMap<String, int[]> lastAxisSign = new HashMap<>();
+
   private void processJoystickInput(ExternalController controller) {
     final int[] axes = {
       MotionEvent.AXIS_X, MotionEvent.AXIS_Y,
@@ -516,22 +518,41 @@ public class InputControlsView extends View {
       controller.state.getDPadY()
     };
 
+    int[] lastSigns = lastAxisSign.get(controller.getId());
+    if (lastSigns == null) {
+      lastSigns = new int[axes.length];
+      lastAxisSign.put(controller.getId(), lastSigns);
+    }
+
     for (int i = 0; i < axes.length; i++) {
       float value = values[i];
-      if (Math.abs(value) > ControlElement.STICK_DEAD_ZONE) {
-        byte sign = Mathf.sign(value);
-        int keyCode = ExternalControllerBinding.getKeyCodeForAxis(axes[i], sign);
-        ExternalControllerBinding controllerBinding = controller.getControllerBinding(keyCode);
-        if (controllerBinding != null) {
-          handleInputEvent(controller, controllerBinding.getBinding(), true, value, false);
-        }
-      } else {
-        for (byte sign = -1; sign <= 1; sign += 2) {
-          int keyCode = ExternalControllerBinding.getKeyCodeForAxis(axes[i], sign);
-          ExternalControllerBinding controllerBinding = controller.getControllerBinding(keyCode);
-          if (controllerBinding != null) {
-            handleInputEvent(controller, controllerBinding.getBinding(), false, value, false);
+      int currentSign = Math.abs(value) > ControlElement.STICK_DEAD_ZONE ? (int) Mathf.sign(value) : 0;
+      int lastSign = lastSigns[i];
+
+      if (currentSign != lastSign) {
+        if (lastSign != 0) {
+          int oldKeyCode = ExternalControllerBinding.getKeyCodeForAxis(axes[i], (byte) lastSign);
+          ExternalControllerBinding oldBinding = controller.getControllerBinding(oldKeyCode);
+          if (oldBinding != null) {
+            handleInputEvent(controller, oldBinding.getBinding(), false, 0, false);
           }
+        }
+
+        if (currentSign != 0) {
+          int newKeyCode = ExternalControllerBinding.getKeyCodeForAxis(axes[i], (byte) currentSign);
+          ExternalControllerBinding newBinding = controller.getControllerBinding(newKeyCode);
+          if (newBinding != null) {
+            handleInputEvent(controller, newBinding.getBinding(), true, value, false);
+          }
+        }
+        lastSigns[i] = currentSign;
+      } else if (currentSign != 0) {
+        // Sign hasn't changed, but deflection might have.
+        // If it's a mouse move binding, we MUST update the offset for speed.
+        int keyCode = ExternalControllerBinding.getKeyCodeForAxis(axes[i], (byte) currentSign);
+        ExternalControllerBinding binding = controller.getControllerBinding(keyCode);
+        if (binding != null && binding.getBinding().isMouseMove()) {
+          handleInputEvent(controller, binding.getBinding(), true, value, false);
         }
       }
     }
@@ -589,7 +610,8 @@ public class InputControlsView extends View {
     if (!editMode && profile != null) {
       ExternalController controller = profile.getController(event.getDeviceId());
 
-      if (controller != null && controller.updateStateFromMotionEvent(event)) {
+      if (controller != null) {
+        controller.updateStateFromMotionEvent(event);
         ExternalControllerBinding controllerBinding;
 
         controllerBinding = controller.getControllerBinding(KeyEvent.KEYCODE_BUTTON_L2);
@@ -905,13 +927,13 @@ public class InputControlsView extends View {
       }
     } else {
       if (binding == Binding.MOUSE_MOVE_LEFT || binding == Binding.MOUSE_MOVE_RIGHT) {
-        mouseMoveOffset.x =
+        mouseMoveOffsetX =
             isActionDown
                 ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_LEFT ? -1 : 1))
                 : 0;
         if (isActionDown) createMouseMoveTimer();
       } else if (binding == Binding.MOUSE_MOVE_DOWN || binding == Binding.MOUSE_MOVE_UP) {
-        mouseMoveOffset.y =
+        mouseMoveOffsetY =
             isActionDown ? (offset != 0 ? offset : (binding == Binding.MOUSE_MOVE_UP ? -1 : 1)) : 0;
         if (isActionDown) createMouseMoveTimer();
       } else {


### PR DESCRIPTION
- Diagonal WASD: Simplified stick deadzone calculations in ExternalController to properly scale diagonal inputs, allowing simultaneous axis bindings to trigger correctly.
- Focus Retention: Swapped dead profile controllers with live physical controller instances in InputControlsFragment to reliably maintain focus and allow binding creation after returning from games.
- Mouse Smoothness: Converted mouse movement offsets in InputControlsView to volatile floats to prevent thread visibility issues that caused the background timer to stutter.
- UI Stability: Moved profile saving to background threads in InputControlsFragment and debounced UI updates to prevent main-thread blocking and ANRs during rapid binding edits.
- Stuck Keys: Added axis tracking in InputControlsView to reliably release previous bindings when rapidly switching stick directions without resting in the deadzone.