### PR TITLE
Stabilize service shutdown and library refresh

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -3,22 +3,14 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
-import com.google.android.gms.games.PlayGamesSdk
-import com.winlator.cmod.app.service.DownloadService
 import com.winlator.cmod.app.update.UpdateChecker
-import com.winlator.cmod.feature.setup.SetupWizardActivity
 import com.winlator.cmod.feature.stores.gog.service.GOGAuthManager
 import com.winlator.cmod.feature.stores.gog.service.GOGConstants
-import com.winlator.cmod.feature.stores.gog.service.GOGService
 import com.winlator.cmod.feature.stores.steam.events.EventDispatcher
-import com.winlator.cmod.feature.stores.steam.service.SteamService
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.runtime.display.XServerDisplayActivity
 import com.winlator.cmod.shared.android.RefreshRateUtils
 import dagger.hilt.android.HiltAndroidApp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 
@@ -28,9 +20,6 @@ class PluviaApp : Application() {
         super.onCreate()
         instance = this
 
-        // Initialize Play Games Services SDK (v2) eagerly so auto sign-in fires at app launch.
-        PlayGamesSdk.initialize(this)
-
         registerRefreshRateLifecycleCallbacks()
 
         // Replace Android's limited BouncyCastle provider with the full one
@@ -38,8 +27,8 @@ class PluviaApp : Application() {
         Security.removeProvider("BC")
         Security.addProvider(BouncyCastleProvider())
 
-        // Init our datastore preferences.
-        PrefManager.init(this)
+        // Register application context so secure Steam prefs can initialize lazily.
+        PrefManager.install(this)
         GOGConstants.init(this)
         GOGAuthManager.updateLoginStatus(this)
 
@@ -47,8 +36,9 @@ class PluviaApp : Application() {
             timber.log.Timber.plant(timber.log.Timber.DebugTree())
         }
 
-        // Record install timestamp for update checker
-        UpdateChecker.refreshInstallTimestamp(this)
+        if (UpdateChecker.isEnabled(this)) {
+            UpdateChecker.refreshInstallTimestamp(this)
+        }
 
         // Rotate logs on app cold start (.log → .old.log) so previous
         // session's logs are preserved until the next full launch.
@@ -60,33 +50,9 @@ class PluviaApp : Application() {
         com.winlator.cmod.runtime.system.LogManager
             .startAppLogging(this)
 
-        DownloadService.populateDownloadService(this)
-
         // Initialize process-wide reactive network state
         com.winlator.cmod.app.service.NetworkMonitor
             .init(this)
-
-        // Initialize database
-        com.winlator.cmod.app.db.PluviaDatabase
-            .init(this)
-
-        CoroutineScope(Dispatchers.IO).launch {
-            SteamService.repairInstalledMetadataFromDisk()
-        }
-
-        // Start SteamService only if setup is complete to avoid premature permission popups
-        try {
-            if (SetupWizardActivity.isSetupComplete(this)) {
-                val intent = android.content.Intent(this, com.winlator.cmod.feature.stores.steam.service.SteamService::class.java)
-                startForegroundService(intent)
-                if (GOGAuthManager.isLoggedIn(this)) {
-                    val gogIntent = android.content.Intent(this, GOGService::class.java)
-                    startForegroundService(gogIntent)
-                }
-            }
-        } catch (e: Exception) {
-            Log.e("PluviaApp", "Failed to start SteamService", e)
-        }
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             Log.e("PluviaApp", "CRASH in thread ${thread.name}", throwable)

--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -11,11 +11,18 @@ import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.runtime.display.XServerDisplayActivity
 import com.winlator.cmod.shared.android.RefreshRateUtils
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 
 @HiltAndroidApp
 class PluviaApp : Application() {
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
     override fun onCreate() {
         super.onCreate()
         instance = this
@@ -30,29 +37,11 @@ class PluviaApp : Application() {
         // Register application context so secure Steam prefs can initialize lazily.
         PrefManager.install(this)
         GOGConstants.init(this)
-        GOGAuthManager.updateLoginStatus(this)
-
-        if (PrefManager.enableSteamLogs) {
-            timber.log.Timber.plant(timber.log.Timber.DebugTree())
-        }
-
-        if (UpdateChecker.isEnabled(this)) {
-            UpdateChecker.refreshInstallTimestamp(this)
-        }
-
-        // Rotate logs on app cold start (.log → .old.log) so previous
-        // session's logs are preserved until the next full launch.
-        com.winlator.cmod.runtime.system.LogManager
-            .rotateLogsOnAppStart(this)
-
-        // Start Application debug logging if enabled (writes PID logcat
-        // in real-time so crash data is persisted even on unexpected termination)
-        com.winlator.cmod.runtime.system.LogManager
-            .startAppLogging(this)
 
         // Initialize process-wide reactive network state
         com.winlator.cmod.app.service.NetworkMonitor
             .init(this)
+        scheduleColdStartWarmups()
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             Log.e("PluviaApp", "CRASH in thread ${thread.name}", throwable)
@@ -120,5 +109,43 @@ class PluviaApp : Application() {
     private fun shouldManageAppRefreshRate(activity: Activity): Boolean {
         // Game windows own per-title refresh policy and should not inherit the global app override.
         return activity !is XServerDisplayActivity
+    }
+
+    private fun scheduleColdStartWarmups() {
+        appScope.launch {
+            // Release the main thread for Activity launch and first Compose work.
+            withContext(Dispatchers.IO) {
+                GOGAuthManager.updateLoginStatus(this@PluviaApp)
+
+                // Pre-warm encrypted preferences off the UI thread so launcher auth checks
+                // are less likely to pay MasterKey/EncryptedSharedPreferences startup cost.
+                val steamLogsEnabled =
+                    runCatching {
+                        PrefManager.init(this@PluviaApp)
+                        PrefManager.libraryLayoutMode
+                        PrefManager.enableSteamLogs
+                    }.getOrElse {
+                        Log.e("PluviaApp", "PrefManager warmup failed", it)
+                        false
+                    }
+
+                if (UpdateChecker.isEnabled(this@PluviaApp)) {
+                    UpdateChecker.refreshInstallTimestamp(this@PluviaApp)
+                }
+
+                com.winlator.cmod.runtime.system.LogManager
+                    .rotateLogsOnAppStart(this@PluviaApp)
+                com.winlator.cmod.runtime.system.LogManager
+                    .startAppLogging(this@PluviaApp)
+
+                if (steamLogsEnabled) {
+                    withContext(Dispatchers.Main.immediate) {
+                        if (timber.log.Timber.forest().none { it is timber.log.Timber.DebugTree }) {
+                            timber.log.Timber.plant(timber.log.Timber.DebugTree())
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/app/di/DatabaseModule.kt
+++ b/app/src/main/app/di/DatabaseModule.kt
@@ -1,7 +1,5 @@
 package com.winlator.cmod.app.di
 import android.content.Context
-import androidx.room.Room
-import com.winlator.cmod.app.db.DATABASE_NAME
 import com.winlator.cmod.app.db.PluviaDatabase
 import com.winlator.cmod.feature.stores.steam.db.dao.*
 import dagger.Module
@@ -18,11 +16,7 @@ class DatabaseModule {
     @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context,
-    ): PluviaDatabase =
-        Room
-            .databaseBuilder(context, PluviaDatabase::class.java, DATABASE_NAME)
-            .fallbackToDestructiveMigration()
-            .build()
+    ): PluviaDatabase = PluviaDatabase.getInstance(context)
 
     @Provides
     @Singleton

--- a/app/src/main/app/service/DownloadService.kt
+++ b/app/src/main/app/service/DownloadService.kt
@@ -2,6 +2,7 @@ package com.winlator.cmod.app.service
 import android.content.Context
 import android.os.Environment
 import android.os.storage.StorageManager
+import com.winlator.cmod.app.PluviaApp
 import com.winlator.cmod.feature.stores.epic.service.EpicService
 import com.winlator.cmod.feature.stores.gog.service.GOGService
 import com.winlator.cmod.feature.stores.steam.service.SteamService
@@ -14,33 +15,94 @@ import java.io.File
 object DownloadService {
     private var lastUpdateTime: Long = 0
     private var downloadDirectoryApps: MutableList<String>? = null
-    var baseDataDirPath: String = ""
-        private set
-    var baseCacheDirPath: String = ""
-        private set
-    var baseExternalAppDirPath: String = ""
-        private set
-    var externalVolumePaths: List<String> = emptyList()
-        private set
-    var appContext: Context? = null
-        private set
+    @Volatile
+    private var initialized = false
+
+    private var _baseDataDirPath: String = ""
+    private var _baseCacheDirPath: String = ""
+    private var _baseExternalAppDirPath: String = ""
+    private var _externalVolumePaths: List<String> = emptyList()
+    private var _appContext: Context? = null
+
+    var baseDataDirPath: String
+        get() {
+            ensureInitialized()
+            return _baseDataDirPath
+        }
+        private set(value) {
+            _baseDataDirPath = value
+        }
+
+    var baseCacheDirPath: String
+        get() {
+            ensureInitialized()
+            return _baseCacheDirPath
+        }
+        private set(value) {
+            _baseCacheDirPath = value
+        }
+
+    var baseExternalAppDirPath: String
+        get() {
+            ensureInitialized()
+            return _baseExternalAppDirPath
+        }
+        private set(value) {
+            _baseExternalAppDirPath = value
+        }
+
+    var externalVolumePaths: List<String>
+        get() {
+            ensureInitialized()
+            return _externalVolumePaths
+        }
+        private set(value) {
+            _externalVolumePaths = value
+        }
+
+    var appContext: Context?
+        get() {
+            ensureInitialized()
+            return _appContext
+        }
+        private set(value) {
+            _appContext = value
+        }
 
     fun populateDownloadService(context: Context) {
-        appContext = context.applicationContext
-        baseDataDirPath = context.dataDir.path
-        baseCacheDirPath = context.cacheDir.path
-        val extFiles = context.getExternalFilesDir(null)
-        baseExternalAppDirPath = extFiles?.parentFile?.path ?: ""
+        ensureInitialized(context)
+    }
 
-        val storageManager = context.getSystemService(StorageManager::class.java)
-        externalVolumePaths =
-            context
-                .getExternalFilesDirs(null)
-                .filterNotNull()
-                .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
-                .filter { storageManager?.getStorageVolume(it)?.isPrimary != true }
-                .map { it.absolutePath }
-                .distinct()
+    private fun ensureInitialized(context: Context? = null) {
+        if (initialized) return
+
+        synchronized(this) {
+            if (initialized) return
+
+            val resolvedContext =
+                context?.applicationContext
+                    ?: _appContext
+                    ?: runCatching { PluviaApp.instance.applicationContext }.getOrNull()
+                    ?: throw IllegalStateException("DownloadService used before application startup")
+
+            appContext = resolvedContext
+            baseDataDirPath = resolvedContext.dataDir.path
+            baseCacheDirPath = resolvedContext.cacheDir.path
+            val extFiles = resolvedContext.getExternalFilesDir(null)
+            baseExternalAppDirPath = extFiles?.parentFile?.path ?: ""
+
+            val storageManager = resolvedContext.getSystemService(StorageManager::class.java)
+            externalVolumePaths =
+                resolvedContext
+                    .getExternalFilesDirs(null)
+                    .filterNotNull()
+                    .filter { Environment.getExternalStorageState(it) == Environment.MEDIA_MOUNTED }
+                    .filter { storageManager?.getStorageVolume(it)?.isPrimary != true }
+                    .map { it.absolutePath }
+                    .distinct()
+
+            initialized = true
+        }
     }
 
     fun getAllDownloads(): List<Pair<String, com.winlator.cmod.feature.stores.steam.data.DownloadInfo>> {

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -5,12 +5,12 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentSender
 import android.content.res.Configuration
+import android.hardware.input.InputManager
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import android.os.Bundle
-import android.os.Process
 import android.provider.DocumentsContract
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
@@ -187,6 +187,7 @@ import com.winlator.cmod.runtime.display.environment.ImageFs
 import com.winlator.cmod.runtime.input.ControllerHelper
 import com.winlator.cmod.runtime.wine.PeIconExtractor
 import com.winlator.cmod.shared.android.ActivityResultHost
+import com.winlator.cmod.shared.android.AppTerminationHelper
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity
 import com.winlator.cmod.shared.android.RefreshRateUtils
@@ -204,7 +205,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import `in`.dragonbra.javasteam.enums.EPersonaState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -261,6 +261,11 @@ class UnifiedActivity :
         val editContainerId: Int = 0,
     )
 
+    private data class ControllerConnectionState(
+        val isConnected: Boolean = ControllerHelper.isControllerConnected(),
+        val isPlayStation: Boolean = ControllerHelper.isPlayStationController(),
+    )
+
     // Root navigation controller for hub <-> settings transitions
     private var rootNavController: NavHostController? = null
 
@@ -278,8 +283,11 @@ class UnifiedActivity :
     private var selectedLibrarySource: String = ""
     private var selectedGogGameId: String = ""
 
-    // Trigger to refresh library when activity resumes from another container
+    // Full library refresh trigger for installs, shortcuts, and external changes.
     var libraryRefreshSignal by mutableIntStateOf(0)
+    // Lightweight refresh trigger for playtime/order changes when returning from a game.
+    var libraryPlaytimeRefreshSignal by mutableIntStateOf(0)
+    private var hasCompletedInitialResume = false
 
     // Freezes the library/store card chasing borders while any full-screen
     // dialog is open, so the ~120 Hz animation cost isn't paid for content
@@ -525,22 +533,18 @@ class UnifiedActivity :
     override fun onPause() {
         super.onPause()
         chasingBordersPaused.value = true
+        UpdateChecker.stopBackgroundLoop()
+        UpdateChecker.cancelPostGameCheck()
     }
 
     override fun onResume() {
         super.onResume()
         chasingBordersPaused.value = false
-        // Ensure all store services are running when returning from a game or other activity
-        if (GOGService.hasStoredCredentials(this) && !GOGService.isRunning) {
-            GOGService.start(this)
+        if (hasCompletedInitialResume) {
+            libraryPlaytimeRefreshSignal++
+        } else {
+            hasCompletedInitialResume = true
         }
-        if (EpicService.hasStoredCredentials(this) && !EpicService.isRunning) {
-            EpicService.start(this)
-        }
-        if (SteamService.hasStoredCredentials(this) && SteamService.instance == null) {
-            SteamService.start(this)
-        }
-        libraryRefreshSignal++
 
         // (Re)start the background update loop (checks hourly + on first tick)
         UpdateChecker.startBackgroundLoop(this)
@@ -698,7 +702,6 @@ class UnifiedActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         instance = this
         super.onCreate(savedInstanceState)
-
         if (!SetupWizardActivity.isSetupComplete(this) || !ImageFs.find(this).isValid) {
             startActivity(
                 Intent(this, SetupWizardActivity::class.java)
@@ -711,10 +714,7 @@ class UnifiedActivity :
         }
 
         supportFragmentManager.registerFragmentLifecycleCallbacks(inputControlsFragmentTracker, true)
-        db = PluviaDatabase.getInstance(this)
         EpicAuthManager.updateLoginStatus(this)
-        GOGAuthManager.updateLoginStatus(this)
-        GOGConstants.init(this)
         SteamService.initLoginStatus(this)
 
         // Start EpicService if user is logged in
@@ -728,11 +728,6 @@ class UnifiedActivity :
             }
             // Make sure the background refresh worker is scheduled (idempotent).
             com.winlator.cmod.feature.stores.epic.service.EpicTokenRefreshWorker.schedule(this)
-        }
-
-        // If the refresh worker fired while the app was killed, push the latest tokens to Google now.
-        lifecycleScope.launch {
-            com.winlator.cmod.feature.sync.google.CloudSyncManager.flushPendingAutoBackup(this@UnifiedActivity)
         }
 
         // Surface store-session events (e.g. Epic refresh-token death, cloud restore) as toasts.
@@ -752,13 +747,7 @@ class UnifiedActivity :
                             android.widget.Toast.LENGTH_LONG,
                         )
                     }
-                    is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRestored -> {
-                        com.winlator.cmod.shared.android.AppUtils.showToast(
-                            this@UnifiedActivity,
-                            "$label session restored from cloud",
-                            android.widget.Toast.LENGTH_SHORT,
-                        )
-                    }
+                    is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRestored -> Unit
                     is com.winlator.cmod.feature.stores.common.StoreSessionEvent.SessionRefreshed -> {
                         // informational — no UI surface
                     }
@@ -774,6 +763,8 @@ class UnifiedActivity :
         if (GOGAuthManager.isLoggedIn(this)) {
             GOGService.start(this)
         }
+
+        SteamService.maybeRepairInstalledMetadataOnStartup(this)
 
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.dark(0xFF141B24.toInt()),
@@ -791,9 +782,6 @@ class UnifiedActivity :
                 window.decorView.systemGestureExclusionRects = listOf(exclusionRect)
             }
         }
-
-        // Start the background update loop (first check fires after 5 s)
-        UpdateChecker.startBackgroundLoop(this)
 
         setContent {
             val navController = rememberNavController()
@@ -990,14 +978,12 @@ class UnifiedActivity :
         var showExitDialog by remember { mutableStateOf(false) }
         var searchQueryTfv by remember { mutableStateOf(TextFieldValue("")) }
         val searchQuery = searchQueryTfv.text
-        var libraryRefreshKey by remember { mutableIntStateOf(0) }
+        var localLibraryRefreshKey by remember { mutableIntStateOf(0) }
         var iconRefreshKey by remember { mutableIntStateOf(0) }
 
         val currentRefreshSignal = this@UnifiedActivity.libraryRefreshSignal
-        LaunchedEffect(currentRefreshSignal) {
-            libraryRefreshKey++
-            iconRefreshKey++
-        }
+        val libraryRefreshKey = currentRefreshSignal + localLibraryRefreshKey
+        val playtimeRefreshKey = this@UnifiedActivity.libraryPlaytimeRefreshSignal
 
         val contentFilters = remember { mutableStateMapOf("games" to true, "dlc" to false, "applications" to false, "tools" to false) }
         var libraryLayoutMode by remember {
@@ -1023,30 +1009,27 @@ class UnifiedActivity :
         val epicApps by db.epicGameDao().getAll().collectAsState(initial = emptyList())
         val gogApps by db.gogGameDao().getAll().collectAsState(initial = emptyList())
 
-        var isControllerConnected by remember { mutableStateOf(ControllerHelper.isControllerConnected()) }
-        val isPS = remember(isControllerConnected) { ControllerHelper.isPlayStationController() }
+        val controllerState = rememberControllerConnectionState()
+        val isControllerConnected = controllerState.isConnected
+        val isPS = controllerState.isPlayStation
         val isLibraryTab = tabs.getOrNull(selectedIdx)?.key == "library"
 
-        // Refresh controller state periodically
-        LaunchedEffect(Unit) {
-            while (true) {
-                isControllerConnected = ControllerHelper.isControllerConnected()
-                kotlinx.coroutines.delay(2000)
-            }
-        }
-
-        // Observe library install status changes to refresh UI
-        LaunchedEffect(Unit) {
-            val listener =
+        val libraryInstallStatusListener =
+            remember {
                 object : EventDispatcher.JavaEventListener {
                     override fun onEvent(event: Any) {
                         if (event is AndroidEvent.LibraryInstallStatusChanged) {
-                            libraryRefreshKey++
+                            localLibraryRefreshKey++
                             iconRefreshKey++
                         }
                     }
                 }
-            PluviaApp.events.onJava(AndroidEvent.LibraryInstallStatusChanged::class, listener)
+            }
+        DisposableEffect(libraryInstallStatusListener) {
+            PluviaApp.events.onJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryInstallStatusListener)
+            onDispose {
+                PluviaApp.events.offJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryInstallStatusListener)
+            }
         }
 
         LaunchedEffect(isEpicLoggedIn) {
@@ -1131,23 +1114,18 @@ class UnifiedActivity :
                 }
             }
 
-        // Sync Steam states periodically without forcing full library recomposition
-        LaunchedEffect(Unit) {
-            while (true) {
-                kotlinx.coroutines.delay(10000)
-                SteamService.syncStates()
-            }
-        }
-
         // Clamp selectedIdx if tabs shrink
         var globalSettingsApp by remember { mutableStateOf<SteamApp?>(null) }
         var globalSettingsGogGame by remember { mutableStateOf<GOGGame?>(null) }
 
         LaunchedEffect(tabs.size) { if (selectedIdx >= tabs.size) selectedIdx = 0 }
-        LaunchedEffect(Unit) { SteamService.requestUserPersona() }
+        LaunchedEffect(isLoggedIn, persona) {
+            if (isLoggedIn && persona == null) {
+                SteamService.requestUserPersona()
+            }
+        }
 
         val activity = LocalContext.current as? UnifiedActivity
-        val listState = rememberLazyListState(initialFirstVisibleItemIndex = 0)
 
         LaunchedEffect(tabs) {
             activity?.keyEventFlow?.collect { event ->
@@ -1365,8 +1343,10 @@ class UnifiedActivity :
                                 gogApps = gogApps,
                                 layoutMode = libraryLayoutMode,
                                 libraryRefreshKey = libraryRefreshKey,
+                                playtimeRefreshKey = playtimeRefreshKey,
                                 iconRefreshKey = iconRefreshKey,
                                 searchQuery = searchQuery,
+                                isControllerConnected = isControllerConnected,
                             )
                         }
 
@@ -1460,7 +1440,7 @@ class UnifiedActivity :
         if (showAddCustomGame) {
             AddCustomGameDialog(onDismiss = {
                 showAddCustomGame = false
-                libraryRefreshKey++
+                localLibraryRefreshKey++
             })
         }
 
@@ -1519,9 +1499,7 @@ class UnifiedActivity :
                             // Exit button
                             Button(
                                 onClick = {
-                                    // Kill all WinNative processes and close fully
-                                    finishAffinity()
-                                    Process.killProcess(Process.myPid())
+                                    AppTerminationHelper.exitApplication(this@UnifiedActivity, "hub_exit_menu")
                                 },
                                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935)),
                                 shape = RoundedCornerShape(12.dp),
@@ -1921,8 +1899,10 @@ class UnifiedActivity :
         gogApps: List<GOGGame>,
         layoutMode: LibraryLayoutMode,
         libraryRefreshKey: Int = 0,
+        playtimeRefreshKey: Int = 0,
         iconRefreshKey: Int = 0,
         searchQuery: String = "",
+        isControllerConnected: Boolean = false,
     ) {
         val context = LocalContext.current
 
@@ -1967,21 +1947,20 @@ class UnifiedActivity :
             }
         }
 
-        // Move expensive filtering (runBlocking DB queries, file I/O) off the main thread
+        // Move expensive filtering (runBlocking DB queries, file I/O) off the main thread.
+        // This set only changes on real library mutations; playtime resorts are handled separately.
+        var mergedInstalledApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var installedApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var gogByPseudoId by remember { mutableStateOf<Map<Int, GOGGame>>(emptyMap()) }
         var libraryLoaded by remember { mutableStateOf(false) }
         // Track whether the LaunchedEffect is still reprocessing after input changes
         // so we don't flash the empty state while filtering is in progress.
-        var inputVersion by remember { mutableIntStateOf(0) }
-        var processedVersion by remember { mutableIntStateOf(0) }
+        var scanVersion by remember { mutableIntStateOf(0) }
+        var processedScanVersion by remember { mutableIntStateOf(0) }
 
         LaunchedEffect(steamApps, epicApps, gogApps, customApps, libraryRefreshKey) {
-            inputVersion++
-            // On first run, wait for DB to emit before declaring loaded
-            if (!libraryLoaded) {
-                db.steamAppDao().getAllOwnedApps().first()
-            }
+            scanVersion++
+            val requestedVersion = scanVersion
             withContext(Dispatchers.IO) {
                 val steamInstalled = steamApps.filter { SteamService.isAppInstalled(it.id) }
 
@@ -2025,11 +2004,36 @@ class UnifiedActivity :
 
                 withContext(Dispatchers.Main) {
                     gogByPseudoId = gogMap
+                    mergedInstalledApps = merged
                     installedApps = sorted
                     libraryLoaded = true
-                    processedVersion = inputVersion
+                    processedScanVersion = requestedVersion
                 }
             }
+        }
+
+        LaunchedEffect(mergedInstalledApps, playtimeRefreshKey) {
+            if (mergedInstalledApps.isEmpty()) {
+                installedApps = emptyList()
+                return@LaunchedEffect
+            }
+
+            val sorted =
+                withContext(Dispatchers.IO) {
+                    val playtimePrefs = context.getSharedPreferences("playtime_stats", android.content.Context.MODE_PRIVATE)
+                    val allPlaytime = playtimePrefs.all
+                    mergedInstalledApps.sortedByDescending { app ->
+                        val searchKey =
+                            if (app.id >= 2000000000 || app.id < 0) {
+                                app.name
+                            } else {
+                                app.name.replace(LIBRARY_NAME_SANITIZE_REGEX, "")
+                            }
+                        (allPlaytime["${searchKey}_last_played"] as? Long) ?: 0L
+                    }
+                }
+
+            installedApps = sorted
         }
 
         val displayedApps =
@@ -2059,7 +2063,7 @@ class UnifiedActivity :
                     (epicApps.isEmpty() && EpicService.hasStoredCredentials(context)) ||
                     (gogApps.isEmpty() && GOGAuthManager.isLoggedIn(context))
             )
-        val showLoading = !libraryLoaded || !minTimeElapsed || processedVersion < inputVersion || awaitingStoreSync
+        val showLoading = !libraryLoaded || !minTimeElapsed || processedScanVersion < scanVersion || awaitingStoreSync
         if (showLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 val spinAlpha by animateFloatAsState(
@@ -2201,7 +2205,7 @@ class UnifiedActivity :
                         gogGame = gogByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = index == focusIndex,
-                        isControllerActive = ControllerHelper.isControllerConnected(),
+                        isControllerActive = isControllerConnected,
                         shortcuts = cachedShortcuts,
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -2241,7 +2245,7 @@ class UnifiedActivity :
                         gogGame = gogByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
-                        isControllerActive = ControllerHelper.isControllerConnected(),
+                        isControllerActive = isControllerConnected,
                         shortcuts = cachedShortcuts,
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -2289,7 +2293,7 @@ class UnifiedActivity :
                         gogGame = gogByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
-                        isControllerActive = ControllerHelper.isControllerConnected(),
+                        isControllerActive = isControllerConnected,
                         shortcuts = cachedShortcuts,
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -6493,19 +6497,48 @@ class UnifiedActivity :
         onSelectDownload: (String?) -> Unit,
     ) {
         val downloads = remember { mutableStateListOf<Pair<String, DownloadInfo>>() }
-        // Tick counter forces recomposition so button labels/states refresh with status changes
         var tick by remember { mutableIntStateOf(0) }
+        val scope = rememberCoroutineScope()
 
-        LaunchedEffect(Unit) {
-            while (true) {
-                val currentDownloads = DownloadService.getAllDownloads()
-                downloads.clear()
-                downloads.addAll(currentDownloads)
-                if (selectedId != null && currentDownloads.none { it.first == selectedId }) {
-                    onSelectDownload(null)
+        val syncDownloads =
+            remember(selectedId, onSelectDownload) {
+                {
+                    val currentDownloads = DownloadService.getAllDownloads()
+                    downloads.clear()
+                    downloads.addAll(currentDownloads)
+                    if (selectedId != null && currentDownloads.none { it.first == selectedId }) {
+                        onSelectDownload(null)
+                    }
                 }
-                tick++
-                kotlinx.coroutines.delay(1000)
+            }
+        val latestSyncDownloads by rememberUpdatedState(syncDownloads)
+
+        val downloadStatusListener =
+            remember {
+                object : EventDispatcher.JavaEventListener {
+                    override fun onEvent(event: Any) {
+                        if (event is AndroidEvent.DownloadStatusChanged) {
+                            scope.launch {
+                                latestSyncDownloads()
+                            }
+                        }
+                    }
+                }
+            }
+
+        DisposableEffect(downloadStatusListener, syncDownloads) {
+            syncDownloads()
+            PluviaApp.events.onJava(AndroidEvent.DownloadStatusChanged::class, downloadStatusListener)
+            onDispose {
+                PluviaApp.events.offJava(AndroidEvent.DownloadStatusChanged::class, downloadStatusListener)
+            }
+        }
+
+        downloads.forEach { (_, info) ->
+            LaunchedEffect(info) {
+                info.getStatusFlow().collect {
+                    tick++
+                }
             }
         }
 
@@ -6518,7 +6551,7 @@ class UnifiedActivity :
             val isController = ControllerHelper.isControllerConnected()
             val isPS = ControllerHelper.isPlayStationController()
 
-            // Read tick to ensure recomposition picks up latest status values
+            // Read tick to ensure global button state reacts to per-download status changes.
             @Suppress("UNUSED_EXPRESSION")
             tick
 
@@ -6752,7 +6785,7 @@ class UnifiedActivity :
             }
 
             LazyColumn(state = listState, modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(downloads) { (id, info) ->
+                items(downloads, key = { it.first }) { (id, info) ->
                     DownloadItemDeck(id, info, isSelected = selectedId == id, onClick = {
                         if (selectedId == id) onSelectDownload(null) else onSelectDownload(id)
                     })
@@ -9743,6 +9776,40 @@ class UnifiedActivity :
                 }
             }
         }
+    }
+
+    @Composable
+    private fun rememberControllerConnectionState(): ControllerConnectionState {
+        val context = LocalContext.current
+        val inputManager = remember(context) { context.getSystemService(InputManager::class.java) }
+        var controllerState by remember { mutableStateOf(ControllerConnectionState()) }
+
+        DisposableEffect(inputManager) {
+            fun refreshState() {
+                controllerState =
+                    ControllerConnectionState(
+                        isConnected = ControllerHelper.isControllerConnected(),
+                        isPlayStation = ControllerHelper.isPlayStationController(),
+                    )
+            }
+
+            val listener =
+                object : InputManager.InputDeviceListener {
+                    override fun onInputDeviceAdded(deviceId: Int) = refreshState()
+
+                    override fun onInputDeviceRemoved(deviceId: Int) = refreshState()
+
+                    override fun onInputDeviceChanged(deviceId: Int) = refreshState()
+                }
+
+            refreshState()
+            inputManager?.registerInputDeviceListener(listener, null)
+            onDispose {
+                inputManager?.unregisterInputDeviceListener(listener)
+            }
+        }
+
+        return controllerState
     }
 }
 

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -202,6 +202,7 @@ import com.winlator.cmod.shared.ui.outlinedSwitchColors
 import com.winlator.cmod.shared.ui.widget.chasingBorder
 import com.winlator.cmod.shared.theme.WinNativeTheme
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.Lazy
 import `in`.dragonbra.javasteam.enums.EPersonaState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -253,7 +254,10 @@ enum class LibraryLayoutMode {
 class UnifiedActivity :
     FixedFontScaleAppCompatActivity(),
     ActivityResultHost {
-    @Inject lateinit var db: PluviaDatabase
+    @Inject lateinit var dbProvider: Lazy<PluviaDatabase>
+
+    private val db: PluviaDatabase
+        get() = dbProvider.get()
 
     private data class PendingNavigation(
         val item: SettingsNavItem = SettingsNavItem.CONTAINERS,
@@ -336,7 +340,8 @@ class UnifiedActivity :
 
         /** Currently attached Activity (or null if the app is fully backgrounded/killed). */
         @JvmStatic
-        fun currentActivity(): UnifiedActivity? = instance
+        fun currentActivity(): UnifiedActivity? =
+            instance?.takeUnless { it.isFinishing || it.isDestroyed }
     }
 
     private val wallpaperImagePickerLauncher =
@@ -550,6 +555,14 @@ class UnifiedActivity :
         UpdateChecker.startBackgroundLoop(this)
     }
 
+    override fun onDestroy() {
+        supportFragmentManager.unregisterFragmentLifecycleCallbacks(inputControlsFragmentTracker)
+        if (instance === this) {
+            instance = null
+        }
+        super.onDestroy()
+    }
+
     override fun dispatchGenericMotionEvent(event: android.view.MotionEvent): Boolean {
         // Forward to InputControlsFragment if it's active (for gamepad binding capture)
         cachedInputControlsFragment?.let { fragment ->
@@ -717,19 +730,6 @@ class UnifiedActivity :
         EpicAuthManager.updateLoginStatus(this)
         SteamService.initLoginStatus(this)
 
-        // Start EpicService if user is logged in
-        if (EpicService.hasStoredCredentials(this)) {
-            EpicService.start(this)
-            // Proactively refresh the access token on app start; runs outside the 15-minute
-            // sync throttle so we extend the ~8h Epic refresh window every time the user
-            // opens the app.
-            lifecycleScope.launch {
-                EpicAuthManager.getStoredCredentials(this@UnifiedActivity)
-            }
-            // Make sure the background refresh worker is scheduled (idempotent).
-            com.winlator.cmod.feature.stores.epic.service.EpicTokenRefreshWorker.schedule(this)
-        }
-
         // Surface store-session events (e.g. Epic refresh-token death, cloud restore) as toasts.
         lifecycleScope.launch {
             com.winlator.cmod.feature.stores.common.StoreSessionBus.events.collect { event ->
@@ -754,17 +754,6 @@ class UnifiedActivity :
                 }
             }
         }
-
-        // Start SteamService if user is logged in
-        if (SteamService.hasStoredCredentials(this)) {
-            SteamService.start(this)
-        }
-
-        if (GOGAuthManager.isLoggedIn(this)) {
-            GOGService.start(this)
-        }
-
-        SteamService.maybeRepairInstalledMetadataOnStartup(this)
 
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.dark(0xFF141B24.toInt()),
@@ -950,6 +939,33 @@ class UnifiedActivity :
                 }
             }
         }
+        scheduleDeferredStoreBootstrap()
+    }
+
+    private fun scheduleDeferredStoreBootstrap() {
+        window.decorView.post {
+            if (isFinishing || isDestroyed) return@post
+            lifecycleScope.launch(Dispatchers.IO) {
+                if (EpicService.hasStoredCredentials(this@UnifiedActivity)) {
+                    EpicService.start(this@UnifiedActivity)
+                    // Refresh outside the first-frame path so the UI can render before
+                    // token validation/network work begins.
+                    EpicAuthManager.getStoredCredentials(this@UnifiedActivity)
+                    com.winlator.cmod.feature.stores.epic.service.EpicTokenRefreshWorker
+                        .schedule(this@UnifiedActivity)
+                }
+
+                if (SteamService.hasStoredCredentials(this@UnifiedActivity)) {
+                    SteamService.start(this@UnifiedActivity)
+                }
+
+                if (GOGAuthManager.isLoggedIn(this@UnifiedActivity)) {
+                    GOGService.start(this@UnifiedActivity)
+                }
+
+                SteamService.maybeRepairInstalledMetadataOnStartup(this@UnifiedActivity)
+            }
+        }
     }
 
     // Tab definitions
@@ -968,6 +984,37 @@ class UnifiedActivity :
         if (storeVisible["epic"] != false) base.add(TabDef("Epic", "epic"))
         if (storeVisible["gog"] != false) base.add(TabDef("GOG", "gog"))
         return base
+    }
+
+    @Composable
+    private fun rememberSteamInstallStateMap(apps: List<SteamApp>): Map<Int, Boolean> {
+        var installStateMap by remember { mutableStateOf<Map<Int, Boolean>>(emptyMap()) }
+
+        LaunchedEffect(apps) {
+            installStateMap =
+                withContext(Dispatchers.IO) {
+                    apps.associate { it.id to SteamService.isAppInstalled(it.id) }
+                }
+        }
+
+        return installStateMap
+    }
+
+    @Composable
+    private fun <K> rememberInstallPathStateMap(entries: List<Pair<K, String?>>): Map<K, Boolean>
+        where K : Any {
+        var installStateMap by remember { mutableStateOf<Map<K, Boolean>>(emptyMap()) }
+
+        LaunchedEffect(entries) {
+            installStateMap =
+                withContext(Dispatchers.IO) {
+                    entries.associate { (key, path) ->
+                        key to (path?.isNotBlank() == true && java.io.File(path).exists())
+                    }
+                }
+        }
+
+        return installStateMap
     }
 
     // Main scaffold
@@ -1368,13 +1415,13 @@ class UnifiedActivity :
                                     }
 
                                     "epic" -> {
-                                        EpicStoreTab(isEpicLoggedIn, searchQuery, libraryLayoutMode) {
+                                        EpicStoreTab(isEpicLoggedIn, epicApps, searchQuery, libraryLayoutMode) {
                                             epicLoginLauncher.launch(Intent(this@UnifiedActivity, EpicOAuthActivity::class.java))
                                         }
                                     }
 
                                     "gog" -> {
-                                        GOGStoreTab(isGogLoggedIn, searchQuery, libraryLayoutMode) {
+                                        GOGStoreTab(isGogLoggedIn, gogApps, searchQuery, libraryLayoutMode) {
                                             gogLoginLauncher.launch(Intent(this@UnifiedActivity, GOGOAuthActivity::class.java))
                                         }
                                     }
@@ -1952,6 +1999,9 @@ class UnifiedActivity :
         var mergedInstalledApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var installedApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var gogByPseudoId by remember { mutableStateOf<Map<Int, GOGGame>>(emptyMap()) }
+        var epicByPseudoId by remember { mutableStateOf<Map<Int, EpicGame>>(emptyMap()) }
+        var customArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var customIconPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
         var libraryLoaded by remember { mutableStateOf(false) }
         // Track whether the LaunchedEffect is still reprocessing after input changes
         // so we don't flash the empty state while filtering is in progress.
@@ -1969,6 +2019,7 @@ class UnifiedActivity :
                 val gogInstalled = gogApps.filter { it.isInstalled && java.io.File(it.installPath).exists() }
 
                 val gogMap = gogInstalled.associateBy { gogPseudoId(it.id) }
+                val epicMap = epicInstalled.associateBy { 2000000000 + it.id }
 
                 val playtimePrefs = context.getSharedPreferences("playtime_stats", android.content.Context.MODE_PRIVATE)
                 val allPlaytime = playtimePrefs.all
@@ -2004,12 +2055,63 @@ class UnifiedActivity :
 
                 withContext(Dispatchers.Main) {
                     gogByPseudoId = gogMap
+                    epicByPseudoId = epicMap
                     mergedInstalledApps = merged
                     installedApps = sorted
                     libraryLoaded = true
                     processedScanVersion = requestedVersion
                 }
             }
+        }
+
+        LaunchedEffect(installedApps, gogByPseudoId, cachedShortcuts, iconRefreshKey) {
+            val appsSnapshot = installedApps
+            val gogSnapshot = gogByPseudoId
+            val shortcutsSnapshot = cachedShortcuts
+
+            val artworkPaths =
+                withContext(Dispatchers.IO) {
+                    buildMap<Int, String> {
+                        appsSnapshot.forEach { app ->
+                            val gogGame = gogSnapshot[app.id]
+                            val isCustom = app.id < 0
+                            val isEpic = app.id >= 2000000000
+                            val epicId = if (isEpic) app.id - 2000000000 else 0
+                            val shortcut =
+                                if (gogGame != null) {
+                                    shortcutsSnapshot.find {
+                                        it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame.id
+                                    }
+                                } else {
+                                    findShortcutForGame(shortcutsSnapshot, app, isCustom, isEpic, epicId)
+                                }
+                            val customPath =
+                                shortcut
+                                    ?.getExtra("customLibraryIconPath")
+                                    ?.ifBlank { shortcut.getExtra("customCoverArtPath") }
+                            if (!customPath.isNullOrBlank() && java.io.File(customPath).exists()) {
+                                put(app.id, customPath)
+                            }
+                        }
+                    }
+                }
+
+            val customIconPaths =
+                withContext(Dispatchers.IO) {
+                    buildMap<Int, String> {
+                        appsSnapshot.forEach { app ->
+                            if (app.id >= 0) return@forEach
+                            val safeName = app.name.replace("/", "_").replace("\\", "_")
+                            val iconFile = java.io.File(context.filesDir, "custom_icons/$safeName.png")
+                            if (iconFile.exists()) {
+                                put(app.id, iconFile.absolutePath)
+                            }
+                        }
+                    }
+                }
+
+            customArtworkPathByAppId = artworkPaths
+            customIconPathByAppId = customIconPaths
         }
 
         LaunchedEffect(mergedInstalledApps, playtimeRefreshKey) {
@@ -2199,14 +2301,17 @@ class UnifiedActivity :
                     gridState = gridState,
                     contentPadding = TabGridContentPadding,
                     clipContent = false,
+                    keyOf = { it.id },
                 ) { app, index, rowHeight ->
                     GameCapsule(
                         app = app,
                         gogGame = gogByPseudoId[app.id],
+                        epicGame = epicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = index == focusIndex,
                         isControllerActive = isControllerConnected,
-                        shortcuts = cachedShortcuts,
+                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
                             detailApp = app
@@ -2243,10 +2348,12 @@ class UnifiedActivity :
                     GameCapsule(
                         app = app,
                         gogGame = gogByPseudoId[app.id],
+                        epicGame = epicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        shortcuts = cachedShortcuts,
+                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
                             detailApp = app
@@ -2287,14 +2394,17 @@ class UnifiedActivity :
                     onSelectedIndexChanged = { newIdx ->
                         activity?.libraryFocusIndex?.value = newIdx
                     },
+                    keyOf = { it.id },
                 ) { app, index, isSelected ->
                     GameCapsule(
                         app = app,
                         gogGame = gogByPseudoId[app.id],
+                        epicGame = epicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        shortcuts = cachedShortcuts,
+                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
                             detailApp = app
@@ -4884,10 +4994,12 @@ class UnifiedActivity :
     private fun GameCapsule(
         app: SteamApp,
         gogGame: GOGGame? = null,
+        epicGame: EpicGame? = null,
         iconRefreshKey: Int = 0,
         isFocusedOverride: Boolean = false,
         isControllerActive: Boolean = false,
-        shortcuts: List<Shortcut> = emptyList(),
+        customArtworkPath: String? = null,
+        customIconPath: String? = null,
         onClick: (() -> Unit)? = null,
         onLongClick: (() -> Unit)? = null,
         useLibraryCapsule: Boolean = false,
@@ -4897,27 +5009,6 @@ class UnifiedActivity :
         val context = LocalContext.current
         val isCustom = app.id < 0
         val isEpic = app.id >= 2000000000
-        val epicId = if (isEpic) app.id - 2000000000 else 0
-        val epicGame by produceState<EpicGame?>(initialValue = null, key1 = epicId) {
-            value = if (isEpic) db.epicGameDao().getById(epicId) else null
-        }
-        // Use pre-cached shortcuts list instead of loading from disk per-item
-        val customLibraryIconPath =
-            remember(app.id, gogGame?.id, iconRefreshKey, shortcuts) {
-                val shortcut =
-                    if (gogGame != null) {
-                        shortcuts.find {
-                            it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame.id
-                        }
-                    } else {
-                        findShortcutForGame(shortcuts, app, isCustom, isEpic, epicId)
-                    }
-                val customPath =
-                    shortcut
-                        ?.getExtra("customLibraryIconPath")
-                        ?.ifBlank { shortcut.getExtra("customCoverArtPath") }
-                customPath?.takeIf { it.isNotBlank() && java.io.File(it).exists() }
-            }
         val defaultClick: () -> Unit = {
             val containerManager =
                 com.winlator.cmod.runtime.container
@@ -4965,9 +5056,8 @@ class UnifiedActivity :
         @Composable
         fun ArtContent(artModifier: Modifier) {
             val customArtworkFile =
-                customLibraryIconPath
+                customArtworkPath
                     ?.let { java.io.File(it) }
-                    ?.takeIf { it.exists() }
 
             if (customArtworkFile != null) {
                 val customArtworkCacheKey =
@@ -4986,9 +5076,8 @@ class UnifiedActivity :
                     contentScale = ContentScale.Crop,
                 )
             } else if (isCustom) {
-                val safeName = app.name.replace("/", "_").replace("\\", "_")
-                val iconFile = java.io.File(context.filesDir, "custom_icons/$safeName.png")
-                if (iconFile.exists()) {
+                val iconFile = customIconPath?.let { path -> java.io.File(path) }
+                if (iconFile != null) {
                     AsyncImage(
                         model =
                             ImageRequest
@@ -5176,6 +5265,7 @@ class UnifiedActivity :
     @Composable
     fun EpicStoreTab(
         isLoggedIn: Boolean,
+        epicApps: List<EpicGame>,
         searchQuery: String = "",
         layoutMode: LibraryLayoutMode = LibraryLayoutMode.GRID_4,
         onLoginClick: () -> Unit,
@@ -5187,7 +5277,6 @@ class UnifiedActivity :
             return
         }
 
-        val epicApps by db.epicGameDao().getAll().collectAsState(initial = emptyList())
         val selectedAppId = remember { mutableStateOf<Int?>(null) }
         val gridState = rememberLazyGridState()
         val activity = LocalContext.current as? UnifiedActivity
@@ -5207,6 +5296,7 @@ class UnifiedActivity :
                     epicApps.filter { it.title.contains(searchQuery, ignoreCase = true) }
                 }
             }
+        val installStateById = rememberInstallPathStateMap(displayedApps.map { it.id to it.installPath })
 
         // Sync store focus infrastructure
         LaunchedEffect(displayedApps.size) {
@@ -5235,8 +5325,14 @@ class UnifiedActivity :
                 modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
                 contentPadding = TabListContentPadding,
+                keyOf = { it.id },
             ) { app, _, _ ->
-                EpicStoreCapsule(app, listMode = true, isControllerActive = ControllerHelper.isControllerConnected()) {
+                EpicStoreCapsule(
+                    app,
+                    isInstalled = installStateById[app.id] == true,
+                    listMode = true,
+                    isControllerActive = ControllerHelper.isControllerConnected(),
+                ) {
                     selectedAppId.value =
                         app.id
                 }
@@ -5261,6 +5357,7 @@ class UnifiedActivity :
                 items = displayedApps,
                 modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
+                keyOf = { it.id },
             ) { app, index, rowHeight ->
                 Box(
                     Modifier.height(rowHeight).then(
@@ -5273,6 +5370,7 @@ class UnifiedActivity :
                 ) {
                     EpicStoreCapsule(
                         app,
+                        isInstalled = installStateById[app.id] == true,
                         isFocusedOverride = index == focusIndex,
                         isControllerActive = ControllerHelper.isControllerConnected(),
                     ) {
@@ -5295,6 +5393,7 @@ class UnifiedActivity :
     @Composable
     fun EpicStoreCapsule(
         app: com.winlator.cmod.feature.stores.epic.data.EpicGame,
+        isInstalled: Boolean,
         listMode: Boolean = false,
         isFocusedOverride: Boolean = false,
         isControllerActive: Boolean = false,
@@ -5310,7 +5409,6 @@ class UnifiedActivity :
             label = "epicCapsuleGlow",
         )
         val effectiveFocus = isControllerActive && (isFocusedOverride || isFocused)
-        val isInstalled = app.installPath != null && java.io.File(app.installPath!!).exists()
         val imageUrl = app.primaryImageUrl ?: app.iconUrl
 
         val borderColor = if (isControllerActive) CardBorder else Color.Transparent
@@ -5850,6 +5948,7 @@ class UnifiedActivity :
     @Composable
     fun GOGStoreTab(
         isLoggedIn: Boolean,
+        gogApps: List<GOGGame>,
         searchQuery: String = "",
         layoutMode: LibraryLayoutMode = LibraryLayoutMode.GRID_4,
         onLoginClick: () -> Unit,
@@ -5859,7 +5958,6 @@ class UnifiedActivity :
             return
         }
 
-        val gogApps by db.gogGameDao().getAll().collectAsState(initial = emptyList())
         val selectedGameId = remember { mutableStateOf<String?>(null) }
         val gridState = rememberLazyGridState()
         val activity = LocalContext.current as? UnifiedActivity
@@ -5872,6 +5970,7 @@ class UnifiedActivity :
                     gogApps.filter { it.title.contains(searchQuery, ignoreCase = true) }
                 }
             }
+        val installStateById = rememberInstallPathStateMap(displayedApps.map { it.id to it.installPath })
 
         // Sync store focus infrastructure
         LaunchedEffect(displayedApps.size) {
@@ -5902,8 +6001,9 @@ class UnifiedActivity :
                 modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
                 contentPadding = TabListContentPadding,
+                keyOf = { it.id },
             ) { app, _, _ ->
-                val isInstalled = app.isInstalled && java.io.File(app.installPath).exists()
+                val isInstalled = installStateById[app.id] == true
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier =
@@ -5973,8 +6073,9 @@ class UnifiedActivity :
                 items = displayedApps,
                 modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
+                keyOf = { it.id },
             ) { app, index, rowHeight ->
-                val isInstalled = app.isInstalled && java.io.File(app.installPath).exists()
+                val isInstalled = installStateById[app.id] == true
                 val isItemFocused = isControllerActive && index == focusIndex
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -6222,6 +6323,7 @@ class UnifiedActivity :
                     steamApps.filter { it.name.contains(searchQuery, ignoreCase = true) }
                 }
             }
+        val installStateById = rememberSteamInstallStateMap(displayedApps)
 
         // Sync store focus infrastructure
         LaunchedEffect(displayedApps.size) {
@@ -6251,11 +6353,18 @@ class UnifiedActivity :
                 modifier = Modifier.tabScreenPadding(),
                 listState = listViewState,
                 contentPadding = TabListContentPadding,
+                keyOf = { it.id },
             ) { app, _, _ ->
-                SteamStoreCapsule(app, listMode = true, isControllerActive = ControllerHelper.isControllerConnected(), onClick = {
-                    selectedAppForDialog =
-                        app
-                })
+                SteamStoreCapsule(
+                    app,
+                    isInstalled = installStateById[app.id] == true,
+                    listMode = true,
+                    isControllerActive = ControllerHelper.isControllerConnected(),
+                    onClick = {
+                        selectedAppForDialog =
+                            app
+                    },
+                )
             }
         } else {
             val focusIndex by (activity?.storeFocusIndex ?: kotlinx.coroutines.flow.MutableStateFlow(0)).collectAsState()
@@ -6280,6 +6389,7 @@ class UnifiedActivity :
                 items = displayedApps,
                 modifier = Modifier.tabScreenPadding(top = TabGridTopPadding),
                 gridState = gridState,
+                keyOf = { it.id },
             ) { app, index, rowHeight ->
                 Box(
                     Modifier.height(rowHeight).then(
@@ -6292,6 +6402,7 @@ class UnifiedActivity :
                 ) {
                     SteamStoreCapsule(
                         app,
+                        isInstalled = installStateById[app.id] == true,
                         isFocusedOverride = index == focusIndex,
                         isControllerActive =
                             ControllerHelper
@@ -6316,12 +6427,12 @@ class UnifiedActivity :
     @Composable
     fun SteamStoreCapsule(
         app: SteamApp,
+        isInstalled: Boolean,
         listMode: Boolean = false,
         isFocusedOverride: Boolean = false,
         isControllerActive: Boolean = false,
         onClick: () -> Unit,
     ) {
-        val isInstalled = SteamService.isAppInstalled(app.id)
         val context = LocalContext.current
         var isFocused by remember { mutableStateOf(false) }
         val clickInteraction = remember { MutableInteractionSource() }

--- a/app/src/main/app/update/UpdateChecker.kt
+++ b/app/src/main/app/update/UpdateChecker.kt
@@ -13,6 +13,8 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.preference.PreferenceManager
+import com.winlator.cmod.app.PluviaApp
+import com.winlator.cmod.runtime.display.XServerDisplayActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -72,7 +74,7 @@ object UpdateChecker {
      */
     fun isEnabled(context: Context): Boolean {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-        return prefs.getBoolean(PREF_CHECK_FOR_UPDATES, true)
+        return prefs.getBoolean(PREF_CHECK_FOR_UPDATES, false)
     }
 
     /**
@@ -108,13 +110,14 @@ object UpdateChecker {
     fun startBackgroundLoop(context: Context) {
         stopBackgroundLoop()
         if (!isEnabled(context)) return
+        if (!isAutoCheckAllowed()) return
 
         val appContext = context.applicationContext
         backgroundHandler = Handler(Looper.getMainLooper())
         backgroundRunnable =
             object : Runnable {
                 override fun run() {
-                    if (isEnabled(appContext)) {
+                    if (isEnabled(appContext) && isAutoCheckAllowed()) {
                         checkForUpdate(appContext, force = false)
                         backgroundHandler?.postDelayed(this, CHECK_INTERVAL_MS)
                     }
@@ -143,6 +146,7 @@ object UpdateChecker {
         force: Boolean = false,
     ) {
         if (!isEnabled(context)) return
+        if (!isAutoCheckAllowed()) return
         if (!force && !isDueForCheck(context)) return
         launchCheck(context)
     }
@@ -177,11 +181,15 @@ object UpdateChecker {
      */
     fun schedulePostGameCheck(context: Context) {
         cancelPostGameCheck()
+        if (!isEnabled(context)) return
+        if (!isAutoCheckAllowed()) return
         val appContext = context.applicationContext
         postGameHandler = Handler(Looper.getMainLooper())
         postGameRunnable =
             Runnable {
-                checkForUpdate(appContext, force = true)
+                if (isAutoCheckAllowed()) {
+                    checkForUpdate(appContext, force = true)
+                }
             }
         postGameHandler?.postDelayed(postGameRunnable!!, POST_GAME_CHECK_DELAY_MS)
     }
@@ -208,11 +216,17 @@ object UpdateChecker {
 
     // ── Internal ──────────────────────────────────────────────────────
 
+    private fun isAutoCheckAllowed(): Boolean {
+        val activity = PluviaApp.currentForegroundActivity ?: return false
+        return activity !is XServerDisplayActivity
+    }
+
     private fun launchCheck(context: Context) {
         if (!isChecking.compareAndSet(false, true)) return
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
+                refreshInstallTimestamp(context)
                 val result = fetchUpdateInfo(context)
                 if (result != null) {
                     withContext(Dispatchers.Main) {

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -109,6 +109,7 @@ class OtherSettingsFragment : Fragment() {
                                 UpdateChecker.startBackgroundLoop(ctx)
                             } else {
                                 UpdateChecker.stopBackgroundLoop()
+                                UpdateChecker.cancelPostGameCheck()
                             }
                             refresh()
                         },
@@ -249,7 +250,7 @@ class OtherSettingsFragment : Fragment() {
 
         uiState =
             OtherSettingsState(
-                checkForUpdates = preferences.getBoolean("check_for_updates", true),
+                checkForUpdates = preferences.getBoolean("check_for_updates", false),
                 languageLabels = languageLabels,
                 languageIndex = languageIndex,
                 refreshRateLabels = refreshRateLabels,

--- a/app/src/main/feature/stores/epic/service/EpicService.kt
+++ b/app/src/main/feature/stores/epic/service/EpicService.kt
@@ -20,6 +20,7 @@ import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.feature.stores.steam.utils.ContainerUtils
 import com.winlator.cmod.feature.stores.steam.utils.MarkerUtils
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
+import com.winlator.cmod.shared.android.AppTerminationHelper
 import com.winlator.cmod.shared.android.NotificationHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -841,6 +842,12 @@ class EpicService : Service() {
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel()
         instance = null
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        Timber.tag("EPIC").i("Task removed; stopping managed app services")
+        AppTerminationHelper.stopManagedServices(applicationContext, "epic_task_removed")
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/feature/stores/gog/service/GOGService.kt
+++ b/app/src/main/feature/stores/gog/service/GOGService.kt
@@ -16,6 +16,7 @@ import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.feature.stores.steam.utils.ContainerUtils
 import com.winlator.cmod.feature.stores.steam.utils.MarkerUtils
 import com.winlator.cmod.runtime.container.Container
+import com.winlator.cmod.shared.android.AppTerminationHelper
 import com.winlator.cmod.shared.android.NotificationHelper
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -909,6 +910,12 @@ class GOGService : Service() {
         stopForeground(STOP_FOREGROUND_REMOVE)
         notificationHelper.cancel()
         instance = null
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        Timber.i("[GOGService] Task removed; stopping managed app services")
+        AppTerminationHelper.stopManagedServices(applicationContext, "gog_task_removed")
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/feature/stores/steam/events/EventDispatcher.kt
+++ b/app/src/main/feature/stores/steam/events/EventDispatcher.kt
@@ -73,6 +73,15 @@ class EventDispatcher {
         listeners.getOrPut(eventClass) { mutableListOf() }.add(typedListener)
     }
 
+    fun offJava(
+        eventClass: KClass<out Event<*>>,
+        listener: JavaEventListener,
+    ) {
+        listeners[eventClass]?.removeIf {
+            it.first == listener.toString()
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     inline fun <reified E : Event<T>, reified T> emit(
         event: E,

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -68,6 +68,7 @@ import com.winlator.cmod.runtime.container.Container
 import com.winlator.cmod.runtime.container.ContainerManager
 import com.winlator.cmod.runtime.display.environment.ImageFs
 import com.winlator.cmod.runtime.system.GPUInformation
+import com.winlator.cmod.shared.android.AppTerminationHelper
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.android.NotificationHelper
 import com.winlator.cmod.shared.io.StorageUtils
@@ -319,6 +320,8 @@ class SteamService :
         private const val DOWNLOAD_INFO_FILE = "depot_bytes.json"
         private const val LEGACY_DOWNLOAD_INFO_FILE = "bytes_downloaded.txt"
         private const val COMPONENTS_BASE_URL = "https://github.com/maxjivi05/Components/releases/download/Components"
+        @Volatile
+        private var startupMetadataRepairJob: Job? = null
 
         /**
          * Default timeout to use when making requests
@@ -1023,6 +1026,71 @@ class SteamService :
                     }
                 }
                 repairedCount
+            }
+        }
+
+        private fun countCompletedInstallMarkers(maxCount: Int = Int.MAX_VALUE): Int {
+            var count = 0
+            for (basePath in allInstallPaths) {
+                val baseDir = File(basePath)
+                val appDirs = baseDir.listFiles() ?: continue
+                for (appDir in appDirs) {
+                    if (!appDir.isDirectory) continue
+                    val hasCompleteMarker = File(appDir, Marker.DOWNLOAD_COMPLETE_MARKER.fileName).exists()
+                    if (!hasCompleteMarker) continue
+
+                    val hasInProgressMarker = File(appDir, Marker.DOWNLOAD_IN_PROGRESS_MARKER.fileName).exists()
+                    if (hasInProgressMarker) continue
+
+                    count++
+                    if (count >= maxCount) return count
+                }
+            }
+            return count
+        }
+
+        private fun shouldRepairInstalledMetadata(): Boolean {
+            val db =
+                runCatching { PluviaDatabase.getInstance() }.getOrElse {
+                    Timber.e(it, "Failed to access database for startup metadata repair gate")
+                    return false
+                }
+
+            val knownAppCount =
+                runBlocking(Dispatchers.IO) {
+                    runCatching { db.steamAppDao().getAllAppIds().size }.getOrElse {
+                        Timber.e(it, "Failed to load Steam app ids for startup metadata repair gate")
+                        return@runBlocking 0
+                    }
+                }
+            if (knownAppCount == 0) return false
+
+            val installedDbCount =
+                runBlocking(Dispatchers.IO) {
+                    runCatching { db.appInfoDao().getAllInstalledAppIds().size }.getOrElse {
+                        Timber.e(it, "Failed to load installed Steam app ids for startup metadata repair gate")
+                        return@runBlocking 0
+                    }
+                }
+
+            val diskInstallCount = countCompletedInstallMarkers(maxCount = installedDbCount + 1)
+            return diskInstallCount > installedDbCount
+        }
+
+        fun maybeRepairInstalledMetadataOnStartup(context: Context) {
+            val appContext = context.applicationContext
+            if (!hasStoredCredentials(appContext)) return
+
+            if (startupMetadataRepairJob?.isActive == true) return
+
+            startupMetadataRepairJob =
+                CoroutineScope(Dispatchers.IO).launch {
+                    if (!shouldRepairInstalledMetadata()) return@launch
+                delay(1500L)
+                val repairedCount = repairInstalledMetadataFromDisk()
+                if (repairedCount > 0) {
+                    Timber.i("Startup metadata repair recovered $repairedCount Steam install record(s)")
+                }
             }
         }
 
@@ -4964,9 +5032,7 @@ class SteamService :
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {
                 Timber.d("Exiting app via notification intent")
-
-                val event = AndroidEvent.EndProcess
-                PluviaApp.events.emit(event)
+                AppTerminationHelper.stopManagedServices(applicationContext, "notification_exit")
 
                 return START_NOT_STICKY
             }
@@ -5068,6 +5134,12 @@ class SteamService :
         notificationHelper.cancel()
 
         scope.launch { stop() }
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        Timber.i("Task removed; stopping managed app services")
+        AppTerminationHelper.stopManagedServices(applicationContext, "steam_task_removed")
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/feature/stores/steam/utils/PrefManager.kt
+++ b/app/src/main/feature/stores/steam/utils/PrefManager.kt
@@ -12,6 +12,9 @@ object PrefManager {
     @Volatile
     private var appContext: Context? = null
 
+    @Volatile
+    private var libraryLayoutModeCache: String? = null
+
     fun install(context: Context) {
         appContext = context.applicationContext
     }
@@ -233,8 +236,13 @@ object PrefManager {
         }
 
     var libraryLayoutMode: String
-        get() = getString("library_layout_mode", "GRID_4")
+        get() =
+            libraryLayoutModeCache
+                ?: getString("library_layout_mode", "GRID_4").also {
+                    libraryLayoutModeCache = it
+                }
         set(value) {
+            libraryLayoutModeCache = value
             setString("library_layout_mode", value)
         }
 
@@ -295,6 +303,7 @@ object PrefManager {
     }
 
     fun clearPreferences() {
+        libraryLayoutModeCache = null
         requirePrefs().edit().clear().commit()
     }
 

--- a/app/src/main/feature/stores/steam/utils/PrefManager.kt
+++ b/app/src/main/feature/stores/steam/utils/PrefManager.kt
@@ -6,38 +6,67 @@ import androidx.security.crypto.MasterKey
 import timber.log.Timber
 
 object PrefManager {
+    @Volatile
     private var prefs: SharedPreferences? = null
 
+    @Volatile
+    private var appContext: Context? = null
+
+    fun install(context: Context) {
+        appContext = context.applicationContext
+    }
+
     fun init(context: Context) {
-        val legacyPrefs = context.getSharedPreferences("PluviaPreferences", Context.MODE_PRIVATE)
+        install(context)
+        ensurePrefsInitialized(context.applicationContext)
+    }
 
-        prefs =
-            try {
-                val masterKey =
-                    MasterKey
-                        .Builder(context)
-                        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                        .build()
-                EncryptedSharedPreferences.create(
-                    context,
-                    "PluviaPreferences_enc",
-                    masterKey,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-                )
-            } catch (e: Exception) {
-                Timber.e(e, "EncryptedSharedPreferences init failed")
-                throw RuntimeException("Failed to initialize secure storage", e)
-            }
+    private fun requirePrefs(): SharedPreferences {
+        prefs?.let { return it }
+        val context = appContext ?: throw IllegalStateException("PrefManager not installed. Call install() or init() first.")
+        return ensurePrefsInitialized(context)
+    }
 
-        migrateLegacyPrefsIfNeeded(legacyPrefs, context)
+    private fun ensurePrefsInitialized(context: Context): SharedPreferences {
+        prefs?.let { return it }
+
+        synchronized(this) {
+            prefs?.let { return it }
+
+            val appContext = context.applicationContext
+            this.appContext = appContext
+            val legacyPrefs = appContext.getSharedPreferences("PluviaPreferences", Context.MODE_PRIVATE)
+
+            val encryptedPrefs =
+                try {
+                    val masterKey =
+                        MasterKey
+                            .Builder(appContext)
+                            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                            .build()
+                    EncryptedSharedPreferences.create(
+                        appContext,
+                        "PluviaPreferences_enc",
+                        masterKey,
+                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                    )
+                } catch (e: Exception) {
+                    Timber.e(e, "EncryptedSharedPreferences init failed")
+                    throw RuntimeException("Failed to initialize secure storage", e)
+                }
+
+            prefs = encryptedPrefs
+            migrateLegacyPrefsIfNeeded(legacyPrefs, appContext, encryptedPrefs)
+            return encryptedPrefs
+        }
     }
 
     private fun migrateLegacyPrefsIfNeeded(
         legacyPrefs: SharedPreferences,
         context: Context,
+        encryptedPrefs: SharedPreferences,
     ) {
-        val encryptedPrefs = prefs ?: return
         val legacyEntries = legacyPrefs.all
         if (legacyEntries.isEmpty()) return
 
@@ -62,49 +91,49 @@ object PrefManager {
     private fun getString(
         key: String,
         defaultValue: String,
-    ): String = prefs?.getString(key, defaultValue) ?: defaultValue
+    ): String = requirePrefs().getString(key, defaultValue) ?: defaultValue
 
     private fun setString(
         key: String,
         value: String,
     ) {
-        prefs?.edit()?.putString(key, value)?.apply()
+        requirePrefs().edit().putString(key, value).apply()
     }
 
     private fun getInt(
         key: String,
         defaultValue: Int,
-    ): Int = prefs?.getInt(key, defaultValue) ?: defaultValue
+    ): Int = requirePrefs().getInt(key, defaultValue)
 
     private fun setInt(
         key: String,
         value: Int,
     ) {
-        prefs?.edit()?.putInt(key, value)?.apply()
+        requirePrefs().edit().putInt(key, value).apply()
     }
 
     private fun getLong(
         key: String,
         defaultValue: Long,
-    ): Long = prefs?.getLong(key, defaultValue) ?: defaultValue
+    ): Long = requirePrefs().getLong(key, defaultValue)
 
     private fun setLong(
         key: String,
         value: Long,
     ) {
-        prefs?.edit()?.putLong(key, value)?.apply()
+        requirePrefs().edit().putLong(key, value).apply()
     }
 
     private fun getBoolean(
         key: String,
         defaultValue: Boolean,
-    ): Boolean = prefs?.getBoolean(key, defaultValue) ?: defaultValue
+    ): Boolean = requirePrefs().getBoolean(key, defaultValue)
 
     private fun setBoolean(
         key: String,
         value: Boolean,
     ) {
-        prefs?.edit()?.putBoolean(key, value)?.apply()
+        requirePrefs().edit().putBoolean(key, value).apply()
     }
 
     var username: String
@@ -252,7 +281,7 @@ object PrefManager {
         }
 
     fun clearAuthTokens() {
-        prefs?.edit()?.apply {
+        requirePrefs().edit().apply {
             remove("user_name")
             remove("refresh_token")
             remove("access_token")
@@ -266,7 +295,7 @@ object PrefManager {
     }
 
     fun clearPreferences() {
-        prefs?.edit()?.clear()?.commit()
+        requirePrefs().edit().clear().commit()
     }
 
     // Legacy support for Winlator properties if needed

--- a/app/src/main/feature/sync/google/CloudSyncManager.kt
+++ b/app/src/main/feature/sync/google/CloudSyncManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.games.PlayGames
@@ -67,6 +69,14 @@ object CloudSyncManager {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val syncMutex = Mutex()
+
+    private fun isActivityValidForPlayGames(activity: Activity): Boolean {
+        if (activity.isFinishing || activity.isDestroyed) {
+            return false
+        }
+        val lifecycleState = (activity as? LifecycleOwner)?.lifecycle?.currentState
+        return lifecycleState?.isAtLeast(Lifecycle.State.STARTED) ?: true
+    }
 
     data class StoreLoginSyncState(
         val googleSignedIn: Boolean = false,
@@ -756,6 +766,13 @@ object CloudSyncManager {
     }
 
     private suspend fun freshSnapshotsClient(activity: Activity): SnapshotsClient? {
+        if (!isActivityValidForPlayGames(activity)) {
+            Timber.tag(TAG).w(
+                "Skipping snapshot client creation for %s because the activity is no longer active",
+                activity::class.java.simpleName,
+            )
+            return null
+        }
         PlayGamesBootstrap.ensureInitialized(activity)
         return PlayGames.getSnapshotsClient(activity)
     }
@@ -1323,6 +1340,9 @@ object CloudSyncManager {
     }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        if (!isActivityValidForPlayGames(activity)) {
+            return false
+        }
         PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
@@ -1358,8 +1378,15 @@ object CloudSyncManager {
         throw IllegalStateException("Play Games authentication did not become ready for Saved Games access.")
     }
 
-    private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
-        try {
+    private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean {
+        if (!isActivityValidForPlayGames(activity)) {
+            Timber.tag(TAG).i(
+                "Skipping Google auth check because %s is finishing or destroyed",
+                activity::class.java.simpleName,
+            )
+            return false
+        }
+        return try {
             PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
@@ -1379,4 +1406,5 @@ object CloudSyncManager {
             Timber.tag(TAG).e(error, "Failed to read Google authentication state")
             false
         }
+    }
 }

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -7,6 +7,8 @@ import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.common.api.Scope
 import com.google.android.gms.games.PlayGames
 import com.google.android.gms.tasks.Tasks
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.winlator.cmod.feature.stores.epic.service.EpicCloudSavesManager
 import com.winlator.cmod.feature.stores.gog.service.GOGService
 import com.winlator.cmod.feature.stores.steam.enums.PathType
@@ -839,8 +841,23 @@ object GameSaveBackupManager {
 
     private fun isGoogleSyncEnabled(context: Context): Boolean = prefs(context).getBoolean(KEY_GOOGLE_SYNC_ENABLED, false)
 
-    private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean =
-        try {
+    private fun isActivityValidForPlayGames(activity: Activity): Boolean {
+        if (activity.isFinishing || activity.isDestroyed) {
+            return false
+        }
+        val lifecycleState = (activity as? LifecycleOwner)?.lifecycle?.currentState
+        return lifecycleState?.isAtLeast(Lifecycle.State.STARTED) ?: true
+    }
+
+    private suspend fun isAuthenticatedBlocking(activity: Activity): Boolean {
+        if (!isActivityValidForPlayGames(activity)) {
+            Timber.tag(TAG).i(
+                "Skipping Google auth check because %s is finishing or destroyed",
+                activity::class.java.simpleName,
+            )
+            return false
+        }
+        return try {
             PlayGamesBootstrap.ensureInitialized(activity)
             val task = PlayGames.getGamesSignInClient(activity).isAuthenticated
             val result =
@@ -857,8 +874,12 @@ object GameSaveBackupManager {
             Timber.tag(TAG).e(error, "Failed to read Google authentication state")
             false
         }
+    }
 
     private suspend fun awaitAuthenticatedSession(activity: Activity): Boolean {
+        if (!isActivityValidForPlayGames(activity)) {
+            return false
+        }
         PlayGamesBootstrap.ensureInitialized(activity)
         repeat(AUTH_SESSION_RETRY_COUNT) { attempt ->
             if (isAuthenticatedBlocking(activity)) {
@@ -879,6 +900,13 @@ object GameSaveBackupManager {
     private suspend fun getDriveAccessToken(activity: Activity): String? =
         withContext(Dispatchers.IO) {
             try {
+                if (!isActivityValidForPlayGames(activity)) {
+                    Timber.tag(TAG).w(
+                        "Skipping Drive authorization because %s is no longer active",
+                        activity::class.java.simpleName,
+                    )
+                    return@withContext null
+                }
                 val authRequest =
                     AuthorizationRequest
                         .builder()

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -312,6 +312,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private Runnable realSteamWatchdogRunnable;
     private final AtomicBoolean exitRequested = new AtomicBoolean(false);
     private final AtomicBoolean steamExitWatchRunning = new AtomicBoolean(false);
+    private final AtomicBoolean activityDestroyed = new AtomicBoolean(false);
+    private final AtomicBoolean forcedCleanupStarted = new AtomicBoolean(false);
 
     private boolean isDarkMode;
     private boolean enableLogsMenu;
@@ -1807,7 +1809,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 long startTime = System.currentTimeMillis();
                 long lastNonCoreSeenAt = -1L;
 
-                while (!exitRequested.get() && System.currentTimeMillis() - startTime < STEAM_TERMINATION_TIMEOUT_MS) {
+                while (!exitRequested.get()
+                        && !activityDestroyed.get()
+                        && System.currentTimeMillis() - startTime < STEAM_TERMINATION_TIMEOUT_MS) {
                     ArrayList<ProcessInfo> snapshot = captureWinHandlerProcessSnapshot();
                     if (snapshot != null) {
                         ArrayList<String> activeNames = new ArrayList<>();
@@ -1830,12 +1834,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                             lastNonCoreSeenAt = now;
                         } else if (lastNonCoreSeenAt > 0L && now - lastNonCoreSeenAt >= STEAM_TERMINATION_POLL_MS) {
                             Log.d("XServerDisplayActivity", "Steam/game processes drained; exiting session");
-                            runOnUiThread(this::exit);
+                            requestExitOnUiThread("steam/game processes drained");
                             return;
                         } else if (lastNonCoreSeenAt < 0L && now - startTime >= STEAM_TERMINATION_GRACE_MS) {
                             Log.d("XServerDisplayActivity",
                                     "No non-core Steam/game process appeared after wrapper exit; exiting session");
-                            runOnUiThread(this::exit);
+                            requestExitOnUiThread("steam wrapper exited without spawning a game");
                             return;
                         }
                     }
@@ -1843,15 +1847,15 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     Thread.sleep(STEAM_TERMINATION_POLL_MS);
                 }
 
-                if (!exitRequested.get()) {
+                if (!exitRequested.get() && !activityDestroyed.get()) {
                     Log.d("XServerDisplayActivity", "Steam exit watch timed out; exiting session");
-                    runOnUiThread(this::exit);
+                    requestExitOnUiThread("steam exit watch timed out");
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 Log.w("XServerDisplayActivity", "Steam exit watch interrupted", e);
-                if (!exitRequested.get()) {
-                    runOnUiThread(this::exit);
+                if (!exitRequested.get() && !activityDestroyed.get()) {
+                    requestExitOnUiThread("steam exit watch interrupted");
                 }
             } finally {
                 steamExitWatchRunning.set(false);
@@ -1874,7 +1878,104 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
     }
 
+    private void requestExitOnUiThread(String reason) {
+        runOnUiThread(() -> {
+            if (activityDestroyed.get() || isFinishing() || isDestroyed()) {
+                Log.d("XServerDisplayActivity", "Skipping exit request after teardown: " + reason);
+                return;
+            }
+            exit();
+        });
+    }
+
+    private void performForcedSessionCleanup(String trigger) {
+        if (!forcedCleanupStarted.compareAndSet(false, true)) {
+            Log.d("XServerLeakCheck", "Forced session cleanup already ran; skipping duplicate request from " + trigger);
+            return;
+        }
+
+        activityDestroyed.set(true);
+        Log.w("XServerLeakCheck", "Starting forced session cleanup from " + trigger);
+
+        try {
+            if (preloaderDialog != null) preloaderDialog.close();
+        } catch (Exception e) {
+            Log.w("XServerLeakCheck", "Failed to close preloader during forced cleanup", e);
+        }
+
+        try {
+            if (handler != null) {
+                if (savePlaytimeRunnable != null) {
+                    handler.removeCallbacks(savePlaytimeRunnable);
+                }
+                if (controllerAutoSwitchRunnable != null) {
+                    handler.removeCallbacks(controllerAutoSwitchRunnable);
+                }
+            }
+        } catch (Exception e) {
+            Log.w("XServerLeakCheck", "Failed to remove handler callbacks during forced cleanup", e);
+        }
+
+        try {
+            if (midiHandler != null) {
+                midiHandler.stop();
+                midiHandler = null;
+            }
+        } catch (Exception e) {
+            Log.e("XServerLeakCheck", "Failed to stop MidiHandler during forced cleanup", e);
+        }
+
+        try {
+            if (sensorManager != null) sensorManager.unregisterListener(gyroListener);
+        } catch (Exception e) {
+            Log.w("XServerLeakCheck", "Failed to unregister sensor listener during forced cleanup", e);
+        }
+
+        try {
+            if (winHandler != null) {
+                winHandler.stop();
+                winHandler = null;
+            }
+        } catch (Exception e) {
+            Log.e("XServerLeakCheck", "Failed to stop WinHandler during forced cleanup", e);
+        }
+
+        try {
+            if (wineRequestHandler != null) {
+                wineRequestHandler.stop();
+                wineRequestHandler = null;
+            }
+        } catch (Exception e) {
+            Log.e("XServerLeakCheck", "Failed to stop WineRequestHandler during forced cleanup", e);
+        }
+
+        try {
+            if (environment != null) {
+                environment.stopEnvironmentComponents();
+                environment = null;
+            }
+        } catch (Exception e) {
+            Log.e("XServerLeakCheck", "Failed to stop environment during forced cleanup", e);
+        }
+
+        xServer = null;
+        xServerView = null;
+
+        ArrayList<String> remaining = ProcessHelper.terminateSessionProcessesAndWait(2000, true);
+        ProcessHelper.drainDeadChildren("forced cleanup (" + trigger + ")");
+        ProcessHelper.scheduleDeadChildReapSweep("forced cleanup (" + trigger + ")", 4000, 200);
+        if (remaining.isEmpty()) {
+            Log.i("XServerLeakCheck", "Forced session cleanup finished cleanly after " + trigger);
+        } else {
+            Log.e("XServerLeakCheck", "Remaining leaked session processes after forced cleanup from " + trigger + ": " + remaining);
+        }
+    }
+
     private void exit() {
+        if (activityDestroyed.get() || isFinishing() || isDestroyed()) {
+            Log.d("XServerDisplayActivity", "Ignoring exit() on torn-down activity");
+            return;
+        }
         if (!exitRequested.compareAndSet(false, true)) {
             Log.d("XServerDisplayActivity", "Exit already in progress; ignoring duplicate request");
             return;
@@ -2209,6 +2310,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        activityDestroyed.set(true);
+        if (preloaderDialog != null) {
+            preloaderDialog.close();
+        }
         super.onDestroy();
         if (preferences != null) {
             preferences.unregisterOnSharedPreferenceChangeListener(prefListener);
@@ -2223,37 +2328,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
 
         if (!exitRequested.get()) {
-            Log.w("XServerLeakCheck", "onDestroy called without exit() — forcing last-resort cleanup");
-            try {
-                if (winHandler != null) winHandler.stop();
-            } catch (Exception e) {
-                Log.e("XServerLeakCheck", "Failed to stop WinHandler during last-resort cleanup", e);
-            }
-            try {
-                if (wineRequestHandler != null) wineRequestHandler.stop();
-            } catch (Exception e) {
-                Log.e("XServerLeakCheck", "Failed to stop WineRequestHandler during last-resort cleanup", e);
-            }
-            try {
-                if (midiHandler != null) midiHandler.stop();
-            } catch (Exception e) {
-                Log.e("XServerLeakCheck", "Failed to stop MidiHandler during last-resort cleanup", e);
-            }
-            try {
-                if (environment != null) {
-                    environment.stopEnvironmentComponents();
-                    environment = null;
-                }
-            } catch (Exception e) {
-                Log.e("XServerLeakCheck", "Failed to stop environment during last-resort cleanup", e);
-            }
-
-            ArrayList<String> remaining = ProcessHelper.terminateSessionProcessesAndWait(2000, true);
-            ProcessHelper.drainDeadChildren("last-resort onDestroy cleanup");
-            ProcessHelper.scheduleDeadChildReapSweep("last-resort onDestroy cleanup", 4000, 200);
-            if (!remaining.isEmpty()) {
-                Log.e("XServerLeakCheck", "Remaining leaked session processes after forced cleanup: " + remaining);
-            }
+            performForcedSessionCleanup("onDestroy");
         }
 
         // Leak detection: log warnings if resources were not cleaned up by exit()
@@ -2307,6 +2382,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         super.onStop();
         savePlaytimeData();
         handler.removeCallbacks(savePlaytimeRunnable);
+        if (!exitRequested.get() && isFinishing() && !isChangingConfigurations()) {
+            performForcedSessionCleanup("onStop finishing");
+        }
     }
 
     private void handleNavigationBackPressed() {

--- a/app/src/main/runtime/system/LogManager.kt
+++ b/app/src/main/runtime/system/LogManager.kt
@@ -59,6 +59,7 @@ object LogManager {
      */
     @JvmStatic
     fun rotateLogsOnAppStart(context: Context) {
+        if (!isAnyLoggingEnabled(context)) return
         val logsDir = getLogsDir(context)
         // Delete any existing .old.log files first
         logsDir.listFiles()?.filter { it.name.endsWith(".old.log") }?.forEach { it.delete() }

--- a/app/src/main/shared/android/AppTerminationHelper.kt
+++ b/app/src/main/shared/android/AppTerminationHelper.kt
@@ -1,0 +1,65 @@
+package com.winlator.cmod.shared.android
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Process
+import com.winlator.cmod.app.PluviaApp
+import com.winlator.cmod.app.service.DownloadService
+import com.winlator.cmod.feature.stores.epic.service.EpicService
+import com.winlator.cmod.feature.stores.epic.service.EpicTokenRefreshWorker
+import com.winlator.cmod.feature.stores.gog.service.GOGService
+import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
+import com.winlator.cmod.feature.stores.steam.service.SteamService
+import timber.log.Timber
+
+object AppTerminationHelper {
+    @JvmStatic
+    fun stopManagedServices(
+        context: Context,
+        reason: String,
+    ) {
+        val appContext = context.applicationContext
+        Timber.i("Stopping managed services for app shutdown (%s)", reason)
+
+        // Stop active transfers without deleting partial download state.
+        runCatching { DownloadService.pauseAll() }
+            .onFailure { Timber.w(it, "Failed to pause downloads during shutdown") }
+
+        runCatching { EpicTokenRefreshWorker.cancel(appContext) }
+            .onFailure { Timber.w(it, "Failed to cancel Epic refresh worker during shutdown") }
+
+        runCatching { PluviaApp.events.emit(AndroidEvent.EndProcess) }
+            .onFailure { Timber.w(it, "Failed to emit EndProcess during shutdown") }
+
+        runCatching { SteamService.stop() }
+            .onFailure { Timber.w(it, "Failed to stop SteamService during shutdown") }
+        runCatching { EpicService.stop() }
+            .onFailure { Timber.w(it, "Failed to stop EpicService during shutdown") }
+        runCatching { GOGService.stop() }
+            .onFailure { Timber.w(it, "Failed to stop GOGService during shutdown") }
+
+        stopServiceSafely<SteamService>(appContext)
+        stopServiceSafely<EpicService>(appContext)
+        stopServiceSafely<GOGService>(appContext)
+    }
+
+    @JvmStatic
+    fun exitApplication(
+        activity: Activity,
+        reason: String,
+    ) {
+        stopManagedServices(activity, reason)
+        activity.finishAffinity()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            activity.finishAndRemoveTask()
+        }
+        Process.killProcess(Process.myPid())
+    }
+
+    private inline fun <reified T> stopServiceSafely(context: Context) {
+        runCatching { context.stopService(Intent(context, T::class.java)) }
+            .onFailure { Timber.w(it, "Failed to stop ${T::class.java.simpleName} via context.stopService()") }
+    }
+}

--- a/app/src/main/shared/android/AppUtils.java
+++ b/app/src/main/shared/android/AppUtils.java
@@ -102,6 +102,7 @@ public abstract class AppUtils {
   }
 
   public static void restartApplication(Context context, int selectedMenuItemId) {
+    AppTerminationHelper.stopManagedServices(context, "restart_application");
     Intent intent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
     Intent mainIntent = Intent.makeRestartActivityTask(intent.getComponent());
     if (selectedMenuItemId > 0) mainIntent.putExtra("selected_menu_item_id", selectedMenuItemId);

--- a/app/src/main/shared/ui/FourByTwoGridView.kt
+++ b/app/src/main/shared/ui/FourByTwoGridView.kt
@@ -55,6 +55,7 @@ fun <T> FourByTwoGridView(
     gridState: LazyGridState = rememberLazyGridState(),
     clipContent: Boolean = true,
     viewMode: ViewMode = ViewMode.Grid,
+    keyOf: ((T) -> Any)? = null,
     itemContent: @Composable (item: T, index: Int, rowHeight: Dp) -> Unit,
 ) {
     when (viewMode) {
@@ -95,7 +96,15 @@ fun <T> FourByTwoGridView(
                             .fillMaxSize()
                             .then(if (!clipContent) Modifier.graphicsLayer { clip = false } else Modifier),
                 ) {
-                    itemsIndexed(items) { index, item ->
+                    itemsIndexed(
+                        items = items,
+                        key =
+                            if (keyOf != null) {
+                                { _, item -> keyOf(item) }
+                            } else {
+                                null
+                            },
+                    ) { index, item ->
                         itemContent(item, index, rowHeight)
                     }
                 }

--- a/app/src/main/shared/ui/ListView.kt
+++ b/app/src/main/shared/ui/ListView.kt
@@ -46,6 +46,7 @@ fun <T> ListView(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     selectedIndex: Int = 0,
     onSelectedIndexChanged: (Int) -> Unit = {},
+    keyOf: ((T) -> Any)? = null,
     itemContent: @Composable (item: T, index: Int, isSelected: Boolean) -> Unit,
 ) {
     val layoutDirection = LocalLayoutDirection.current
@@ -72,7 +73,15 @@ fun <T> ListView(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxSize(),
     ) {
-        itemsIndexed(items) { index, item ->
+        itemsIndexed(
+            items = items,
+            key =
+                if (keyOf != null) {
+                    { _, item -> keyOf(item) }
+                } else {
+                    null
+                },
+        ) { index, item ->
             Box(
                 modifier = Modifier.widthIn(max = 500.dp).fillMaxWidth(),
                 contentAlignment = Alignment.Center,

--- a/app/src/main/shared/ui/dialog/PreloaderDialog.java
+++ b/app/src/main/shared/ui/dialog/PreloaderDialog.java
@@ -24,7 +24,7 @@ public class PreloaderDialog {
   }
 
   private void create() {
-    if (dialog != null) return;
+    if (dialog != null || isHostActivityInvalid()) return;
     dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
     dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
     dialog.setCancelable(false);
@@ -55,6 +55,19 @@ public class PreloaderDialog {
     dialog.setContentView(composeView);
   }
 
+  private boolean isHostActivityInvalid() {
+    return activity.isFinishing() || activity.isDestroyed();
+  }
+
+  private void showDialogSafely() {
+    if (dialog == null || isShowing() || isHostActivityInvalid()) return;
+
+    try {
+      dialog.show();
+    } catch (WindowManager.BadTokenException | IllegalStateException ignored) {
+    }
+  }
+
   private void clearLaunchMetadata() {
     composeState.setGameName("");
     composeState.setPlatform("");
@@ -68,33 +81,36 @@ public class PreloaderDialog {
 
   public synchronized void show(int textResId, boolean indeterminate) {
     if (dialog == null) create();
+    if (dialog == null) return;
     clearLaunchMetadata();
     composeState.setText(activity.getString(textResId));
     composeState.setIndeterminate(indeterminate);
     if (!indeterminate) {
       composeState.setProgress(0);
     }
-    if (!isShowing()) dialog.show();
+    showDialogSafely();
   }
 
   public synchronized void show(String text) {
     if (dialog == null) create();
+    if (dialog == null) return;
     clearLaunchMetadata();
     composeState.setText(text);
     composeState.setIndeterminate(true);
-    if (!isShowing()) dialog.show();
+    showDialogSafely();
   }
 
   public synchronized void show(
       String text, String gameName, String platform, String containerName) {
     if (dialog == null) create();
+    if (dialog == null) return;
     composeState.setText(text);
     composeState.setGameName(gameName != null ? gameName : "");
     composeState.setPlatform(platform != null ? platform : "");
     composeState.setContainerName(containerName != null ? containerName : "");
     composeState.setStableLaunchLayout(true);
     composeState.setIndeterminate(true);
-    if (!isShowing()) dialog.show();
+    showDialogSafely();
   }
 
   public synchronized void show(
@@ -113,24 +129,24 @@ public class PreloaderDialog {
   }
 
   public void setProgressOnUiThread(final int percent) {
-    activity.runOnUiThread(() -> setProgress(percent));
+    uiHandler.post(() -> setProgress(percent));
   }
 
   public void setIndeterminateOnUiThread(final boolean indeterminate) {
-    activity.runOnUiThread(() -> setIndeterminate(indeterminate));
+    uiHandler.post(() -> setIndeterminate(indeterminate));
   }
 
   public void showOnUiThread(final int textResId) {
-    activity.runOnUiThread(() -> show(textResId));
+    uiHandler.post(() -> show(textResId));
   }
 
   public void showOnUiThread(final String text) {
-    activity.runOnUiThread(() -> show(text));
+    uiHandler.post(() -> show(text));
   }
 
   public void showOnUiThread(
       final String text, final String gameName, final String platform, final String containerName) {
-    activity.runOnUiThread(() -> show(text, gameName, platform, containerName));
+    uiHandler.post(() -> show(text, gameName, platform, containerName));
   }
 
   public void showProgressOnUiThread(
@@ -139,7 +155,7 @@ public class PreloaderDialog {
       final String platform,
       final String containerName,
       final int percent) {
-    activity.runOnUiThread(
+    uiHandler.post(
         () -> {
           show(text, gameName, platform, containerName);
           composeState.setIndeterminate(false);
@@ -148,7 +164,7 @@ public class PreloaderDialog {
   }
 
   public void setStepOnUiThread(final String step) {
-    activity.runOnUiThread(
+    uiHandler.post(
         () -> {
           if (dialog != null) composeState.setText(step);
         });
@@ -176,7 +192,7 @@ public class PreloaderDialog {
   }
 
   public void closeOnUiThread() {
-    activity.runOnUiThread(this::close);
+    uiHandler.post(this::close);
   }
 
   public boolean isShowing() {


### PR DESCRIPTION
- `app/src/main/app/PluviaApp.kt`: removed eager Play Games, download-service, database, and foreground-service startup work; switched secure prefs to context installation and only refreshed update timestamps when update checks are enabled. Benefit: lighter cold starts and fewer premature background/service side effects.
- `app/src/main/app/di/DatabaseModule.kt`: routed Hilt database provisioning through `PluviaDatabase.getInstance(context)` instead of building a second Room instance. Benefit: one consistent database lifecycle across DI and manual callers.
- `app/src/main/app/service/DownloadService.kt`: added synchronized lazy initialization with application-context fallback and guarded property access. Benefit: download path/state lookups still work after removing eager app-start bootstrap, without null/race failures.
- `app/src/main/app/shell/UnifiedActivity.kt`: split full library refreshes from playtime-only refreshes, replaced polling with event/listener-driven updates for installs, downloads, and controllers, trimmed duplicated startup work, and routed exit through the shared termination helper. Benefit: less recomposition churn, fewer leaked listeners, and cleaner shutdown behavior.
- `app/src/main/app/update/UpdateChecker.kt`: made update checks disabled by default, blocked auto-checks while an `XServerDisplayActivity` is foregrounded, refreshed install timestamps during real checks, and canceled/restarted loops more deliberately. Benefit: fewer unsolicited checks and no update activity during gameplay sessions.
- `app/src/main/feature/settings/other/OtherSettingsFragment.kt`: aligned the settings default with the new update-check default and canceled pending post-game checks when the feature is turned off. Benefit: the toggle now immediately stops scheduled work instead of allowing stale delayed checks.
- `app/src/main/feature/stores/epic/service/EpicService.kt`: stopped managed app services from `onTaskRemoved`. Benefit: swiping the task away no longer leaves Epic-managed background work behind.
- `app/src/main/feature/stores/gog/service/GOGService.kt`: stopped managed app services from `onTaskRemoved`. Benefit: GOG cleanup now matches the rest of the shutdown flow.
- `app/src/main/feature/stores/steam/events/EventDispatcher.kt`: added `offJava` support for unregistering Java listeners. Benefit: Compose/UI listeners can now detach cleanly and avoid duplicate callbacks or leaks.
- `app/src/main/feature/stores/steam/service/SteamService.kt`: centralized notification-exit cleanup through the new termination helper, added task-removal cleanup, and gated startup metadata repair behind disk/database mismatch detection before doing the expensive recovery scan. Benefit: cleaner exits plus targeted metadata recovery instead of unconditional startup work.
- `app/src/main/feature/stores/steam/utils/PrefManager.kt`: introduced `install()` plus lazy encrypted-preference initialization and changed accessors to require a real initialized store instead of silently tolerating null. Benefit: safer secure-storage access with less eager startup cost and fewer hidden preference failures.
- `app/src/main/runtime/system/LogManager.kt`: skipped log rotation when logging is disabled. Benefit: avoids unnecessary filesystem churn on launches that are not recording logs.
- `app/src/main/shared/android/AppUtils.java`: stopped managed services before restarting the app process. Benefit: restarts now begin from a cleaner state instead of inheriting live services/workers.
- `app/src/main/shared/android/AppTerminationHelper.kt`: added a shared shutdown helper that pauses downloads, cancels the Epic refresh worker, emits the end-process event, stops store services, and performs the final process exit path. Benefit: one authoritative shutdown routine for exit, restart, notification, and task-removal flows.

---
- `app/src/main/app/PluviaApp.kt`, `app/src/main/feature/stores/steam/utils/PrefManager.kt`: deferred GOG auth/log/update warmups off the launch-critical path and cached `libraryLayoutMode` after the first secure-pref read. 
- `app/src/main/app/shell/UnifiedActivity.kt`, `app/src/main/shared/ui/FourByTwoGridView.kt`, `app/src/main/shared/ui/ListView.kt`: postponed store bootstrap until after the root view is attached, switched store/install checks to precomputed state maps, added stable Compose item keys, and pushed Epic/GOG/custom-art lookup work out of each individual capsule.
- `app/src/main/feature/sync/google/CloudSyncManager.kt`, `app/src/main/feature/sync/google/GameSaveBackupManager.kt`: refuse Play Games auth, snapshot, and Drive-token work when the hosting activity is finishing, destroyed, or no longer started. 
- `app/src/main/runtime/display/XServerDisplayActivity.java`, `app/src/main/shared/ui/dialog/PreloaderDialog.java`: block delayed exit callbacks once teardown starts, move forced session cleanup earlier into finishing `onStop()`, and make the preloader dialog fail closed on invalid activity windows. 