### PR TITLE
Fix PR release asset upload for PR# APK names

### DIFF
--- a/.github/workflows/pr-release-publish.yml
+++ b/.github/workflows/pr-release-publish.yml
@@ -135,14 +135,31 @@ jobs:
               --prerelease
           fi
 
-          test -f "artifacts/standard/${{ steps.apk.outputs.standard }}"
-          test -f "artifacts/ludashi/${{ steps.apk.outputs.ludashi }}"
+          standard_path="artifacts/standard/${{ steps.apk.outputs.standard }}"
+          ludashi_path="artifacts/ludashi/${{ steps.apk.outputs.ludashi }}"
+          test -f "$standard_path"
+          test -f "$ludashi_path"
 
-          gh release upload "$tag" \
-            "artifacts/standard/${{ steps.apk.outputs.standard }}" \
-            "artifacts/ludashi/${{ steps.apk.outputs.ludashi }}" \
-            --repo "$TARGET_REPO" \
-            --clobber
+          release_id=$(gh api "repos/$TARGET_REPO/releases/tags/$tag" --jq '.id')
+
+          upload_asset() {
+            local file_path="$1"
+            local asset_name
+            asset_name=$(basename "$file_path")
+            local encoded_name
+            encoded_name=$(jq -rn --arg v "$asset_name" '$v|@uri')
+
+            gh release delete-asset "$tag" "$asset_name" --repo "$TARGET_REPO" --yes >/dev/null 2>&1 || true
+            gh api \
+              --method POST \
+              -H "Content-Type: application/vnd.android.package-archive" \
+              --input "$file_path" \
+              "repos/$TARGET_REPO/releases/$release_id/assets?name=$encoded_name" \
+              >/dev/null
+          }
+
+          upload_asset "$standard_path"
+          upload_asset "$ludashi_path"
 
           release_url=$(gh release view "$tag" --repo "$TARGET_REPO" --json url --jq '.url')
           {


### PR DESCRIPTION
## What changed
This updates `PR Release Publish` to upload APK assets to `WinNative-CI` through the GitHub Releases API instead of `gh release upload`.

## Why
The PR APK filenames now intentionally include `PR#<number>` so they can match the build artifact naming. `gh release upload` treats `#` inside an asset argument as the separator for an optional display label, which truncates paths like `WinNative-Debug-Standard-PR#250-f7b1c.apk` and causes the publish step to fail.

## Impact
PR release publishing can now upload the exact APK filenames produced by the PR CI workflow, including names containing `#`.

## Root cause
The release workflow was passing filenames with `#` directly to `gh release upload`, and the CLI parsed the path incorrectly before upload.

## Validation
- Cherry-picked only the release upload fix onto a fresh branch from `upstream/main`
- Ran `git diff --check`
- Confirmed the change is limited to `.github/workflows/pr-release-publish.yml`
