### PR TITLE
Default secondary binding to None

### DIFF
--- a/app/src/main/runtime/input/controls/Binding.java
+++ b/app/src/main/runtime/input/controls/Binding.java
@@ -154,6 +154,8 @@ public enum Binding {
   @NonNull @Override
   public String toString() {
     switch (this) {
+      case NONE:
+        return "None";
       case KEY_INSERT:
         return "INSERT";
       case KEY_SHIFT_L:
@@ -199,6 +201,7 @@ public enum Binding {
   }
 
   public static Binding fromString(String name) {
+    if ("None".equalsIgnoreCase(name)) return Binding.NONE;
     switch (name) {
       case "KEY_INSERT":
         return Binding.KEY_INSERT;
@@ -251,36 +254,42 @@ public enum Binding {
 
   public static String[] mouseBindingLabels() {
     ArrayList<String> names = new ArrayList<>();
+    names.add(NONE.toString());
     for (Binding binding : values()) if (binding.isMouse()) names.add(binding.toString());
     return names.toArray(new String[0]);
   }
 
   public static String[] keyboardBindingLabels() {
     ArrayList<String> labels = new ArrayList<>();
+    labels.add(NONE.toString());
     for (Binding binding : values()) if (binding.isKeyboard()) labels.add(binding.toString());
     return labels.toArray(new String[0]);
   }
 
   public static String[] gamepadBindingLabels() {
     ArrayList<String> names = new ArrayList<>();
+    names.add(NONE.toString());
     for (Binding binding : values()) if (binding.isGamepad()) names.add(binding.toString());
     return names.toArray(new String[0]);
   }
 
   public static Binding[] mouseBindingValues() {
     ArrayList<Binding> labels = new ArrayList<>();
+    labels.add(NONE);
     for (Binding binding : values()) if (binding.isMouse()) labels.add(binding);
     return labels.toArray(new Binding[0]);
   }
 
   public static Binding[] keyboardBindingValues() {
     ArrayList<Binding> values = new ArrayList<>();
+    values.add(NONE);
     for (Binding binding : values()) if (binding.isKeyboard()) values.add(binding);
     return values.toArray(new Binding[0]);
   }
 
   public static Binding[] gamepadBindingValues() {
     ArrayList<Binding> labels = new ArrayList<>();
+    labels.add(NONE);
     for (Binding binding : values()) if (binding.isGamepad()) labels.add(binding);
     return labels.toArray(new Binding[0]);
   }


### PR DESCRIPTION
- Add `None` as the first option in keyboard, mouse, and gamepad binding picker lists.
- Keep secondary bindings that are unset from falling back to `UP` in the control editor.
- Preserve existing profile serialization by continuing to write the enum value `NONE`.