### PR TITLE
feat: Custom artwork for library games

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -147,6 +147,7 @@ import com.winlator.cmod.feature.settings.SettingsHost
 import com.winlator.cmod.feature.settings.SettingsNavItem
 import com.winlator.cmod.feature.setup.SetupWizardActivity
 import com.winlator.cmod.feature.shortcuts.LibraryShortcutUtils
+import com.winlator.cmod.feature.shortcuts.LibraryShortcutArtwork
 import com.winlator.cmod.feature.shortcuts.ShortcutBroadcastReceiver
 import com.winlator.cmod.feature.shortcuts.ShortcutSettingsComposeDialog
 import com.winlator.cmod.feature.shortcuts.ShortcutsFragment
@@ -1021,10 +1022,12 @@ class UnifiedActivity :
         var searchQueryTfv by remember { mutableStateOf(TextFieldValue("")) }
         val searchQuery = searchQueryTfv.text
         var localLibraryRefreshKey by remember { mutableIntStateOf(0) }
+        var shortcutDataRefreshKey by remember { mutableIntStateOf(0) }
         var iconRefreshKey by remember { mutableIntStateOf(0) }
 
         val currentRefreshSignal = this@UnifiedActivity.libraryRefreshSignal
         val libraryRefreshKey = currentRefreshSignal + localLibraryRefreshKey
+        val shortcutRefreshKey = libraryRefreshKey + shortcutDataRefreshKey
         val playtimeRefreshKey = this@UnifiedActivity.libraryPlaytimeRefreshSignal
 
         val contentFilters = remember { mutableStateMapOf("games" to true, "dlc" to false, "applications" to false, "tools" to false) }
@@ -1056,21 +1059,30 @@ class UnifiedActivity :
         val isPS = controllerState.isPlayStation
         val isLibraryTab = tabs.getOrNull(selectedIdx)?.key == "library"
 
-        val libraryInstallStatusListener =
+        val libraryRefreshListener =
             remember {
                 object : EventDispatcher.JavaEventListener {
                     override fun onEvent(event: Any) {
-                        if (event is AndroidEvent.LibraryInstallStatusChanged) {
-                            localLibraryRefreshKey++
-                            iconRefreshKey++
+                        when (event) {
+                            is AndroidEvent.LibraryInstallStatusChanged -> {
+                                localLibraryRefreshKey++
+                                shortcutDataRefreshKey++
+                                iconRefreshKey++
+                            }
+                            is AndroidEvent.LibraryArtworkChanged -> {
+                                shortcutDataRefreshKey++
+                                iconRefreshKey++
+                            }
                         }
                     }
                 }
             }
-        DisposableEffect(libraryInstallStatusListener) {
-            PluviaApp.events.onJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryInstallStatusListener)
+        DisposableEffect(libraryRefreshListener) {
+            PluviaApp.events.onJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryRefreshListener)
+            PluviaApp.events.onJava(AndroidEvent.LibraryArtworkChanged::class, libraryRefreshListener)
             onDispose {
-                PluviaApp.events.offJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryInstallStatusListener)
+                PluviaApp.events.offJava(AndroidEvent.LibraryInstallStatusChanged::class, libraryRefreshListener)
+                PluviaApp.events.offJava(AndroidEvent.LibraryArtworkChanged::class, libraryRefreshListener)
             }
         }
 
@@ -1385,6 +1397,7 @@ class UnifiedActivity :
                                 gogApps = gogApps,
                                 layoutMode = libraryLayoutMode,
                                 libraryRefreshKey = libraryRefreshKey,
+                                shortcutRefreshKey = shortcutRefreshKey,
                                 playtimeRefreshKey = playtimeRefreshKey,
                                 iconRefreshKey = iconRefreshKey,
                                 searchQuery = searchQuery,
@@ -1941,6 +1954,7 @@ class UnifiedActivity :
         gogApps: List<GOGGame>,
         layoutMode: LibraryLayoutMode,
         libraryRefreshKey: Int = 0,
+        shortcutRefreshKey: Int = 0,
         playtimeRefreshKey: Int = 0,
         iconRefreshKey: Int = 0,
         searchQuery: String = "",
@@ -1951,7 +1965,7 @@ class UnifiedActivity :
         // Load all shortcuts once and cache for both custom app discovery and GameCapsule icon lookup
         var cachedShortcuts by remember { mutableStateOf<List<Shortcut>>(emptyList()) }
         var customApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
-        LaunchedEffect(libraryRefreshKey) {
+        LaunchedEffect(shortcutRefreshKey) {
             withContext(Dispatchers.IO) {
                 try {
                     val cm = ContainerManager(context)
@@ -1996,6 +2010,9 @@ class UnifiedActivity :
         var gogByPseudoId by remember { mutableStateOf<Map<Int, GOGGame>>(emptyMap()) }
         var epicByPseudoId by remember { mutableStateOf<Map<Int, EpicGame>>(emptyMap()) }
         var customArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var customGridArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var customCarouselArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
+        var customListArtworkPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
         var customIconPathByAppId by remember { mutableStateOf<Map<Int, String>>(emptyMap()) }
         var libraryLoaded by remember { mutableStateOf(false) }
         // Track whether the LaunchedEffect is still reprocessing after input changes
@@ -2091,6 +2108,78 @@ class UnifiedActivity :
                     }
                 }
 
+            val gridArtworkPaths =
+                withContext(Dispatchers.IO) {
+                    buildMap<Int, String> {
+                        appsSnapshot.forEach { app ->
+                            val gogGame = gogSnapshot[app.id]
+                            val isCustom = app.id < 0
+                            val isEpic = app.id >= 2000000000
+                            val epicId = if (isEpic) app.id - 2000000000 else 0
+                            val shortcut =
+                                if (gogGame != null) {
+                                    shortcutsSnapshot.find {
+                                        it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame.id
+                                    }
+                                } else {
+                                    findShortcutForGame(shortcutsSnapshot, app, isCustom, isEpic, epicId)
+                                }
+                            val customPath = shortcut?.getExtra(LibraryShortcutArtwork.LibraryArtworkSlot.GRID.extraKey)
+                            if (!customPath.isNullOrBlank() && java.io.File(customPath).exists()) {
+                                put(app.id, customPath)
+                            }
+                        }
+                    }
+                }
+
+            val carouselArtworkPaths =
+                withContext(Dispatchers.IO) {
+                    buildMap<Int, String> {
+                        appsSnapshot.forEach { app ->
+                            val gogGame = gogSnapshot[app.id]
+                            val isCustom = app.id < 0
+                            val isEpic = app.id >= 2000000000
+                            val epicId = if (isEpic) app.id - 2000000000 else 0
+                            val shortcut =
+                                if (gogGame != null) {
+                                    shortcutsSnapshot.find {
+                                        it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame.id
+                                    }
+                                } else {
+                                    findShortcutForGame(shortcutsSnapshot, app, isCustom, isEpic, epicId)
+                                }
+                            val customPath = shortcut?.getExtra(LibraryShortcutArtwork.LibraryArtworkSlot.CAROUSEL.extraKey)
+                            if (!customPath.isNullOrBlank() && java.io.File(customPath).exists()) {
+                                put(app.id, customPath)
+                            }
+                        }
+                    }
+                }
+
+            val listArtworkPaths =
+                withContext(Dispatchers.IO) {
+                    buildMap<Int, String> {
+                        appsSnapshot.forEach { app ->
+                            val gogGame = gogSnapshot[app.id]
+                            val isCustom = app.id < 0
+                            val isEpic = app.id >= 2000000000
+                            val epicId = if (isEpic) app.id - 2000000000 else 0
+                            val shortcut =
+                                if (gogGame != null) {
+                                    shortcutsSnapshot.find {
+                                        it.getExtra("game_source") == "GOG" && it.getExtra("gog_id") == gogGame.id
+                                    }
+                                } else {
+                                    findShortcutForGame(shortcutsSnapshot, app, isCustom, isEpic, epicId)
+                                }
+                            val customPath = shortcut?.getExtra(LibraryShortcutArtwork.LibraryArtworkSlot.LIST.extraKey)
+                            if (!customPath.isNullOrBlank() && java.io.File(customPath).exists()) {
+                                put(app.id, customPath)
+                            }
+                        }
+                    }
+                }
+
             val customIconPaths =
                 withContext(Dispatchers.IO) {
                     buildMap<Int, String> {
@@ -2106,6 +2195,9 @@ class UnifiedActivity :
                 }
 
             customArtworkPathByAppId = artworkPaths
+            customGridArtworkPathByAppId = gridArtworkPaths
+            customCarouselArtworkPathByAppId = carouselArtworkPaths
+            customListArtworkPathByAppId = listArtworkPaths
             customIconPathByAppId = customIconPaths
         }
 
@@ -2305,7 +2397,7 @@ class UnifiedActivity :
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = index == focusIndex,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customArtworkPath = customGridArtworkPathByAppId[app.id] ?: customArtworkPathByAppId[app.id],
                         customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -2347,7 +2439,7 @@ class UnifiedActivity :
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customArtworkPath = customCarouselArtworkPathByAppId[app.id] ?: customArtworkPathByAppId[app.id],
                         customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -2389,7 +2481,7 @@ class UnifiedActivity :
                         iconRefreshKey = iconRefreshKey,
                         isFocusedOverride = isSelected,
                         isControllerActive = isControllerConnected,
-                        customArtworkPath = customArtworkPathByAppId[app.id],
+                        customArtworkPath = customListArtworkPathByAppId[app.id] ?: customArtworkPathByAppId[app.id],
                         customIconPath = customIconPathByAppId[app.id],
                         onClick = {
                             detailGogGame = gogByPseudoId[app.id]
@@ -2755,6 +2847,22 @@ class UnifiedActivity :
                         isPinned = shortcut?.let { LibraryShortcutUtils.hasPinnedHomeShortcut(context, it) } == true,
                     )
                 }
+        }
+        val artworkRefreshListener =
+            remember(app.id, isCustom, isEpic, epicId) {
+                object : EventDispatcher.JavaEventListener {
+                    override fun onEvent(event: Any) {
+                        if (event is AndroidEvent.LibraryArtworkChanged) {
+                            shortcutRefreshKey++
+                        }
+                    }
+                }
+            }
+        DisposableEffect(artworkRefreshListener) {
+            PluviaApp.events.onJava(AndroidEvent.LibraryArtworkChanged::class, artworkRefreshListener)
+            onDispose {
+                PluviaApp.events.offJava(AndroidEvent.LibraryArtworkChanged::class, artworkRefreshListener)
+            }
         }
         val hasPinnedShortcut = pinnedShortcutOverride ?: homeShortcutState.isPinned
 
@@ -3232,7 +3340,6 @@ class UnifiedActivity :
                                     val cm = ContainerManager(context)
                                     val sc = findLibraryShortcutForGame(cm, app, isCustom, isEpic, epicId)
                                     sc?.let { LibraryShortcutUtils.deleteShortcutArtifacts(context, it) }
-                                    java.io.File(context.filesDir, "custom_icons/${app.name.replace("/", "_")}.png").delete()
                                     PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(app.id))
                                     withContext(Dispatchers.Main) {
                                         com.winlator.cmod.shared.android.AppUtils.showToast(
@@ -3678,11 +3785,37 @@ class UnifiedActivity :
                     )
                 }
         }
+        val artworkRefreshListener =
+            remember(app.id, gogGame?.id) {
+                object : EventDispatcher.JavaEventListener {
+                    override fun onEvent(event: Any) {
+                        if (event is AndroidEvent.LibraryArtworkChanged) {
+                            shortcutRefreshKey++
+                        }
+                    }
+                }
+            }
+        DisposableEffect(artworkRefreshListener) {
+            PluviaApp.events.onJava(AndroidEvent.LibraryArtworkChanged::class, artworkRefreshListener)
+            onDispose {
+                PluviaApp.events.offJava(AndroidEvent.LibraryArtworkChanged::class, artworkRefreshListener)
+            }
+        }
         val hasPinnedShortcut = pinnedShortcutOverride ?: homeShortcutState.isPinned
 
         // Hero image
+        val customHeroImageFile =
+            homeShortcutState.shortcut
+                ?.getExtra("customLibraryHeroArtPath")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { java.io.File(it) }
+                ?.takeIf { it.exists() }
+        val customHeroImageCacheKey =
+            customHeroImageFile?.let {
+                "library_custom_hero:${it.absolutePath}:${it.lastModified()}"
+            }
         val heroImageUrl: Any? =
-            when {
+            customHeroImageFile ?: when {
                 isGog -> {
                     gogGame!!.imageUrl.ifEmpty { gogGame.iconUrl }
                 }
@@ -3692,9 +3825,17 @@ class UnifiedActivity :
                 }
 
                 isCustom -> {
-                    val safeName = app.name.replace("/", "_").replace("\\", "_")
-                    val iconFile = java.io.File(context.filesDir, "custom_icons/$safeName.png")
-                    if (iconFile.exists()) iconFile else null
+                    val customCoverArt =
+                        homeShortcutState.shortcut
+                            ?.getExtra("customCoverArtPath")
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { java.io.File(it) }
+                            ?.takeIf { it.exists() }
+                    customCoverArt ?: run {
+                        val safeName = app.name.replace("/", "_").replace("\\", "_")
+                        val iconFile = java.io.File(context.filesDir, "custom_icons/$safeName.png")
+                        if (iconFile.exists()) iconFile else null
+                    }
                 }
 
                 else -> {
@@ -3953,7 +4094,12 @@ class UnifiedActivity :
                                             ImageRequest
                                                 .Builder(context)
                                                 .data(heroImageUrl)
-                                                .crossfade(150)
+                                                .apply {
+                                                    if (customHeroImageCacheKey != null) {
+                                                        memoryCacheKey(customHeroImageCacheKey)
+                                                        diskCacheKey(customHeroImageCacheKey)
+                                                    }
+                                                }.crossfade(150)
                                                 .memoryCachePolicy(coil.request.CachePolicy.ENABLED)
                                                 .diskCachePolicy(coil.request.CachePolicy.ENABLED)
                                                 .build(),
@@ -9804,6 +9950,18 @@ class UnifiedActivity :
         if (!desktopDir.exists()) desktopDir.mkdirs()
         val safeName = name.replace("/", "_").replace("\\", "_")
         val shortcutFile = java.io.File(desktopDir, "$safeName.desktop")
+        val shortcutUuid = java.util.UUID.randomUUID().toString()
+        val iconOutFile = LibraryShortcutArtwork.buildManagedCustomGameArtworkFile(context, shortcutUuid)
+        val extractedArtworkPath =
+            try {
+                if (PeIconExtractor.extractAndSave(java.io.File(exePath), iconOutFile)) {
+                    iconOutFile.absolutePath
+                } else {
+                    null
+                }
+            } catch (_: Exception) {
+                null
+            }
         val content = StringBuilder()
         content.append("[Desktop Entry]\n")
         content.append("Type=Application\n")
@@ -9815,18 +9973,13 @@ class UnifiedActivity :
         content.append("custom_name=$name\n")
         content.append("custom_exe=$exePath\n")
         content.append("custom_game_folder=$gameFolderPath\n")
+        content.append("uuid=$shortcutUuid\n")
+        extractedArtworkPath?.let { content.append("customCoverArtPath=$it\n") }
         content.append("container_id=${container.id}\n")
         content.append("use_container_defaults=1\n")
         com.winlator.cmod.shared.io.FileUtils
             .writeString(shortcutFile, content.toString())
         container.saveData()
-
-        // Extract exe icon and save as PNG for carousel artwork
-        try {
-            val iconOutFile = java.io.File(context.filesDir, "custom_icons/$safeName.png")
-            PeIconExtractor.extractAndSave(java.io.File(exePath), iconOutFile)
-        } catch (_: Exception) {
-        }
     }
 
     @Composable

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Monitor
@@ -144,6 +145,14 @@ class GameSettingsStateHolder {
     val selectedScreenSize = mutableIntStateOf(0)
     val customWidth = mutableStateOf("")
     val customHeight = mutableStateOf("")
+    val gameCardArtworkSelected = mutableStateOf(false)
+    val gameCardArtworkSummary = mutableStateOf("")
+    val gridArtworkSelected = mutableStateOf(false)
+    val gridArtworkSummary = mutableStateOf("")
+    val carouselArtworkSelected = mutableStateOf(false)
+    val carouselArtworkSummary = mutableStateOf("")
+    val listArtworkSelected = mutableStateOf(false)
+    val listArtworkSummary = mutableStateOf("")
     val refreshRateEntries = mutableStateOf<List<String>>(emptyList())
     val selectedRefreshRate = mutableIntStateOf(0)
 
@@ -321,6 +330,15 @@ interface GameSettingsCallbacks {
     fun onConfirm()
     fun onDismiss()
     fun onAddToHomeScreen()
+    fun onPickGameCardArtwork() {}
+    fun onRemoveGameCardArtwork() {}
+    fun onPickGridArtwork() {}
+    fun onRemoveGridArtwork() {}
+    fun onPickCarouselArtwork() {}
+    fun onRemoveCarouselArtwork() {}
+    fun onPickListArtwork() {}
+    fun onRemoveListArtwork() {}
+    fun onOpenArtworkSource() {}
     fun onRemoveEnvVar(index: Int)
     fun onUpdateWinComponent(isDirectX: Boolean, index: Int, newValue: Int)
     fun onSelectExe() {}
@@ -829,6 +847,102 @@ private fun GeneralSection(
 ) {
     val isContainer = state.isContainerEditMode.value
 
+    @Composable
+    fun ArtworkPickerRow(
+        title: String,
+        summary: String,
+        selected: Boolean,
+        onPick: () -> Unit,
+        onRemove: () -> Unit,
+    ) {
+        @Composable
+        fun ActionButton(
+            text: String,
+            tint: Color,
+            onClick: () -> Unit,
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(tint.copy(alpha = 0.08f))
+                    .border(1.dp, tint.copy(alpha = 0.2f), RoundedCornerShape(9.dp))
+                    .clickable { onClick() }
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = text,
+                    color = tint,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(InputSurface)
+                .border(1.dp, InputBorder, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = title,
+                        color = TextPrimary,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+
+                    if (summary.isNotBlank()) {
+                        Spacer(Modifier.height(3.dp))
+
+                        Text(
+                            text = summary,
+                            color = TextSecondary,
+                            fontSize = 11.sp,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ActionButton(
+                        text =
+                            stringResource(
+                                if (selected) {
+                                    R.string.shortcuts_library_artwork_change
+                                } else {
+                                    R.string.shortcuts_library_artwork_set
+                                }
+                            ),
+                        tint = AccentBlue,
+                        onClick = onPick
+                    )
+
+                    if (selected) {
+                        ActionButton(
+                            text = stringResource(R.string.common_ui_remove),
+                            tint = DangerRed,
+                            onClick = onRemove
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     SettingGroup {
         // Name
         SettingTextField(
@@ -917,6 +1031,91 @@ private fun GeneralSection(
                     )
                 }
             }
+        }
+    }
+
+    if (!isContainer) {
+        Spacer(Modifier.height(16.dp))
+
+        SettingGroup {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(R.string.shortcuts_library_artwork_title),
+                    color = TextSecondary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 0.8.sp
+                )
+
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(AccentBlue.copy(alpha = 0.08f))
+                        .border(1.dp, AccentBlue.copy(alpha = 0.2f), RoundedCornerShape(10.dp))
+                        .clickable { callbacks.onOpenArtworkSource() }
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.OpenInNew,
+                            contentDescription = null,
+                            tint = AccentBlue,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.shortcuts_library_artwork_open_source),
+                            color = AccentBlue,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            ArtworkPickerRow(
+                title = stringResource(R.string.shortcuts_library_artwork_game_card_title),
+                summary = state.gameCardArtworkSummary.value,
+                selected = state.gameCardArtworkSelected.value,
+                onPick = callbacks::onPickGameCardArtwork,
+                onRemove = callbacks::onRemoveGameCardArtwork
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            ArtworkPickerRow(
+                title = stringResource(R.string.shortcuts_library_artwork_grid_title),
+                summary = state.gridArtworkSummary.value,
+                selected = state.gridArtworkSelected.value,
+                onPick = callbacks::onPickGridArtwork,
+                onRemove = callbacks::onRemoveGridArtwork
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            ArtworkPickerRow(
+                title = stringResource(R.string.shortcuts_library_artwork_carousel_title),
+                summary = state.carouselArtworkSummary.value,
+                selected = state.carouselArtworkSelected.value,
+                onPick = callbacks::onPickCarouselArtwork,
+                onRemove = callbacks::onRemoveCarouselArtwork
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            ArtworkPickerRow(
+                title = stringResource(R.string.shortcuts_library_artwork_list_title),
+                summary = state.listArtworkSummary.value,
+                selected = state.listArtworkSelected.value,
+                onPick = callbacks::onPickListArtwork,
+                onRemove = callbacks::onRemoveListArtwork
+            )
         }
     }
 

--- a/app/src/main/feature/shortcuts/LibraryShortcutArtwork.kt
+++ b/app/src/main/feature/shortcuts/LibraryShortcutArtwork.kt
@@ -1,0 +1,169 @@
+package com.winlator.cmod.feature.shortcuts
+
+import android.content.Context
+import com.winlator.cmod.runtime.container.Shortcut
+import java.io.File
+
+object LibraryShortcutArtwork {
+    private const val HOME_ICON_DIR = "library_home_icons"
+    private const val VIEW_ARTWORK_DIR = "library_view_artwork"
+    private const val CUSTOM_GAME_ARTWORK_DIR = "library_game_artwork"
+    private const val LEGACY_CUSTOM_ICON_DIR = "custom_icons"
+
+    enum class LibraryArtworkSlot(
+        val extraKey: String,
+        val fileSuffix: String,
+    ) {
+        GAME_CARD("customLibraryHeroArtPath", "hero"),
+        GRID("customLibraryGridArtPath", "grid"),
+        CAROUSEL("customLibraryCarouselArtPath", "carousel"),
+        LIST("customLibraryListArtPath", "list"),
+    }
+
+    @JvmStatic
+    fun ensureShortcutUuid(shortcut: Shortcut): String {
+        if (shortcut.getExtra("uuid").isEmpty()) {
+            shortcut.genUUID()
+        }
+        return shortcut.getExtra("uuid")
+    }
+
+    @JvmStatic
+    fun buildManagedHomeIconFile(
+        context: Context,
+        shortcut: Shortcut,
+    ): File {
+        val shortcutUuid = ensureShortcutUuid(shortcut)
+        val dir = File(context.filesDir, HOME_ICON_DIR)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+        return File(dir, "$shortcutUuid.png")
+    }
+
+    @JvmStatic
+    fun buildManagedCustomGameArtworkFile(
+        context: Context,
+        shortcutUuid: String,
+    ): File {
+        val dir = File(context.filesDir, CUSTOM_GAME_ARTWORK_DIR)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+        return File(dir, "$shortcutUuid.png")
+    }
+
+    @JvmStatic
+    fun buildManagedViewArtworkFile(
+        context: Context,
+        shortcut: Shortcut,
+        slot: LibraryArtworkSlot,
+    ): File {
+        val shortcutUuid = ensureShortcutUuid(shortcut)
+        val dir = File(context.filesDir, VIEW_ARTWORK_DIR)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+        return File(dir, "${shortcutUuid}_${slot.fileSuffix}.png")
+    }
+
+    @JvmStatic
+    fun buildLegacyCustomIconFile(
+        context: Context,
+        shortcutName: String,
+    ): File {
+        val safeName = shortcutName.replace("/", "_").replace("\\", "_")
+        return File(context.filesDir, "$LEGACY_CUSTOM_ICON_DIR/$safeName.png")
+    }
+
+    @JvmStatic
+    fun findPreferredHomeIconFile(
+        context: Context,
+        shortcut: Shortcut,
+    ): File? {
+        val customLibraryIcon =
+            shortcut
+                .getExtra("customLibraryIconPath")
+                .takeIf { it.isNotBlank() }
+                ?.let(::File)
+                ?.takeIf { it.isFile() }
+        if (customLibraryIcon != null) {
+            return customLibraryIcon
+        }
+
+        val customCoverArt =
+            shortcut
+                .getExtra("customCoverArtPath")
+                .takeIf { it.isNotBlank() }
+                ?.let(::File)
+                ?.takeIf { it.isFile() }
+        if (customCoverArt != null) {
+            return customCoverArt
+        }
+
+        val shortcutDisplayName = shortcut.getExtra("custom_name", shortcut.name).ifBlank { shortcut.name }
+        val legacyIcon = buildLegacyCustomIconFile(context, shortcutDisplayName)
+        return legacyIcon.takeIf { it.isFile() }
+    }
+
+    @JvmStatic
+    fun deleteManagedArtwork(
+        context: Context,
+        absolutePath: String?,
+    ): Boolean {
+        if (absolutePath.isNullOrBlank() || !isManagedArtworkPath(context, absolutePath)) {
+            return false
+        }
+
+        val targetFile = File(absolutePath)
+        return targetFile.exists() && targetFile.delete()
+    }
+
+    @JvmStatic
+    fun deleteShortcutArtwork(
+        context: Context,
+        shortcut: Shortcut,
+    ): Int {
+        val managedPaths =
+            buildSet {
+                add(shortcut.getExtra("customLibraryIconPath"))
+                add(shortcut.getExtra("customCoverArtPath"))
+                LibraryArtworkSlot.values().forEach { slot ->
+                    add(shortcut.getExtra(slot.extraKey))
+                }
+            }
+
+        val shortcutDisplayName = shortcut.getExtra("custom_name", shortcut.name).ifBlank { shortcut.name }
+        val legacyIcon = buildLegacyCustomIconFile(context, shortcutDisplayName)
+        return managedPaths.count { deleteManagedArtwork(context, it) } +
+            if (deleteManagedArtwork(context, legacyIcon.absolutePath)) 1 else 0
+    }
+
+    private fun isManagedArtworkPath(
+        context: Context,
+        absolutePath: String,
+    ): Boolean {
+        val target = try {
+            File(absolutePath).canonicalFile
+        } catch (_: Exception) {
+            return false
+        }
+
+        val managedRoots =
+            listOf(
+                File(context.filesDir, HOME_ICON_DIR),
+                File(context.filesDir, VIEW_ARTWORK_DIR),
+                File(context.filesDir, CUSTOM_GAME_ARTWORK_DIR),
+                File(context.filesDir, LEGACY_CUSTOM_ICON_DIR),
+            )
+
+        return managedRoots.any { root ->
+            try {
+                val canonicalRoot = root.canonicalFile
+                target.path == canonicalRoot.path || target.path.startsWith(canonicalRoot.path + File.separator)
+            } catch (_: Exception) {
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/feature/shortcuts/LibraryShortcutUtils.kt
+++ b/app/src/main/feature/shortcuts/LibraryShortcutUtils.kt
@@ -96,6 +96,7 @@ object LibraryShortcutUtils {
         var deletedAny = false
 
         disablePinnedHomeShortcut(context, shortcut)
+        LibraryShortcutArtwork.deleteShortcutArtwork(context, shortcut)
 
         try {
             ShortcutsFragment.disableShortcutOnScreen(context, shortcut)

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
+import android.graphics.BitmapFactory
 import android.graphics.drawable.Icon
 import android.net.Uri
 import android.util.DisplayMetrics
@@ -24,6 +25,7 @@ import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.winlator.cmod.BuildConfig
 import com.winlator.cmod.R
+import com.winlator.cmod.app.PluviaApp
 import com.winlator.cmod.feature.library.DriveItem
 import com.winlator.cmod.feature.library.EnvVarItem
 import com.winlator.cmod.feature.library.GameSettingsCallbacks
@@ -34,6 +36,7 @@ import com.winlator.cmod.feature.settings.DXVKConfigUtils
 import com.winlator.cmod.feature.settings.GraphicsDriverConfigUtils
 import com.winlator.cmod.feature.settings.WineD3DConfigUtils
 import com.winlator.cmod.feature.setup.SetupWizardActivity
+import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
 import com.winlator.cmod.runtime.compat.box64.Box64Preset
 import com.winlator.cmod.runtime.compat.box64.Box64PresetManager
 import com.winlator.cmod.runtime.container.Container
@@ -42,6 +45,7 @@ import com.winlator.cmod.runtime.container.Shortcut
 import com.winlator.cmod.runtime.content.ContentProfile
 import com.winlator.cmod.runtime.content.ContentsManager
 import com.winlator.cmod.shared.android.AppUtils
+import com.winlator.cmod.shared.android.ImageUtils
 import com.winlator.cmod.shared.io.AssetPaths
 import com.winlator.cmod.runtime.wine.DefaultVersion
 import com.winlator.cmod.runtime.wine.EnvVars
@@ -65,6 +69,13 @@ import java.lang.reflect.Field
 import java.util.Arrays
 import java.util.Locale
 import java.util.concurrent.Executors
+
+private enum class LibraryArtworkTarget {
+    GAME_CARD,
+    GRID,
+    CAROUSEL,
+    LIST,
+}
 
 class ShortcutSettingsComposeDialog private constructor(
     private val activity: Activity,
@@ -90,6 +101,8 @@ class ShortcutSettingsComposeDialog private constructor(
     // Preset ID lists (parallel to display name lists)
     private var box64PresetIds = mutableListOf<String>()
     private var fexcorePresetIds = mutableListOf<String>()
+    private var shouldRefreshLibraryOnSave = false
+    private var pendingArtworkTarget = LibraryArtworkTarget.GAME_CARD
 
     // SDL2 Compatibility env vars — must match ContainerDetailFragment.SDL2_ENV_VARS.
     private val sdl2EnvVars = listOf(
@@ -124,6 +137,15 @@ class ShortcutSettingsComposeDialog private constructor(
             } else {
                 AppUtils.showToast(context, R.string.common_ui_select_valid_exe_file, Toast.LENGTH_SHORT)
             }
+        }
+
+    private val artworkPickerLauncher: ActivityResultLauncher<Array<String>>? =
+        (activity as? ComponentActivity)?.activityResultRegistry?.register(
+            "shortcut_artwork_picker",
+            ActivityResultContracts.OpenDocument()
+        ) { uri: Uri? ->
+            if (uri == null) return@register
+            saveSelectedArtwork(uri)
         }
 
     init {
@@ -181,6 +203,7 @@ class ShortcutSettingsComposeDialog private constructor(
         return object : GameSettingsCallbacks {
             override fun onConfirm() {
                 saveSettings()
+                emitLibraryRefreshIfNeeded()
                 dismiss()
             }
 
@@ -203,6 +226,53 @@ class ShortcutSettingsComposeDialog private constructor(
                             R.string.library_games_failed_to_create_shortcut,
                             shortcut.name
                         )
+                    )
+                }
+            }
+
+            override fun onPickGameCardArtwork() {
+                pendingArtworkTarget = LibraryArtworkTarget.GAME_CARD
+                artworkPickerLauncher?.launch(arrayOf("image/*"))
+            }
+
+            override fun onRemoveGameCardArtwork() {
+                clearLibraryArtwork(LibraryArtworkTarget.GAME_CARD)
+            }
+
+            override fun onPickGridArtwork() {
+                pendingArtworkTarget = LibraryArtworkTarget.GRID
+                artworkPickerLauncher?.launch(arrayOf("image/*"))
+            }
+
+            override fun onRemoveGridArtwork() {
+                clearLibraryArtwork(LibraryArtworkTarget.GRID)
+            }
+
+            override fun onPickCarouselArtwork() {
+                pendingArtworkTarget = LibraryArtworkTarget.CAROUSEL
+                artworkPickerLauncher?.launch(arrayOf("image/*"))
+            }
+
+            override fun onRemoveCarouselArtwork() {
+                clearLibraryArtwork(LibraryArtworkTarget.CAROUSEL)
+            }
+
+            override fun onPickListArtwork() {
+                pendingArtworkTarget = LibraryArtworkTarget.LIST
+                artworkPickerLauncher?.launch(arrayOf("image/*"))
+            }
+
+            override fun onRemoveListArtwork() {
+                clearLibraryArtwork(LibraryArtworkTarget.LIST)
+            }
+
+            override fun onOpenArtworkSource() {
+                runCatching {
+                    context.startActivity(
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            Uri.parse("https://www.steamgriddb.com/"),
+                        ),
                     )
                 }
             }
@@ -270,6 +340,7 @@ class ShortcutSettingsComposeDialog private constructor(
         // General
         state.name.value = shortcut.name
         state.launchExePath.value = resolveInitialLaunchExePath()
+        syncLibraryArtworkState()
 
         // Input
         val inputType = Integer.parseInt(
@@ -1231,8 +1302,7 @@ class ShortcutSettingsComposeDialog private constructor(
             ?: return ShortcutsFragment.PinShortcutResult.FAILED
         if (!shortcutManager.isRequestPinShortcutSupported) return ShortcutsFragment.PinShortcutResult.FAILED
 
-        val shortcutIcon = if (shortcut.icon != null) Icon.createWithBitmap(shortcut.icon)
-        else Icon.createWithResource(context, R.drawable.icon_shortcut)
+        val shortcutIcon = buildPinnedShortcutIcon()
 
         val info = ShortcutInfo.Builder(context, shortcutIds.last())
             .setShortLabel(shortcut.name)
@@ -1268,6 +1338,155 @@ class ShortcutSettingsComposeDialog private constructor(
         }
 
         return ""
+    }
+
+    private fun syncLibraryArtworkState() {
+        syncLibraryArtworkSlotState(
+            target = LibraryArtworkTarget.GAME_CARD,
+        )
+        syncLibraryArtworkSlotState(
+            target = LibraryArtworkTarget.GRID,
+        )
+        syncLibraryArtworkSlotState(
+            target = LibraryArtworkTarget.CAROUSEL,
+        )
+        syncLibraryArtworkSlotState(
+            target = LibraryArtworkTarget.LIST,
+        )
+    }
+
+    private fun syncLibraryArtworkSlotState(
+        target: LibraryArtworkTarget,
+    ) {
+        val file =
+            getLibraryArtworkExtraKey(target)
+                ?.let { shortcut.getExtra(it) }
+                ?.takeIf { it.isNotBlank() }
+                ?.let(::File)
+                ?.takeIf { it.isFile() }
+
+        when (target) {
+            LibraryArtworkTarget.GAME_CARD -> {
+                state.gameCardArtworkSelected.value = file != null
+                state.gameCardArtworkSummary.value =
+                    if (file != null) {
+                        context.getString(R.string.shortcuts_library_artwork_selected, file.name)
+                    } else {
+                        ""
+                    }
+            }
+            LibraryArtworkTarget.GRID -> {
+                state.gridArtworkSelected.value = file != null
+                state.gridArtworkSummary.value =
+                    if (file != null) {
+                        context.getString(R.string.shortcuts_library_artwork_selected, file.name)
+                    } else {
+                        ""
+                    }
+            }
+            LibraryArtworkTarget.CAROUSEL -> {
+                state.carouselArtworkSelected.value = file != null
+                state.carouselArtworkSummary.value =
+                    if (file != null) {
+                        context.getString(R.string.shortcuts_library_artwork_selected, file.name)
+                    } else {
+                        ""
+                    }
+            }
+            LibraryArtworkTarget.LIST -> {
+                state.listArtworkSelected.value = file != null
+                state.listArtworkSummary.value =
+                    if (file != null) {
+                        context.getString(R.string.shortcuts_library_artwork_selected, file.name)
+                    } else {
+                        ""
+                    }
+            }
+        }
+    }
+
+    private fun saveSelectedArtwork(uri: Uri) =
+        saveSelectedLibraryArtwork(uri, pendingArtworkTarget)
+
+    private fun saveSelectedLibraryArtwork(
+        uri: Uri,
+        target: LibraryArtworkTarget,
+    ) {
+        val bitmap = ImageUtils.getBitmapFromUri(context, uri, 1024)
+        if (bitmap == null) {
+            AppUtils.showToast(context, R.string.shortcuts_library_artwork_failed, Toast.LENGTH_SHORT)
+            return
+        }
+
+        val extraKey = getLibraryArtworkExtraKey(target) ?: return
+        val previousPath = shortcut.getExtra(extraKey)
+        val slot = getLibraryArtworkSlot(target) ?: return
+        val outputFile = LibraryShortcutArtwork.buildManagedViewArtworkFile(context, shortcut, slot)
+        if (!FileUtils.saveBitmapToFile(bitmap, outputFile)) {
+            AppUtils.showToast(context, R.string.shortcuts_library_artwork_failed, Toast.LENGTH_SHORT)
+            return
+        }
+
+        if (previousPath.isNotBlank() && previousPath != outputFile.absolutePath) {
+            LibraryShortcutArtwork.deleteManagedArtwork(context, previousPath)
+        }
+
+        shortcut.putExtra(extraKey, outputFile.absolutePath)
+        shortcut.saveData()
+        shouldRefreshLibraryOnSave = true
+        syncLibraryArtworkState()
+    }
+
+    private fun clearLibraryArtwork(target: LibraryArtworkTarget) {
+        val extraKey = getLibraryArtworkExtraKey(target) ?: return
+        LibraryShortcutArtwork.deleteManagedArtwork(context, shortcut.getExtra(extraKey))
+        shortcut.putExtra(extraKey, null)
+        shortcut.saveData()
+        shouldRefreshLibraryOnSave = true
+        syncLibraryArtworkState()
+    }
+
+    private fun getLibraryArtworkExtraKey(target: LibraryArtworkTarget): String? =
+        when (target) {
+            LibraryArtworkTarget.GAME_CARD -> LibraryShortcutArtwork.LibraryArtworkSlot.GAME_CARD.extraKey
+            LibraryArtworkTarget.GRID -> LibraryShortcutArtwork.LibraryArtworkSlot.GRID.extraKey
+            LibraryArtworkTarget.CAROUSEL -> LibraryShortcutArtwork.LibraryArtworkSlot.CAROUSEL.extraKey
+            LibraryArtworkTarget.LIST -> LibraryShortcutArtwork.LibraryArtworkSlot.LIST.extraKey
+        }
+
+    private fun getLibraryArtworkSlot(target: LibraryArtworkTarget): LibraryShortcutArtwork.LibraryArtworkSlot? =
+        when (target) {
+            LibraryArtworkTarget.GAME_CARD -> LibraryShortcutArtwork.LibraryArtworkSlot.GAME_CARD
+            LibraryArtworkTarget.GRID -> LibraryShortcutArtwork.LibraryArtworkSlot.GRID
+            LibraryArtworkTarget.CAROUSEL -> LibraryShortcutArtwork.LibraryArtworkSlot.CAROUSEL
+            LibraryArtworkTarget.LIST -> LibraryShortcutArtwork.LibraryArtworkSlot.LIST
+        }
+
+    private fun emitLibraryRefreshIfNeeded() {
+        if (!shouldRefreshLibraryOnSave) {
+            return
+        }
+        shouldRefreshLibraryOnSave = false
+        PluviaApp.events.emit(AndroidEvent.LibraryArtworkChanged)
+    }
+
+    private fun refreshPinnedHomeShortcutIfNeeded() {
+        if (!LibraryShortcutUtils.hasPinnedHomeShortcut(context, shortcut)) {
+            return
+        }
+        addShortcutToScreen(shortcut)
+    }
+
+    private fun buildPinnedShortcutIcon(): Icon {
+        val preferredIconBitmap =
+            LibraryShortcutArtwork
+                .findPreferredHomeIconFile(context, shortcut)
+                ?.let { BitmapFactory.decodeFile(it.absolutePath) }
+                ?: shortcut.coverArt
+                ?: shortcut.icon
+
+        return preferredIconBitmap?.let { Icon.createWithBitmap(it) }
+            ?: Icon.createWithResource(context, R.drawable.icon_shortcut)
     }
 
     private fun getShortcutSetting(key: String, containerValue: String): String {
@@ -1894,7 +2113,7 @@ class ShortcutSettingsComposeDialog private constructor(
         fragment?.updateShortcutOnScreen(
             newName, newName, shortcut.container.id,
             File(parent, "$newName.desktop").absolutePath,
-            Icon.createWithBitmap(shortcut.icon),
+            buildPinnedShortcutIcon(),
             shortcut.getExtra("uuid")
         )
     }

--- a/app/src/main/feature/shortcuts/ShortcutsFragment.java
+++ b/app/src/main/feature/shortcuts/ShortcutsFragment.java
@@ -11,6 +11,8 @@ import android.content.IntentSender;
 import android.content.SharedPreferences;
 import android.content.pm.ShortcutInfo;
 import android.content.pm.ShortcutManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.os.Build;
@@ -439,9 +441,10 @@ public class ShortcutsFragment extends Fragment {
     if (shortcutManager == null || !shortcutManager.isRequestPinShortcutSupported())
       return PinShortcutResult.FAILED;
 
+    Bitmap shortcutBitmap = resolveShortcutIcon(shortcut);
     Icon shortcutIcon =
-        shortcut.icon != null
-            ? Icon.createWithBitmap(shortcut.icon)
+        shortcutBitmap != null
+            ? Icon.createWithBitmap(shortcutBitmap)
             : Icon.createWithResource(requireContext(), R.drawable.icon_shortcut);
 
     return pinOrUpdateShortcut(
@@ -486,6 +489,19 @@ public class ShortcutsFragment extends Fragment {
       } catch (Exception ignored) {
       }
     }
+  }
+
+  private Bitmap resolveShortcutIcon(Shortcut shortcut) {
+    if (shortcut == null) return null;
+
+    File customIconFile = LibraryShortcutArtwork.findPreferredHomeIconFile(requireContext(), shortcut);
+    if (customIconFile != null) {
+      Bitmap bitmap = BitmapFactory.decodeFile(customIconFile.getAbsolutePath());
+      if (bitmap != null) return bitmap;
+    }
+
+    if (shortcut.getCoverArt() != null) return shortcut.getCoverArt();
+    return shortcut.icon;
   }
 
   public void updateShortcutOnScreen(

--- a/app/src/main/feature/stores/steam/events/AndroidEvent.kt
+++ b/app/src/main/feature/stores/steam/events/AndroidEvent.kt
@@ -15,4 +15,6 @@ sealed interface AndroidEvent<T> : Event<T> {
     data class LibraryInstallStatusChanged(
         val appId: Int,
     ) : AndroidEvent<Unit>
+
+    data object LibraryArtworkChanged : AndroidEvent<Unit>
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,16 @@
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Do you want to remove this shortcut?</string>
     <string name="shortcuts_list_add_to_home_screen">Add to Home Screen</string>
+    <string name="shortcuts_library_artwork_title">Library Artwork</string>
+    <string name="shortcuts_library_artwork_game_card_title">Game Card Image</string>
+    <string name="shortcuts_library_artwork_grid_title">Grid Image</string>
+    <string name="shortcuts_library_artwork_carousel_title">Carousel Image</string>
+    <string name="shortcuts_library_artwork_list_title">List Image</string>
+    <string name="shortcuts_library_artwork_selected">Selected: %1$s</string>
+    <string name="shortcuts_library_artwork_set">Set image</string>
+    <string name="shortcuts_library_artwork_change">Change image</string>
+    <string name="shortcuts_library_artwork_failed">Failed to load the selected image.</string>
+    <string name="shortcuts_library_artwork_open_source">Open SteamGridDB</string>
     <string name="shortcuts_list_not_available">This shortcut is no longer available. Please delete or recreate it.</string>
     <string name="shortcuts_list_select_a_container">Select a container</string>
     <string name="shortcuts_list_error_opening_settings">Error opening shortcut settings</string>


### PR DESCRIPTION
- add custom managed artwork slots for game card, grid, carousel, and list library views
- add library artwork controls to shortcut settings with SteamGridDB access and per-view image selection
- refresh open library artwork surfaces after save without routing through the generic install-status refresh path
- clean up managed artwork files when shortcuts or installed games are removed across Steam, Epic, GOG, and custom games
