### PR TITLE
fix: default second binding and container name

### DIFF
--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -27,6 +27,7 @@ import com.winlator.cmod.feature.library.WinComponentItem
 import com.winlator.cmod.runtime.compat.box64.Box64Preset
 import com.winlator.cmod.runtime.compat.box64.Box64PresetManager
 import com.winlator.cmod.runtime.container.Container
+import com.winlator.cmod.runtime.container.ContainerNameUtils
 import com.winlator.cmod.runtime.container.ContainerManager
 import com.winlator.cmod.runtime.content.ContentProfile
 import com.winlator.cmod.runtime.content.ContentsManager
@@ -79,6 +80,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
     private var box64PresetIds = mutableListOf<String>()
     private var fexcorePresetIds = mutableListOf<String>()
     private var wineVersionIdentifiers = mutableListOf<String>()
+    private var lastAutoContainerName: String? = null
 
     // Drives working copy, mirrored into state.drivesList via syncDrivesState.
     private val drivesWorking = mutableListOf<Pair<String, String>>()
@@ -236,6 +238,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 val wineInfo = WineInfo.fromIdentifier(context, contentsManager, identifier)
                 isArm64EC = wineInfo.isArm64EC()
                 state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
+                syncDefaultContainerName(identifier)
                 // Box64 list depends on arch (box64 vs wowbox64 entries).
                 rebuildEmulatorLists()
                 loadBox64Versions()
@@ -291,8 +294,16 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         if (c != null) {
             state.name.value = c.getName()
         } else {
-            state.name.value = context.getString(R.string.common_ui_container) +
-                "-" + manager.getNextContainerId()
+            val defaultWineVersion = WineInfo.MAIN_WINE_VERSION.identifier()
+            state.name.value =
+                ContainerNameUtils.buildUniqueVersionBasedName(
+                    context,
+                    contentsManager,
+                    defaultWineVersion,
+                    manager.containers,
+                    null
+                )
+            lastAutoContainerName = state.name.value
         }
 
         val inputType = c?.getInputType() ?: WinHandler.DEFAULT_INPUT_TYPE.toInt()
@@ -561,6 +572,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val archChanged = isArm64EC != wineInfo.isArm64EC()
         isArm64EC = wineInfo.isArm64EC()
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
+        syncDefaultContainerName(selectedIdentifier, force = true)
 
         rebuildEmulatorLists()
         // Always reset emulator selections when populating for the first time
@@ -882,6 +894,26 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             e32.equals("box64", true) || e64.equals("box64", true) || usesWowbox64
         state.showFexcoreFrame.value =
             e32.equals("fexcore", true) || e64.equals("fexcore", true)
+    }
+
+    private fun syncDefaultContainerName(wineVersion: String, force: Boolean = false) {
+        if (container != null) return
+
+        val currentName = state.name.value.trim()
+        if (!force && currentName.isNotEmpty() && currentName != lastAutoContainerName) {
+            return
+        }
+
+        val autoName =
+            ContainerNameUtils.buildUniqueVersionBasedName(
+                context,
+                contentsManager,
+                wineVersion,
+                manager.containers,
+                null
+            )
+        state.name.value = autoName
+        lastAutoContainerName = autoName
     }
 
     private fun formatWineVersionDisplay(wineInfo: WineInfo): String {

--- a/app/src/main/feature/sync/google/ContainerBackupManager.java
+++ b/app/src/main/feature/sync/google/ContainerBackupManager.java
@@ -11,6 +11,8 @@ import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.games.PlayGames;
 import com.google.android.gms.tasks.Tasks;
 import com.winlator.cmod.runtime.container.Container;
+import com.winlator.cmod.runtime.container.ContainerNameUtils;
+import com.winlator.cmod.runtime.content.ContentsManager;
 import com.winlator.cmod.shared.android.ActivityResultHost;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -155,7 +157,7 @@ public final class ContainerBackupManager {
         return new BackupResult(false, "Failed to access WinNative/Containers on Google Drive.");
       }
 
-      String fileName = buildBackupFileName(container);
+      String fileName = buildBackupFileName(context, container);
       String existingFileId = findDriveFileId(accessToken, folderId, fileName);
       boolean uploaded =
           existingFileId != null
@@ -194,7 +196,7 @@ public final class ContainerBackupManager {
             Collections.emptyList());
       }
 
-      String expectedFileName = buildBackupFileName(container);
+      String expectedFileName = buildBackupFileName(context, container);
       DriveBackupFile matchedFile = findDriveFile(accessToken, folderId, expectedFileName);
       if (matchedFile != null) {
         return new RestorePreparation(true, false, null, matchedFile, Collections.emptyList());
@@ -454,10 +456,14 @@ public final class ContainerBackupManager {
     }
   }
 
-  private static String buildBackupFileName(Container container) {
+  private static String buildBackupFileName(Context context, Container container) {
     String containerName = container.getName();
     if (containerName == null || containerName.trim().isEmpty()) {
-      containerName = "Container-" + container.id;
+      ContentsManager contentsManager = new ContentsManager(context);
+      contentsManager.syncContents();
+      containerName =
+          ContainerNameUtils.buildVersionBasedName(
+              context, contentsManager, container.getWineVersion());
     }
     String safeName =
         containerName.replace('/', '_').replace('\\', '_').replace('\n', '_').replace('\r', '_');

--- a/app/src/main/runtime/container/ContainerManager.java
+++ b/app/src/main/runtime/container/ContainerManager.java
@@ -231,6 +231,11 @@ public class ContainerManager {
       String wineVersion = data.getString("wineVersion");
       Log.d("ContainerManager", "createContainer: wineVersion=" + wineVersion);
       container.setWineVersion(wineVersion);
+      if (ContainerNameUtils.isUnspecifiedName(container.getName(), id)) {
+        container.setName(
+            ContainerNameUtils.buildUniqueVersionBasedName(
+                context, contentsManager, wineVersion, containers, null));
+      }
 
       // Set the correct emulators based on the wine architecture, unless the
       // caller already specified them in the JSON data.  This ensures every

--- a/app/src/main/runtime/container/ContainerNameUtils.java
+++ b/app/src/main/runtime/container/ContainerNameUtils.java
@@ -1,0 +1,70 @@
+package com.winlator.cmod.runtime.container;
+
+import android.content.Context;
+import androidx.annotation.Nullable;
+import com.winlator.cmod.runtime.content.ContentProfile;
+import com.winlator.cmod.runtime.content.ContentsManager;
+import com.winlator.cmod.runtime.wine.WineInfo;
+import java.util.Collection;
+
+public final class ContainerNameUtils {
+  private ContainerNameUtils() {}
+
+  public static String buildVersionBasedName(
+      Context context, ContentsManager contentsManager, @Nullable String wineVersion) {
+    if (wineVersion == null || wineVersion.trim().isEmpty()) {
+      return "Container";
+    }
+
+    if (contentsManager != null) {
+      ContentProfile profile = contentsManager.getProfileByEntryName(wineVersion);
+      if (profile != null && profile.verName != null && !profile.verName.trim().isEmpty()) {
+        return profile.verName.trim();
+      }
+    }
+
+    WineInfo wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersion);
+    return wineInfo.toString().trim();
+  }
+
+  public static String buildUniqueVersionBasedName(
+      Context context,
+      ContentsManager contentsManager,
+      @Nullable String wineVersion,
+      Collection<Container> existingContainers,
+      @Nullable Integer excludeContainerId) {
+    String baseName = buildVersionBasedName(context, contentsManager, wineVersion);
+    if (baseName.isEmpty()) {
+      baseName = "Container";
+    }
+
+    String uniqueName = baseName;
+    int suffix = 2;
+    while (containsName(existingContainers, uniqueName, excludeContainerId)) {
+      uniqueName = baseName + " " + suffix;
+      suffix++;
+    }
+    return uniqueName;
+  }
+
+  public static boolean isUnspecifiedName(@Nullable String name, int containerId) {
+    if (name == null || name.trim().isEmpty()) {
+      return true;
+    }
+    return ("Container-" + containerId).equals(name.trim());
+  }
+
+  private static boolean containsName(
+      Collection<Container> containers, String name, @Nullable Integer excludeContainerId) {
+    for (Container container : containers) {
+      if (excludeContainerId != null && container.id == excludeContainerId) {
+        continue;
+      }
+      String existingName = container.getName();
+      if (existingName != null && existingName.equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/app/src/main/runtime/input/controls/Binding.java
+++ b/app/src/main/runtime/input/controls/Binding.java
@@ -251,37 +251,43 @@ public enum Binding {
 
   public static String[] mouseBindingLabels() {
     ArrayList<String> names = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isMouse()) names.add(binding.toString());
+    names.add(Binding.NONE.toString());
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isMouse()) names.add(binding.toString());
     return names.toArray(new String[0]);
   }
 
   public static String[] keyboardBindingLabels() {
     ArrayList<String> labels = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isKeyboard()) labels.add(binding.toString());
+    labels.add(Binding.NONE.toString());
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isKeyboard()) labels.add(binding.toString());
     return labels.toArray(new String[0]);
   }
 
   public static String[] gamepadBindingLabels() {
     ArrayList<String> names = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isGamepad()) names.add(binding.toString());
+    names.add(Binding.NONE.toString());
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isGamepad()) names.add(binding.toString());
     return names.toArray(new String[0]);
   }
 
   public static Binding[] mouseBindingValues() {
     ArrayList<Binding> labels = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isMouse()) labels.add(binding);
+    labels.add(Binding.NONE);
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isMouse()) labels.add(binding);
     return labels.toArray(new Binding[0]);
   }
 
   public static Binding[] keyboardBindingValues() {
     ArrayList<Binding> values = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isKeyboard()) values.add(binding);
+    values.add(Binding.NONE);
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isKeyboard()) values.add(binding);
     return values.toArray(new Binding[0]);
   }
 
   public static Binding[] gamepadBindingValues() {
     ArrayList<Binding> labels = new ArrayList<>();
-    for (Binding binding : values()) if (binding.isGamepad()) labels.add(binding);
+    labels.add(Binding.NONE);
+    for (Binding binding : values()) if (binding != Binding.NONE && binding.isGamepad()) labels.add(binding);
     return labels.toArray(new Binding[0]);
   }
 }


### PR DESCRIPTION
- Add `None` as the default first option for mouse, keyboard, and gamepad secondary binding lists so second bindings can be left unset.
- Add shared container naming helpers that derive new container names from the selected Wine/Proton version and make duplicate names unique with numeric suffixes.
- Update container creation to replace generic `Container-<id>` defaults with runtime-version names and keep the create dialog auto-name synced to the selected Wine/Proton version until manually edited.
- Update Google Drive backup filename fallback to use the runtime-version-based container name when a container name is empty.
- Validate with `./gradlew.bat :app:compileStandardDebugKotlin :app:compileStandardDebugJavaWithJavac`.
