### PR TITLE
Fix exit restart cleanup path

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2023,7 +2023,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     if (preloaderDialog != null && preloaderDialog.isShowing()) preloaderDialog.closeOnUiThread();
                     // Match Ludashi/vanilla behavior: restart the app to ensure native/GL
                     // resources are fully released between sessions.
-                    AppUtils.restartApplication(this);
+                    AppUtils.restartApplication(XServerDisplayActivity.this);
                 }
             }, 1000);
         });

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2023,7 +2023,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     if (preloaderDialog != null && preloaderDialog.isShowing()) preloaderDialog.closeOnUiThread();
                     // Match Ludashi/vanilla behavior: restart the app to ensure native/GL
                     // resources are fully released between sessions.
-                    AppUtils.restartApplication(getApplicationContext());
+                    AppUtils.restartApplication(this);
                 }
             }, 1000);
         });

--- a/app/src/main/shared/android/AppUtils.java
+++ b/app/src/main/shared/android/AppUtils.java
@@ -12,6 +12,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Process;
 import android.text.Html;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -107,7 +108,7 @@ public abstract class AppUtils {
     Intent mainIntent = Intent.makeRestartActivityTask(intent.getComponent());
     if (selectedMenuItemId > 0) mainIntent.putExtra("selected_menu_item_id", selectedMenuItemId);
     context.startActivity(mainIntent);
-    Runtime.getRuntime().exit(0);
+    Process.killProcess(Process.myPid());
   }
 
   public static void showKeyboard(AppCompatActivity activity) {


### PR DESCRIPTION
## Summary
- keep the in-session exit flow on the hard restart path
- restart the app from the activity context so the managed shutdown helper runs before relaunch
- use a direct process kill during app restart after managed services are stopped

## Why
The recent shutdown changes introduced managed service teardown for app termination paths, but the in-session Exit action still needed to preserve the existing restart-based cleanup behavior. This keeps the explicit Wine/session teardown on Exit while wiring the restart step into the newer managed shutdown path.

## Root cause
The Exit button relied on the app restart helper, but that helper used `Runtime.getRuntime().exit(0)` and the caller passed application context. Updating the restart call to use the activity context and a direct process kill aligns the restart path with the newer shutdown plumbing.

## Impact
- Exit still forcefully cleans up the running session and reopens the app
- managed service shutdown logs now appear on the Exit path as well
- the restart path uses a more explicit process termination step

## Validation
- not run: Gradle/compile checks in this environment because `java` and `JAVA_HOME` are not configured
