### PR TITLE
Allow fork PR release publishing

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,13 +6,11 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
-      - 'input_controls/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
       - '**.md'
       - '.gitignore'
-      - 'input_controls/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/pr-release-publish.yml
+++ b/.github/workflows/pr-release-publish.yml
@@ -29,7 +29,7 @@ jobs:
       PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - name: Verify PR is from this repository
+      - name: Verify PR targets this repository
         id: scope
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,11 +39,11 @@ jobs:
           head_repo=$(jq -r '.head.repo.full_name // ""' pr.json)
           base_repo=$(jq -r '.base.repo.full_name // ""' pr.json)
 
-          if [ "$head_repo" = "$SOURCE_REPO" ] && [ "$base_repo" = "$SOURCE_REPO" ]; then
+          if [ "$base_repo" = "$SOURCE_REPO" ]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
             echo "allowed=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping publish for fork PR: head=$head_repo base=$base_repo"
+            echo "Skipping publish for PR targeting a different repository: head=$head_repo base=$base_repo"
           fi
 
       - name: Download PR build artifacts

--- a/.github/workflows/pr-release-publish.yml
+++ b/.github/workflows/pr-release-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: none
       pull-requests: read
     env:
       SOURCE_REPO: ${{ github.repository }}
@@ -36,8 +36,8 @@ jobs:
         run: |
           gh api "repos/$SOURCE_REPO/pulls/$PR_NUMBER" > pr.json
 
-          head_repo=$(jq -r '.head.repo.full_name' pr.json)
-          base_repo=$(jq -r '.base.repo.full_name' pr.json)
+          head_repo=$(jq -r '.head.repo.full_name // ""' pr.json)
+          base_repo=$(jq -r '.base.repo.full_name // ""' pr.json)
 
           if [ "$head_repo" = "$SOURCE_REPO" ] && [ "$base_repo" = "$SOURCE_REPO" ]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
@@ -100,6 +100,8 @@ jobs:
         if: ${{ steps.scope.outputs.allowed == 'true' }}
         id: release
         env:
+          # Use a fine-grained PAT scoped only to MaxsTechReview/WinNative-CI
+          # with "Contents" repository permission set to write.
           GH_TOKEN: ${{ secrets.WINNATIVE_CI_TOKEN }}
         run: |
           tag="${{ steps.pr.outputs.tag }}"


### PR DESCRIPTION
This updates the PR release publish workflow so successful PR builds targeting `MaxsTechReview/WinNative` publish to `MaxsTechReview/WinNative-CI`, including PRs opened from forks.

It also keeps the tighter job permissions and documents that `WINNATIVE_CI_TOKEN` should be a fine-grained token scoped to the CI repo.

Validation: `git diff --check`.