### PR TITLE
fix controller mappings and session stability

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -3,6 +3,7 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
+import com.winlator.cmod.app.db.PluviaDatabase
 import com.winlator.cmod.app.update.UpdateChecker
 import com.winlator.cmod.feature.stores.gog.service.GOGAuthManager
 import com.winlator.cmod.feature.stores.gog.service.GOGConstants
@@ -132,6 +133,9 @@ class PluviaApp : Application() {
                 if (UpdateChecker.isEnabled(this@PluviaApp)) {
                     UpdateChecker.refreshInstallTimestamp(this@PluviaApp)
                 }
+
+                runCatching { PluviaDatabase.init(this@PluviaApp) }
+                    .onFailure { Log.e("PluviaApp", "Database warmup failed", it) }
 
                 com.winlator.cmod.runtime.system.LogManager
                     .rotateLogsOnAppStart(this@PluviaApp)

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -1315,7 +1315,7 @@ class UnifiedActivity :
                                 }
                             } else {
                                 val steam = steamApps.find { it.id == selectedSteamAppId }
-                                if (steam != null && SteamService.isAppInstalled(steam.id)) {
+                                if (steam != null) {
                                     launchSteamGame(context, containerManager, steam)
                                 }
                             }
@@ -5102,7 +5102,7 @@ class UnifiedActivity :
                 launchGogGame(context, containerManager, gogGame)
             } else if (isEpic) {
                 epicGame?.let { launchEpicGame(context, containerManager, it) }
-            } else if (SteamService.isAppInstalled(app.id)) {
+            } else {
                 launchSteamGame(context, containerManager, app)
             }
         }
@@ -7284,6 +7284,7 @@ class UnifiedActivity :
         var isLoading by remember { mutableStateOf(true) }
         var manifestSizes by remember { mutableStateOf(SteamService.ManifestSizes()) }
         var dlcApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
+        var installed by remember(app.id) { mutableStateOf<Boolean?>(null) }
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
         var showCustomPathWarning by remember { mutableStateOf(false) }
@@ -7360,13 +7361,17 @@ class UnifiedActivity :
         val selectedDlcIdsKey = selectedDlcIds.toList().sorted().joinToString(",")
 
         LaunchedEffect(app.id) {
-            val (downloadableDlcApps, sizes) =
+            val (downloadableDlcApps, sizes, isInstalled) =
                 withContext(Dispatchers.IO) {
-                    (db.steamAppDao().findDownloadableDLCApps(app.id) ?: emptyList<SteamApp>()) to
-                        SteamService.getSelectedManifestSizes(app.id)
+                    Triple(
+                        db.steamAppDao().findDownloadableDLCApps(app.id) ?: emptyList(),
+                        SteamService.getSelectedManifestSizes(app.id),
+                        SteamService.isAppInstalled(app.id),
+                    )
                 }
             dlcApps = downloadableDlcApps
             manifestSizes = sizes
+            installed = isInstalled
             isLoading = false
         }
 
@@ -7396,7 +7401,6 @@ class UnifiedActivity :
             }
         val isInstallEnabled = availableBytes >= totalInstallSize
         val installPathDisplay = customPath ?: SteamService.defaultAppInstallPath
-        val installed = SteamService.isAppInstalled(app.id)
 
         StoreInstallDialogShell(
             title = app.name,
@@ -7430,7 +7434,7 @@ class UnifiedActivity :
                 }
             },
         ) {
-            if (!installed) {
+            if (installed == false) {
                 InstallButton(
                     loading = isLoading,
                     onClick = {
@@ -8385,34 +8389,34 @@ class UnifiedActivity :
         containerManager: ContainerManager,
         app: SteamApp,
     ) {
-        val gameInstallPath = SteamService.getAppDirPath(app.id)
-        val gameDir = java.io.File(gameInstallPath)
-        if (!gameDir.exists()) {
-            com.winlator.cmod.shared.android.AppUtils.showToast(
-                context,
-                "Game not installed: ${app.name}",
-                android.widget.Toast.LENGTH_SHORT,
-            )
-            return
-        }
-
-        val shortcut =
-            containerManager.loadShortcuts().find {
-                it.getExtra("game_source") == "STEAM" && it.getExtra("app_id") == app.id.toString()
+        lifecycleScope.launch(Dispatchers.IO) {
+            val gameInstallPath = SteamService.getAppDirPath(app.id)
+            val gameDir = java.io.File(gameInstallPath)
+            if (!gameDir.exists()) {
+                withContext(Dispatchers.Main) {
+                    com.winlator.cmod.shared.android.AppUtils.showToast(
+                        context,
+                        "Game not installed: ${app.name}",
+                        android.widget.Toast.LENGTH_SHORT,
+                    )
+                }
+                return@launch
             }
 
-        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main).launch {
-            val launchExecutable =
-                withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    SteamService.getInstalledExe(app.id)
+            val shortcut =
+                containerManager.loadShortcuts().find {
+                    it.getExtra("game_source") == "STEAM" && it.getExtra("app_id") == app.id.toString()
                 }
+            val launchExecutable = SteamService.getInstalledExe(app.id)
 
             if (shortcut != null) {
                 if (!SetupWizardActivity.isContainerUsable(context, shortcut.container)) {
-                    SetupWizardActivity.promptToInstallWineOrCreateContainer(
-                        context,
-                        shortcut.container.wineVersion,
-                    )
+                    withContext(Dispatchers.Main) {
+                        SetupWizardActivity.promptToInstallWineOrCreateContainer(
+                            context,
+                            shortcut.container.wineVersion,
+                        )
+                    }
                     return@launch
                 }
                 ensureGameDrive(shortcut.container, gameInstallPath)
@@ -8443,12 +8447,16 @@ class UnifiedActivity :
                 intent.putExtra("container_id", shortcut.container.id)
                 intent.putExtra("shortcut_path", shortcut.file.path)
                 intent.putExtra("shortcut_name", shortcut.name)
-                launchGame(context, intent)
+                withContext(Dispatchers.Main) {
+                    launchGame(context, intent)
+                }
             } else {
                 val container = SetupWizardActivity.getPreferredGameContainer(context, containerManager)
 
                 if (container == null) {
-                    SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                    withContext(Dispatchers.Main) {
+                        SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                    }
                     return@launch
                 }
 
@@ -8483,7 +8491,9 @@ class UnifiedActivity :
                 intent.putExtra("container_id", container.id)
                 intent.putExtra("shortcut_path", shortcutFile.path)
                 intent.putExtra("shortcut_name", app.name)
-                launchGame(context, intent)
+                withContext(Dispatchers.Main) {
+                    launchGame(context, intent)
+                }
             }
         }
     }
@@ -8493,40 +8503,40 @@ class UnifiedActivity :
         containerManager: ContainerManager,
         app: EpicGame,
     ) {
-        val gameInstallPath = app.installPath.takeIf { it.isNotEmpty() } ?: EpicConstants.getGameInstallPath(context, app.appName)
-        val gameDir = java.io.File(gameInstallPath)
-        if (!gameDir.exists()) {
-            com.winlator.cmod.shared.android.AppUtils.showToast(
-                context,
-                "Game not installed: ${app.title}",
-                android.widget.Toast.LENGTH_SHORT,
-            )
-            return
-        }
-
-        // Try to find an existing shortcut first (preserves per-game settings)
-        var existingShortcut =
-            containerManager.loadShortcuts().find {
-                it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == app.id.toString()
+        lifecycleScope.launch(Dispatchers.IO) {
+            val gameInstallPath = app.installPath.takeIf { it.isNotEmpty() } ?: EpicConstants.getGameInstallPath(context, app.appName)
+            val gameDir = java.io.File(gameInstallPath)
+            if (!gameDir.exists()) {
+                withContext(Dispatchers.Main) {
+                    com.winlator.cmod.shared.android.AppUtils.showToast(
+                        context,
+                        "Game not installed: ${app.title}",
+                        android.widget.Toast.LENGTH_SHORT,
+                    )
+                }
+                return@launch
             }
 
-        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main).launch {
-            val launchArgsResult =
-                withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    EpicGameLauncher.buildLaunchParameters(context, app)
+            // Try to find an existing shortcut first (preserves per-game settings)
+            val existingShortcut =
+                containerManager.loadShortcuts().find {
+                    it.getExtra("game_source") == "EPIC" && it.getExtra("app_id") == app.id.toString()
                 }
+            val launchArgsResult = EpicGameLauncher.buildLaunchParameters(context, app)
             val args = launchArgsResult.getOrNull()?.joinToString(" ") ?: ""
 
             if (existingShortcut != null) {
-                if (!SetupWizardActivity.isContainerUsable(context, existingShortcut!!.container)) {
-                    SetupWizardActivity.promptToInstallWineOrCreateContainer(
-                        context,
-                        existingShortcut!!.container.wineVersion,
-                    )
+                if (!SetupWizardActivity.isContainerUsable(context, existingShortcut.container)) {
+                    withContext(Dispatchers.Main) {
+                        SetupWizardActivity.promptToInstallWineOrCreateContainer(
+                            context,
+                            existingShortcut.container.wineVersion,
+                        )
+                    }
                     return@launch
                 }
                 // Existing shortcut found: preserve per-game settings and update the mapped install path
-                val shortcut = existingShortcut!!
+                val shortcut = existingShortcut
                 // Ensure game_install_path is always up-to-date
                 shortcut.putExtra("game_install_path", gameInstallPath)
                 ensureGameDrive(shortcut.container, gameInstallPath)
@@ -8537,7 +8547,7 @@ class UnifiedActivity :
                     currentPath == "A:\\" || currentPath == "A:\\\\" ||
                     currentPath.startsWith("A:\\")
                 ) {
-                    var exePath = withContext(kotlinx.coroutines.Dispatchers.IO) { EpicService.getInstalledExe(app.id) }
+                    val exePath = EpicService.getInstalledExe(app.id)
                     val newExecCmd =
                         if (exePath.isNotEmpty()) {
                             buildStoreWineExecCommand(
@@ -8578,15 +8588,18 @@ class UnifiedActivity :
                 intent.putExtra("shortcut_path", shortcut.file.path)
                 intent.putExtra("shortcut_name", shortcut.name)
                 intent.putExtra("extra_exec_args", args) // Pass fresh tokens
-                launchGame(context, intent)
+                withContext(Dispatchers.Main) {
+                    launchGame(context, intent)
+                }
             } else {
                 // No existing shortcut — create a new one
-                var exePath = withContext(kotlinx.coroutines.Dispatchers.IO) { EpicService.getInstalledExe(app.id) }
-
-                var container = SetupWizardActivity.getPreferredGameContainer(context, containerManager)
+                val exePath = EpicService.getInstalledExe(app.id)
+                val container = SetupWizardActivity.getPreferredGameContainer(context, containerManager)
 
                 if (container == null) {
-                    SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                    withContext(Dispatchers.Main) {
+                        SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                    }
                     return@launch
                 }
 
@@ -8634,7 +8647,9 @@ class UnifiedActivity :
                 intent.putExtra("shortcut_path", shortcutFile.path)
                 intent.putExtra("shortcut_name", app.title)
                 intent.putExtra("extra_exec_args", args) // Pass fresh tokens
-                launchGame(context, intent)
+                withContext(Dispatchers.Main) {
+                    launchGame(context, intent)
+                }
             }
         }
     }
@@ -8644,35 +8659,37 @@ class UnifiedActivity :
         containerManager: ContainerManager,
         app: GOGGame,
     ) {
-        val gameInstallPath = app.installPath.takeIf { it.isNotEmpty() } ?: GOGConstants.getGameInstallPath(app.title)
-        val gameDir = java.io.File(gameInstallPath)
-        if (!gameDir.exists()) {
-            com.winlator.cmod.shared.android.AppUtils.showToast(
-                context,
-                "Game not installed: ${app.title}",
-                android.widget.Toast.LENGTH_SHORT,
-            )
-            return
-        }
-
-        var existingShortcut =
-            containerManager.loadShortcuts().find {
-                it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == app.id
+        lifecycleScope.launch(Dispatchers.IO) {
+            val gameInstallPath = app.installPath.takeIf { it.isNotEmpty() } ?: GOGConstants.getGameInstallPath(app.title)
+            val gameDir = java.io.File(gameInstallPath)
+            if (!gameDir.exists()) {
+                withContext(Dispatchers.Main) {
+                    com.winlator.cmod.shared.android.AppUtils.showToast(
+                        context,
+                        "Game not installed: ${app.title}",
+                        android.widget.Toast.LENGTH_SHORT,
+                    )
+                }
+                return@launch
             }
 
-        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main).launch {
+            val existingShortcut =
+                containerManager.loadShortcuts().find {
+                    it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == app.id
+                }
+
             val gogAppId = "GOG_${app.id}"
-            withContext(kotlinx.coroutines.Dispatchers.IO) {
-                GOGService.syncCloudSaves(context, gogAppId)
-            }
+            GOGService.syncCloudSaves(context, gogAppId)
 
             if (existingShortcut != null) {
-                val shortcut = existingShortcut!!
+                val shortcut = existingShortcut
                 if (!SetupWizardActivity.isContainerUsable(context, shortcut.container)) {
-                    SetupWizardActivity.promptToInstallWineOrCreateContainer(
-                        context,
-                        shortcut.container.wineVersion,
-                    )
+                    withContext(Dispatchers.Main) {
+                        SetupWizardActivity.promptToInstallWineOrCreateContainer(
+                            context,
+                            shortcut.container.wineVersion,
+                        )
+                    }
                     return@launch
                 }
                 shortcut.putExtra("game_install_path", gameInstallPath)
@@ -8706,10 +8723,7 @@ class UnifiedActivity :
                         } else {
                             val libraryItem =
                                 LibraryItem("GOG_${app.id}", app.title, com.winlator.cmod.feature.stores.steam.enums.GameSource.GOG)
-                            val exePath =
-                                withContext(kotlinx.coroutines.Dispatchers.IO) {
-                                    GOGService.getInstalledExe(libraryItem)
-                                }
+                            val exePath = GOGService.getInstalledExe(libraryItem)
                             if (exePath.isNotEmpty()) {
                                 buildStoreWineExecCommand(
                                     shortcut.container,
@@ -8749,20 +8763,21 @@ class UnifiedActivity :
                 intent.putExtra("container_id", shortcut.container.id)
                 intent.putExtra("shortcut_path", shortcut.file.path)
                 intent.putExtra("shortcut_name", shortcut.name)
-                launchGame(context, intent)
+                withContext(Dispatchers.Main) {
+                    launchGame(context, intent)
+                }
                 return@launch
             }
 
             val libraryItem = LibraryItem("GOG_${app.id}", app.title, com.winlator.cmod.feature.stores.steam.enums.GameSource.GOG)
-            val exePath =
-                withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    GOGService.getInstalledExe(libraryItem)
-                }
+            val exePath = GOGService.getInstalledExe(libraryItem)
 
-            var container = SetupWizardActivity.getPreferredGameContainer(context, containerManager)
+            val container = SetupWizardActivity.getPreferredGameContainer(context, containerManager)
 
             if (container == null) {
-                SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                withContext(Dispatchers.Main) {
+                    SetupWizardActivity.promptToInstallWineOrCreateContainer(context)
+                }
                 return@launch
             }
 
@@ -8809,7 +8824,9 @@ class UnifiedActivity :
             intent.putExtra("container_id", container.id)
             intent.putExtra("shortcut_path", shortcutFile.path)
             intent.putExtra("shortcut_name", app.title)
-            launchGame(context, intent)
+            withContext(Dispatchers.Main) {
+                launchGame(context, intent)
+            }
         }
     }
 
@@ -8887,55 +8904,61 @@ class UnifiedActivity :
         containerManager: ContainerManager,
         gameName: String,
     ) {
-        val allShortcuts = containerManager.loadShortcuts()
+        lifecycleScope.launch(Dispatchers.IO) {
+            val allShortcuts = containerManager.loadShortcuts()
 
-        // Try matching by app_id (for non-official Steam/Epic), custom_name, or filename
-        var shortcut =
-            allShortcuts.find { it.getExtra("app_id") == gameName }
-                ?: allShortcuts.find { it.getExtra("custom_name") == gameName }
-                ?: allShortcuts.find { it.name == gameName }
-                ?: allShortcuts.find { it.name == gameName.replace("/", "_").replace("\\", "_") }
+            // Try matching by app_id (for non-official Steam/Epic), custom_name, or filename
+            var shortcut =
+                allShortcuts.find { it.getExtra("app_id") == gameName }
+                    ?: allShortcuts.find { it.getExtra("custom_name") == gameName }
+                    ?: allShortcuts.find { it.name == gameName }
+                    ?: allShortcuts.find { it.name == gameName.replace("/", "_").replace("\\", "_") }
 
-        // If still not found, try matching by looking at the safe filename directly
-        if (shortcut == null) {
-            val safeName = gameName.replace("/", "_").replace("\\", "_")
-            for (container in containerManager.containers) {
-                val desktopFile = java.io.File(container.getDesktopDir(), "$safeName.desktop")
-                if (desktopFile.exists()) {
-                    shortcut =
-                        com.winlator.cmod.runtime.container
-                            .Shortcut(container, desktopFile)
-                    break
+            // If still not found, try matching by looking at the safe filename directly
+            if (shortcut == null) {
+                val safeName = gameName.replace("/", "_").replace("\\", "_")
+                for (container in containerManager.containers) {
+                    val desktopFile = java.io.File(container.getDesktopDir(), "$safeName.desktop")
+                    if (desktopFile.exists()) {
+                        shortcut =
+                            com.winlator.cmod.runtime.container
+                                .Shortcut(container, desktopFile)
+                        break
+                    }
                 }
             }
-        }
 
-        if (shortcut == null) {
-            com.winlator.cmod.shared.android.AppUtils.showToast(
-                context,
-                "Custom game shortcut not found: $gameName",
-                android.widget.Toast.LENGTH_SHORT,
-            )
-            return
-        }
+            if (shortcut == null) {
+                withContext(Dispatchers.Main) {
+                    com.winlator.cmod.shared.android.AppUtils.showToast(
+                        context,
+                        "Custom game shortcut not found: $gameName",
+                        android.widget.Toast.LENGTH_SHORT,
+                    )
+                }
+                return@launch
+            }
 
-        // Backfill custom_name if missing (legacy shortcuts)
-        if (shortcut.getExtra("custom_name").isEmpty()) {
-            shortcut.putExtra("custom_name", gameName)
-            shortcut.saveData()
-        }
+            // Backfill custom_name if missing (legacy shortcuts)
+            if (shortcut.getExtra("custom_name").isEmpty()) {
+                shortcut.putExtra("custom_name", gameName)
+                shortcut.saveData()
+            }
 
-        // Ensure the custom game folder is mapped into the container.
-        val gameFolder = shortcut.getExtra("custom_game_folder", "")
-        if (gameFolder.isNotEmpty()) {
-            ensureGameDrive(shortcut.container, gameFolder, "F")
-            shortcut.container.saveData()
+            // Ensure the custom game folder is mapped into the container.
+            val gameFolder = shortcut.getExtra("custom_game_folder", "")
+            if (gameFolder.isNotEmpty()) {
+                ensureGameDrive(shortcut.container, gameFolder, "F")
+                shortcut.container.saveData()
+            }
+            val intent = Intent(context, XServerDisplayActivity::class.java)
+            intent.putExtra("container_id", shortcut.container.id)
+            intent.putExtra("shortcut_path", shortcut.file.path)
+            intent.putExtra("shortcut_name", gameName)
+            withContext(Dispatchers.Main) {
+                launchGame(context, intent)
+            }
         }
-        val intent = Intent(context, XServerDisplayActivity::class.java)
-        intent.putExtra("container_id", shortcut.container.id)
-        intent.putExtra("shortcut_path", shortcut.file.path)
-        intent.putExtra("shortcut_name", gameName)
-        launchGame(context, intent)
     }
 
     private fun launchGame(

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
+import android.util.Log
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -296,6 +297,12 @@ class UnifiedActivity :
     // dialog is open, so the ~120 Hz animation cost isn't paid for content
     // the user can't see or interact with.
     private val chasingBordersPaused = mutableStateOf(false)
+
+    // Keep the first composition light until secure prefs/auth state and the Room DB
+    // are primed off the UI thread. Rapid relaunches after task removal otherwise
+    // hit cold-start work here and can stall input.
+    private var startupBootstrapReady by mutableStateOf(false)
+    private var startupLibraryLayoutMode by mutableStateOf<LibraryLayoutMode?>(null)
 
     // LibraryCarousel is always composed (kept alive behind an alpha(0f) when
     // another tab is active). This flag lets GameCapsule skip its animation
@@ -706,6 +713,38 @@ class UnifiedActivity :
         handleSettingsIntent(intent)
     }
 
+    private fun bootstrapStartupState() {
+        startupBootstrapReady = false
+        startupLibraryLayoutMode = null
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val appContext = applicationContext
+            val resolvedLayoutMode =
+                runCatching {
+                    PrefManager.init(appContext)
+                    LibraryLayoutMode.valueOf(PrefManager.libraryLayoutMode)
+                }.getOrElse { error ->
+                    Log.w("UnifiedActivity", "Failed to resolve initial library layout", error)
+                    LibraryLayoutMode.GRID_4
+                }
+
+            runCatching { dbProvider.get() }
+                .onFailure { Log.w("UnifiedActivity", "Database warmup failed", it) }
+            runCatching { EpicAuthManager.updateLoginStatus(appContext) }
+                .onFailure { Log.w("UnifiedActivity", "Epic auth warmup failed", it) }
+            runCatching { GOGAuthManager.updateLoginStatus(appContext) }
+                .onFailure { Log.w("UnifiedActivity", "GOG auth warmup failed", it) }
+            runCatching { SteamService.initLoginStatus(appContext) }
+                .onFailure { Log.w("UnifiedActivity", "Steam auth warmup failed", it) }
+
+            withContext(Dispatchers.Main.immediate) {
+                startupLibraryLayoutMode = resolvedLayoutMode
+                currentLibraryLayoutMode = resolvedLayoutMode
+                startupBootstrapReady = true
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         instance = this
         super.onCreate(savedInstanceState)
@@ -721,8 +760,7 @@ class UnifiedActivity :
         }
 
         supportFragmentManager.registerFragmentLifecycleCallbacks(inputControlsFragmentTracker, true)
-        EpicAuthManager.updateLoginStatus(this)
-        SteamService.initLoginStatus(this)
+        bootstrapStartupState()
 
         // Surface store-session events (e.g. Epic refresh-token death, cloud restore) as toasts.
         lifecycleScope.launch {
@@ -1014,6 +1052,30 @@ class UnifiedActivity :
     // Main scaffold
     @Composable
     fun UnifiedHub() {
+        val initialLibraryLayoutMode = startupLibraryLayoutMode
+        if (!startupBootstrapReady || initialLibraryLayoutMode == null) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(BgDark),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    CircularProgressIndicator(color = Accent)
+                    Text(
+                        text = stringResource(R.string.common_ui_app_name),
+                        color = TextPrimary,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+            }
+            return
+        }
+
         val storeVisible = remember { mutableStateMapOf("steam" to true, "epic" to true, "gog" to true) }
         var showAddCustomGame by remember { mutableStateOf(false) }
         var showExitDialog by remember { mutableStateOf(false) }
@@ -1029,8 +1091,7 @@ class UnifiedActivity :
         val contentFilters = remember { mutableStateMapOf("games" to true, "dlc" to false, "applications" to false, "tools" to false) }
         var libraryLayoutMode by remember {
             mutableStateOf(
-                runCatching { LibraryLayoutMode.valueOf(PrefManager.libraryLayoutMode) }
-                    .getOrDefault(LibraryLayoutMode.GRID_4),
+                initialLibraryLayoutMode,
             )
         }
         val tabs = remember(storeVisible.toMap()) { buildTabs(storeVisible) }
@@ -1950,61 +2011,74 @@ class UnifiedActivity :
         // Load all shortcuts once and cache for both custom app discovery and GameCapsule icon lookup
         var cachedShortcuts by remember { mutableStateOf<List<Shortcut>>(emptyList()) }
         var customApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
+        var shortcutsLoaded by remember { mutableStateOf(false) }
         LaunchedEffect(libraryRefreshKey) {
-            withContext(Dispatchers.IO) {
-                try {
-                    val cm = ContainerManager(context)
-                    val allShortcuts = cm.loadShortcuts()
-                    val apps =
-                        allShortcuts
-                            .mapNotNull { shortcut ->
-                                if (!LibraryShortcutUtils.isCustomLibraryShortcut(shortcut)) {
-                                    return@mapNotNull null
+            shortcutsLoaded = false
+
+            val shortcutScanResult =
+                runCatching {
+                    withContext(Dispatchers.IO) {
+                        val cm = ContainerManager(context)
+                        val allShortcuts = cm.loadShortcuts()
+                        val apps =
+                            allShortcuts
+                                .mapNotNull { shortcut ->
+                                    if (!LibraryShortcutUtils.isCustomLibraryShortcut(shortcut)) {
+                                        return@mapNotNull null
+                                    }
+
+                                    val displayName =
+                                        shortcut
+                                            .getExtra("custom_name", shortcut.name)
+                                            .ifBlank { shortcut.name }
+                                    val customId = -(displayName.hashCode().and(0x7FFFFFFF) + 1)
+
+                                    SteamApp(
+                                        id = customId,
+                                        name = displayName,
+                                        developer = "Custom",
+                                        gameDir =
+                                            shortcut.getExtra(
+                                                "game_install_path",
+                                                shortcut.getExtra("custom_game_folder", ""),
+                                            ),
+                                    )
                                 }
 
-                                val displayName =
-                                    shortcut
-                                        .getExtra("custom_name", shortcut.name)
-                                        .ifBlank { shortcut.name }
-                                val customId = -(displayName.hashCode().and(0x7FFFFFFF) + 1)
-
-                                SteamApp(
-                                    id = customId,
-                                    name = displayName,
-                                    developer = "Custom",
-                                    gameDir =
-                                        shortcut.getExtra(
-                                            "game_install_path",
-                                            shortcut.getExtra("custom_game_folder", ""),
-                                        ),
-                                )
-                            }
-                    withContext(Dispatchers.Main) {
-                        cachedShortcuts = allShortcuts
-                        customApps = apps
+                        allShortcuts to apps
                     }
-                } catch (_: Exception) {
-                }
+                }.getOrNull()
+
+            if (shortcutScanResult != null) {
+                cachedShortcuts = shortcutScanResult.first
+                customApps = shortcutScanResult.second
             }
+
+            shortcutsLoaded = true
         }
 
         // Move expensive filtering (runBlocking DB queries, file I/O) off the main thread.
         // This set only changes on real library mutations; playtime resorts are handled separately.
         var mergedInstalledApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var installedApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
+        var stableInstalledApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var gogByPseudoId by remember { mutableStateOf<Map<Int, GOGGame>>(emptyMap()) }
         var epicByPseudoId by remember { mutableStateOf<Map<Int, EpicGame>>(emptyMap()) }
+        var stableGogByPseudoId by remember { mutableStateOf<Map<Int, GOGGame>>(emptyMap()) }
+        var stableEpicByPseudoId by remember { mutableStateOf<Map<Int, EpicGame>>(emptyMap()) }
         var customArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
         var customIconPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var stableCustomArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var stableCustomIconPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
         var libraryLoaded by remember { mutableStateOf(false) }
-        // Track whether the LaunchedEffect is still reprocessing after input changes
-        // so we don't flash the empty state while filtering is in progress.
-        var scanVersion by remember { mutableIntStateOf(0) }
-        var processedScanVersion by remember { mutableIntStateOf(0) }
+        // Track whether a new source snapshot is awaiting recomputation. The token
+        // changes during composition as soon as any input list changes, so we can
+        // suppress transient empty states before the background coroutine starts.
+        val scanInputToken =
+            remember(steamApps, epicApps, gogApps, customApps, libraryRefreshKey) { Any() }
+        var processedScanToken by remember { mutableStateOf<Any?>(null) }
 
-        LaunchedEffect(steamApps, epicApps, gogApps, customApps, libraryRefreshKey) {
-            scanVersion++
-            val requestedVersion = scanVersion
+        LaunchedEffect(scanInputToken) {
             withContext(Dispatchers.IO) {
                 val steamInstalled = steamApps.filter { SteamService.isAppInstalled(it.id) }
 
@@ -2052,8 +2126,13 @@ class UnifiedActivity :
                     epicByPseudoId = epicMap
                     mergedInstalledApps = merged
                     installedApps = sorted
+                    if (sorted.isNotEmpty()) {
+                        stableInstalledApps = sorted
+                        stableGogByPseudoId = gogMap
+                        stableEpicByPseudoId = epicMap
+                    }
                     libraryLoaded = true
-                    processedScanVersion = requestedVersion
+                    processedScanToken = scanInputToken
                 }
             }
         }
@@ -2106,6 +2185,10 @@ class UnifiedActivity :
 
             customArtworkPathByAppId = artworkPaths
             customIconPathByAppId = customIconPaths
+            if (appsSnapshot.isNotEmpty()) {
+                stableCustomArtworkPathByAppId = artworkPaths
+                stableCustomIconPathByAppId = customIconPaths
+            }
         }
 
         LaunchedEffect(mergedInstalledApps, playtimeRefreshKey) {
@@ -2132,22 +2215,31 @@ class UnifiedActivity :
             installedApps = sorted
         }
 
+        val awaitingShortcutScan = installedApps.isEmpty() && !shortcutsLoaded
+        val keepPreviousLibraryVisible =
+            installedApps.isEmpty() &&
+                stableInstalledApps.isNotEmpty() &&
+                (processedScanToken !== scanInputToken || awaitingShortcutScan)
+        val visibleInstalledApps = if (keepPreviousLibraryVisible) stableInstalledApps else installedApps
+        val visibleGogByPseudoId = if (keepPreviousLibraryVisible) stableGogByPseudoId else gogByPseudoId
+        val visibleEpicByPseudoId = if (keepPreviousLibraryVisible) stableEpicByPseudoId else epicByPseudoId
+        val visibleCustomArtworkPathByAppId =
+            if (keepPreviousLibraryVisible) stableCustomArtworkPathByAppId else customArtworkPathByAppId
+        val visibleCustomIconPathByAppId =
+            if (keepPreviousLibraryVisible) stableCustomIconPathByAppId else customIconPathByAppId
+
         val displayedApps =
-            remember(installedApps, searchQuery) {
+            remember(visibleInstalledApps, searchQuery) {
                 if (searchQuery.isBlank()) {
-                    installedApps
+                    visibleInstalledApps
                 } else {
-                    installedApps.filter { it.name.contains(searchQuery, ignoreCase = true) }
+                    visibleInstalledApps.filter { it.name.contains(searchQuery, ignoreCase = true) }
                 }
             }
 
-        // Show a loading spinner until the first library scan completes,
-        // with a minimum display time so it doesn't flash
-        var minTimeElapsed by remember { mutableStateOf(false) }
-        LaunchedEffect(Unit) {
-            delay(500)
-            minTimeElapsed = true
-        }
+        // The startup bootstrap screen already masks the first frame. Do not
+        // force an extra minimum spinner duration here or the library visibly
+        // bounces through two loading states on launch.
         // A logged-in store whose owned-apps list is still empty hasn't finished
         // its initial library fetch yet — keep the spinner up instead of flashing
         // "No games installed". This resolves itself once the store populates its
@@ -2159,7 +2251,13 @@ class UnifiedActivity :
                     (epicApps.isEmpty() && EpicService.hasStoredCredentials(context)) ||
                     (gogApps.isEmpty() && GOGAuthManager.isLoggedIn(context))
             )
-        val showLoading = !libraryLoaded || !minTimeElapsed || processedScanVersion < scanVersion || awaitingStoreSync
+        // Only block the surface while the first library result is unresolved.
+        // After that, keep the current content/empty state visible during
+        // background refreshes so the UI does not flicker back to a spinner.
+        val initialLibraryLoadPending = !libraryLoaded
+        val waitingForFirstEmptyStateResolution =
+            installedApps.isEmpty() && (processedScanToken !== scanInputToken || awaitingStoreSync || awaitingShortcutScan)
+        val showLoading = initialLibraryLoadPending || waitingForFirstEmptyStateResolution
         if (showLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 val spinAlpha by animateFloatAsState(
@@ -2176,7 +2274,7 @@ class UnifiedActivity :
             return
         }
 
-        if (installedApps.isEmpty()) {
+        if (visibleInstalledApps.isEmpty()) {
             val epicLoggedIn by EpicAuthManager.isLoggedInFlow.collectAsState()
             val gogLoggedIn by GOGAuthManager.isLoggedInFlow.collectAsState()
             val anyLoggedIn = isLoggedIn || epicLoggedIn || gogLoggedIn
@@ -2254,7 +2352,7 @@ class UnifiedActivity :
             val app = displayedApps.getOrNull(focusIndex) ?: displayedApps.firstOrNull()
             selectedSteamAppId = app?.id ?: 0
             selectedSteamAppName = app?.name ?: ""
-            val gogGame = app?.let { gogByPseudoId[it.id] }
+            val gogGame = app?.let { visibleGogByPseudoId[it.id] }
             selectedLibrarySource =
                 when {
                     gogGame != null -> "GOG"
@@ -2270,7 +2368,7 @@ class UnifiedActivity :
             activity?.libraryFocusIndex?.value = index
             selectedSteamAppId = app.id
             selectedSteamAppName = app.name
-            val gogGame = gogByPseudoId[app.id]
+            val gogGame = visibleGogByPseudoId[app.id]
             selectedLibrarySource =
                 when {
                     gogGame != null -> "GOG"
@@ -2299,15 +2397,15 @@ class UnifiedActivity :
                 ) { app, index, rowHeight ->
                     GameCapsule(
                         app = app,
-                        gogGame = gogByPseudoId[app.id],
-                        epicGame = epicByPseudoId[app.id],
+                        gogGame = visibleGogByPseudoId[app.id],
+                        epicGame = visibleEpicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = index == focusIndex,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
-                        customIconPath = customIconPathByAppId[app.id],
+                        customArtworkPath = visibleCustomArtworkPathByAppId[app.id],
+                        customIconPath = visibleCustomIconPathByAppId[app.id],
                         onClick = {
-                            detailGogGame = gogByPseudoId[app.id]
+                            detailGogGame = visibleGogByPseudoId[app.id]
                             detailApp = app
                         },
                         onLongClick = {
@@ -2341,15 +2439,15 @@ class UnifiedActivity :
                 ) { app, index, isSelected, cardWidth, cardHeight ->
                     GameCapsule(
                         app = app,
-                        gogGame = gogByPseudoId[app.id],
-                        epicGame = epicByPseudoId[app.id],
+                        gogGame = visibleGogByPseudoId[app.id],
+                        epicGame = visibleEpicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
-                        customIconPath = customIconPathByAppId[app.id],
+                        customArtworkPath = visibleCustomArtworkPathByAppId[app.id],
+                        customIconPath = visibleCustomIconPathByAppId[app.id],
                         onClick = {
-                            detailGogGame = gogByPseudoId[app.id]
+                            detailGogGame = visibleGogByPseudoId[app.id]
                             detailApp = app
                         },
                         onLongClick = { openSettingsForApp(index, app) },
@@ -2383,15 +2481,15 @@ class UnifiedActivity :
                 ) { app, index, isSelected ->
                     GameCapsule(
                         app = app,
-                        gogGame = gogByPseudoId[app.id],
-                        epicGame = epicByPseudoId[app.id],
+                        gogGame = visibleGogByPseudoId[app.id],
+                        epicGame = visibleEpicByPseudoId[app.id],
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
-                        customIconPath = customIconPathByAppId[app.id],
+                        customArtworkPath = visibleCustomArtworkPathByAppId[app.id],
+                        customIconPath = visibleCustomIconPathByAppId[app.id],
                         onClick = {
-                            detailGogGame = gogByPseudoId[app.id]
+                            detailGogGame = visibleGogByPseudoId[app.id]
                             detailApp = app
                         },
                         onLongClick = { openSettingsForApp(index, app) },

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -10,8 +10,8 @@
     <integer name="keycode_button_l2">104</integer> <!-- KeyEvent.KEYCODE_BUTTON_L2 -->
     <integer name="keycode_button_start">108</integer> <!-- KeyEvent.KEYCODE_BUTTON_START -->
     <integer name="keycode_button_select">109</integer> <!-- KeyEvent.KEYCODE_BUTTON_SELECT -->
-    <integer name="keycode_button_r3">106</integer> <!-- KeyEvent.KEYCODE_BUTTON_R3 -->
-    <integer name="keycode_button_l3">107</integer> <!-- KeyEvent.KEYCODE_BUTTON_L3 -->
+    <integer name="keycode_button_r3">107</integer> <!-- KeyEvent.KEYCODE_BUTTON_THUMBR (R3) -->
+    <integer name="keycode_button_l3">106</integer> <!-- KeyEvent.KEYCODE_BUTTON_THUMBL (L3) -->
     <integer name="keycode_dpad_up">19</integer> <!-- KeyEvent.KEYCODE_DPAD_UP -->
     <integer name="keycode_dpad_down">20</integer> <!-- KeyEvent.KEYCODE_DPAD_DOWN -->
     <integer name="keycode_dpad_left">21</integer> <!-- KeyEvent.KEYCODE_DPAD_LEFT -->

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3090,10 +3090,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Check after applyGeneralPatches — container_pattern_common.tzst provides these files
         ensureWinePrefixEssentialFiles();
 
-        // Self-heal arm64ec containers that still carry the mis-packaged x86_64 xinput DLLs
-        // deployed by pre-Mar-2026 builds. No-op on healthy or non-arm64ec containers.
-        WineUtils.repairArm64ECXinputDlls(this, container, wineInfo);
-
         String dxwrapper = shortcut != null ? getShortcutSetting("dxwrapper", this.dxwrapper) : this.dxwrapper;
 
         if (dxwrapper.contains("dxvk")) {
@@ -3393,6 +3389,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 exclusiveXInput = extra.equals("1");
             }
         }
+        // Proton-version flips repair controller detection because they rebuild the prefix and
+        // restore controller DllOverrides. Keep that correction narrow and explicit here.
+        WineUtils.ensureControllerDllOverrides(container);
         WineUtils.setJoystickRegistryKeys(container, dinputEnabled, exclusiveXInput);
         WineUtils.ensureWinebusConfig(container);
 

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -656,51 +656,29 @@ public abstract class WineUtils {
     "xinput1_4.dll", "xinput9_1_0.dll", "xinputuap.dll"
   };
 
-  /**
-   * Heals arm64ec containers corrupted by pre-Mar-2026 builds that extracted a mis-packaged
-   * <code>xinput_virtual_arm64ec.tzst</code> — its name claimed arm64ec but its <code>system32/</code>
-   * payload was x86_64 PE binaries. Those builds also flipped xinput DllOverrides to
-   * {@code native,builtin} and set the container extra <code>xinput_virtual_deployed=10</code>.
-   *
-   * <p>Presence of that extra is the signal. We overwrite system32 xinput DLLs with the arm64
-   * builtins from the Proton tree, reset the xinput DllOverrides to {@code builtin,native}, then
-   * clear the flag so the heal runs at most once per container.
-   */
-  public static void repairArm64ECXinputDlls(
-      Context context, Container container, WineInfo wineInfo) {
-    if (container == null || wineInfo == null || !wineInfo.isArm64EC()) return;
-    if (!"10".equals(container.getExtra("xinput_virtual_deployed"))) return;
-    if (wineInfo.path == null || wineInfo.path.isEmpty()) return;
+  public static void ensureControllerDllOverrides(Container container) {
+    if (container == null) return;
 
-    File rootDir = ImageFs.find(context).getRootDir();
-    File srcDir = new File(wineInfo.path + "/lib/wine/aarch64-windows");
-    File dstDir = new File(rootDir, ImageFs.WINEPREFIX + "/drive_c/windows/system32");
+    File userRegFile = new File(container.getRootDir(), ".wine/user.reg");
+    if (!userRegFile.isFile()) return;
 
-    int restored = 0;
-    for (String dll : XINPUT_DLLS) {
-      File src = new File(srcDir, dll);
-      File dst = new File(dstDir, dll);
-      if (src.exists()) {
-        FileUtils.copy(src, dst);
-        restored++;
-      }
-    }
+    final String dllOverridesKey = "Software\\Wine\\DllOverrides";
+    final String[] dinputLibs = {"dinput", "dinput8"};
 
-    File userRegFile = new File(rootDir, ImageFs.WINEPREFIX + "/user.reg");
     try (WineRegistryEditor registryEditor = new WineRegistryEditor(userRegFile)) {
+      for (String name : dinputLibs) {
+        if (!"builtin,native".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
+          registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        }
+      }
+
       for (String dll : XINPUT_DLLS) {
         String name = dll.substring(0, dll.length() - 4);
-        registryEditor.setStringValue("Software\\Wine\\DllOverrides", name, "builtin,native");
+        if (!"builtin,native".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
+          registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        }
       }
     }
-
-    container.putExtra("xinput_virtual_deployed", null);
-    container.saveData();
-
-    Log.i(
-        "WineUtils",
-        "repairArm64ECXinputDlls: restored " + restored + " arm64 xinput DLL(s) in container "
-            + container.id + " and cleared xinput_virtual_deployed flag.");
   }
 
   /** Registers core Windows fonts and Wine fonts in the registry. */


### PR DESCRIPTION
- Includes `library fix`.
- Includes `ui stability fixes`.
- Restores `dinput`, `dinput8`, and `xinput*` `DllOverrides` to `builtin,native` on launch so controller detection no longer depends on switching Proton/Wine versions back and forth.
- Removes the legacy `arm64ec` xinput self-heal path that only applied to old broken prefixes.
- Fixes the gyroscope activator `R3`/`L3` keycodes so selecting `R3` stores the right stick button instead of the left stick button.
- Validation: `./gradlew.bat :app:compileStandardDebugJavaWithJavac`.