### PR TITLE
feat: silently install bundled Ubisoft Connect on first launch

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6052,6 +6052,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         File ubisoftDir = new File(gameInstallPath, "_CommonRedist/UbisoftConnect");
         String[] names = { "UbisoftConnectInstaller.exe", "UplayInstaller.exe" };
         File installer = null;
+        boolean placementFailed = false;
         for (String name : names) {
             File candidate = new File(ubisoftDir, name);
             if (candidate.isFile()) { installer = candidate; break; }
@@ -6063,12 +6064,20 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     installer = candidate;
                     break;
                 } catch (Exception e) {
+                    // Symlinks can fail on Android external/FUSE-backed storage.
+                    // Don't cache "done" in that case — retry on next launch.
                     Log.w("XServerDisplayActivity", "Ubisoft Connect symlink failed", e);
+                    placementFailed = true;
                 }
             }
         }
 
         if (installer == null) {
+            if (placementFailed) {
+                Log.w("XServerDisplayActivity", "Ubisoft Connect installer present at game root but symlink failed for appId="
+                        + appId + " — will retry next launch");
+                return;
+            }
             Log.d("XServerDisplayActivity", "No Ubisoft Connect installer for appId=" + appId
                     + " — marking done so we don't re-probe");
             container.putExtra(key, "true");

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -5764,6 +5764,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Step 2: Install redistributables for this game if not already done in this container
         installRedistributablesIfNeeded(launcher);
 
+        // Step 2b: Install Ubisoft Connect into the prefix when the game bundles its installer.
+        // No-op when the game doesn't ship a Ubisoft Connect installer.
+        installUbisoftConnectIfNeeded(launcher);
+
         // Step 3: Run Steamless DRM stripping.
         // Runtime DRM Patcher (extra_dlls) handles most games automatically when
         // enabled, but Steamless is needed as a fallback for stubborn SteamStub
@@ -6012,6 +6016,82 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Mark as done for this game+container combo
         container.putExtra(redistKey, "true");
         container.saveData();
+    }
+
+    /**
+     * Installs Ubisoft Connect into the Wine prefix when the game bundles the installer.
+     * Only runs when UbisoftConnectInstaller.exe or UplayInstaller.exe is present under
+     * <gameInstallPath>/_CommonRedist/UbisoftConnect/ (or loose at the game root — in which
+     * case we symlink it into _CommonRedist/UbisoftConnect/ first, since the installer
+     * refuses to run from the game root).
+     *
+     * Tracked per game+container via container extra "ubisoft_connect_<appId>" so we don't
+     * re-probe every launch. Best-effort silent install via /S — the user still signs in to
+     * Ubisoft Connect manually once per Wine prefix.
+     */
+    private void installUbisoftConnectIfNeeded(GuestProgramLauncherComponent launcher) {
+        if (shortcut == null || !"STEAM".equals(shortcut.getExtra("game_source"))) return;
+
+        int appId;
+        try {
+            appId = Integer.parseInt(shortcut.getExtra("app_id"));
+        } catch (Exception e) {
+            return;
+        }
+
+        String key = "ubisoft_connect_" + appId;
+        if ("true".equals(container.getExtra(key, "false"))) {
+            Log.d("XServerDisplayActivity", "Ubisoft Connect for appId=" + appId
+                    + " already processed in container " + container.id + ", skipping");
+            return;
+        }
+
+        String gameInstallPath = resolveSteamGameInstallPath(appId);
+        if (gameInstallPath == null || gameInstallPath.isEmpty()) return;
+
+        File ubisoftDir = new File(gameInstallPath, "_CommonRedist/UbisoftConnect");
+        String[] names = { "UbisoftConnectInstaller.exe", "UplayInstaller.exe" };
+        File installer = null;
+        for (String name : names) {
+            File candidate = new File(ubisoftDir, name);
+            if (candidate.isFile()) { installer = candidate; break; }
+            File atRoot = new File(gameInstallPath, name);
+            if (atRoot.isFile()) {
+                try {
+                    ubisoftDir.mkdirs();
+                    java.nio.file.Files.createSymbolicLink(candidate.toPath(), atRoot.toPath());
+                    installer = candidate;
+                    break;
+                } catch (Exception e) {
+                    Log.w("XServerDisplayActivity", "Ubisoft Connect symlink failed", e);
+                }
+            }
+        }
+
+        if (installer == null) {
+            Log.d("XServerDisplayActivity", "No Ubisoft Connect installer for appId=" + appId
+                    + " — marking done so we don't re-probe");
+            container.putExtra(key, "true");
+            container.saveData();
+            return;
+        }
+
+        try {
+            String winPath = WineUtils.getWindowsPath(container, installer.getAbsolutePath());
+            Log.d("XServerDisplayActivity", "Installing Ubisoft Connect (silent): " + winPath);
+            launcher.execShellCommand("wine \"" + winPath + "\" /S");
+            try {
+                launcher.execShellCommand("wineserver -k");
+            } catch (Exception e) {
+                Log.w("XServerDisplayActivity", "wineserver -k failed after Ubisoft Connect install", e);
+            }
+            container.putExtra(key, "true");
+            container.saveData();
+            Log.d("XServerDisplayActivity", "Ubisoft Connect install attempted for appId=" + appId
+                    + " in container " + container.id);
+        } catch (Exception e) {
+            Log.w("XServerDisplayActivity", "Ubisoft Connect install failed", e);
+        }
     }
 
     /**

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6039,7 +6039,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             return;
         }
 
-        String key = "ubisoft_connect_" + appId;
+        // v2 key: bumped from "ubisoft_connect_" to force re-probe on containers that
+        // cached a stuck marker under the earlier symlink-only implementation.
+        String key = "ubisoft_connect_v2_" + appId;
         if ("true".equals(container.getExtra(key, "false"))) {
             Log.d("XServerDisplayActivity", "Ubisoft Connect for appId=" + appId
                     + " already processed in container " + container.id + ", skipping");
@@ -6058,17 +6060,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             if (candidate.isFile()) { installer = candidate; break; }
             File atRoot = new File(gameInstallPath, name);
             if (atRoot.isFile()) {
-                try {
-                    ubisoftDir.mkdirs();
-                    java.nio.file.Files.createSymbolicLink(candidate.toPath(), atRoot.toPath());
+                if (relocateUbisoftInstaller(atRoot, candidate, ubisoftDir)) {
                     installer = candidate;
                     break;
-                } catch (Exception e) {
-                    // Symlinks can fail on Android external/FUSE-backed storage.
-                    // Don't cache "done" in that case — retry on next launch.
-                    Log.w("XServerDisplayActivity", "Ubisoft Connect symlink failed", e);
-                    placementFailed = true;
                 }
+                placementFailed = true;
+                // Keep looping — the sibling filename may already sit at the target path.
             }
         }
 
@@ -6101,6 +6098,56 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         } catch (Exception e) {
             Log.w("XServerDisplayActivity", "Ubisoft Connect install failed", e);
         }
+    }
+
+    /**
+     * Places a Ubisoft Connect installer found at the game root into _CommonRedist/UbisoftConnect/
+     * (the installer refuses to run from the game root). Cascades symlink → hard link → file copy
+     * so this works on Android external/FUSE-backed storage where symlinks are blocked.
+     * Returns true on first successful strategy, false if all three fail.
+     */
+    private boolean relocateUbisoftInstaller(File from, File to, File parentDir) {
+        try {
+            parentDir.mkdirs();
+        } catch (Exception e) {
+            Log.w("XServerDisplayActivity", "Failed to create _CommonRedist/UbisoftConnect dir", e);
+            return false;
+        }
+
+        // 1. Symlink — zero disk cost.
+        try {
+            java.nio.file.Files.createSymbolicLink(to.toPath(), from.toPath());
+            if (to.exists()) {
+                Log.d("XServerDisplayActivity", "Ubisoft installer placed via symlink: " + to.getAbsolutePath());
+                return true;
+            }
+        } catch (Exception e) {
+            Log.d("XServerDisplayActivity", "Ubisoft symlink failed, trying hard link: " + e.getMessage());
+        }
+
+        // 2. Hard link — same inode, same filesystem; often works where symlinks don't.
+        try {
+            java.nio.file.Files.createLink(to.toPath(), from.toPath());
+            if (to.exists()) {
+                Log.d("XServerDisplayActivity", "Ubisoft installer placed via hard link: " + to.getAbsolutePath());
+                return true;
+            }
+        } catch (Exception e) {
+            Log.d("XServerDisplayActivity", "Ubisoft hard link failed, trying copy: " + e.getMessage());
+        }
+
+        // 3. Full copy — bulletproof one-time fallback (~50-100 MB for a typical installer).
+        try {
+            java.nio.file.Files.copy(from.toPath(), to.toPath(),
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            if (to.exists() && to.length() > 0) {
+                Log.d("XServerDisplayActivity", "Ubisoft installer placed via copy: " + to.getAbsolutePath());
+                return true;
+            }
+        } catch (Exception e) {
+            Log.w("XServerDisplayActivity", "Ubisoft installer copy failed", e);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
When a Steam game ships UbisoftConnectInstaller.exe or UplayInstaller.exe under _CommonRedist/UbisoftConnect/ (or loose at the game root — which we symlink into _CommonRedist/UbisoftConnect/ since the installer refuses to run from the root), run it silently in the Wine prefix as part of the pre-game setup chain, right after the existing redist step. No-op when the game doesn't bundle an installer. Tracked per appId+container so we don't re-probe every launch. Users still sign in to Ubisoft Connect manually once per prefix.