### PR TITLE
feat: add pubg flavor (com.tencent.ig)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -34,6 +34,10 @@ jobs:
             artifactName: apk-ludashi
             gradleTask: assembleLudashiDebug
             apkPath: app/build/outputs/apk/ludashi/debug/ludashi.apk
+          - name: Pubg
+            artifactName: apk-pubg
+            gradleTask: assemblePubgDebug
+            apkPath: app/build/outputs/apk/pubg/debug/pubg.apk
 
     steps:
     - name: Clone repository

--- a/.github/workflows/pr-release-publish.yml
+++ b/.github/workflows/pr-release-publish.yml
@@ -83,8 +83,10 @@ jobs:
             echo "label=$label"
             echo "standard=WinNative-Debug-Standard-${label}.apk"
             echo "ludashi=WinNative-Debug-Ludashi-${label}.apk"
+            echo "pubg=WinNative-Debug-Pubg-${label}.apk"
             echo "release_standard=WinNative-Debug-Standard-${release_label}.apk"
             echo "release_ludashi=WinNative-Debug-Ludashi-${release_label}.apk"
+            echo "release_pubg=WinNative-Debug-Pubg-${release_label}.apk"
           } >> "$GITHUB_OUTPUT"
 
       - name: Download PR build artifacts
@@ -95,6 +97,7 @@ jobs:
           mkdir -p artifacts
           gh run download "$RUN_ID" --repo "$SOURCE_REPO" --name apk-standard --dir artifacts/standard
           gh run download "$RUN_ID" --repo "$SOURCE_REPO" --name apk-ludashi --dir artifacts/ludashi
+          gh run download "$RUN_ID" --repo "$SOURCE_REPO" --name apk-pubg --dir artifacts/pubg
 
       - name: Build release notes from PR metadata
         if: ${{ steps.scope.outputs.allowed == 'true' }}
@@ -135,6 +138,7 @@ jobs:
             printf '\n## Attached Artifacts\n\n'
             printf -- '%s\n' "- ${{ steps.apk.outputs.release_standard }}"
             printf -- '%s\n' "- ${{ steps.apk.outputs.release_ludashi }}"
+            printf -- '%s\n' "- ${{ steps.apk.outputs.release_pubg }}"
             printf '\nBuilt from source commit `%s`.\n' "$short_sha"
           } > release-notes.md
 
@@ -177,13 +181,17 @@ jobs:
 
           standard_path="artifacts/standard/${{ steps.apk.outputs.standard }}"
           ludashi_path="artifacts/ludashi/${{ steps.apk.outputs.ludashi }}"
+          pubg_path="artifacts/pubg/${{ steps.apk.outputs.pubg }}"
           release_standard_path="release-assets/${{ steps.apk.outputs.release_standard }}"
           release_ludashi_path="release-assets/${{ steps.apk.outputs.release_ludashi }}"
+          release_pubg_path="release-assets/${{ steps.apk.outputs.release_pubg }}"
           test -f "$standard_path"
           test -f "$ludashi_path"
+          test -f "$pubg_path"
           mkdir -p release-assets
           cp "$standard_path" "$release_standard_path"
           cp "$ludashi_path" "$release_ludashi_path"
+          cp "$pubg_path" "$release_pubg_path"
 
           release_json=$(gh api "repos/$TARGET_REPO/releases/tags/$tag")
           existing_apk_assets=$(
@@ -220,6 +228,7 @@ jobs:
 
           upload_asset "$release_standard_path"
           upload_asset "$release_ludashi_path"
+          upload_asset "$release_pubg_path"
 
           release_url=$(gh release view "$tag" --repo "$TARGET_REPO" --json url --jq '.url')
           {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,6 +108,10 @@ android {
             dimension "branding"
             applicationId "com.ludashi.benchmark"
         }
+        pubg {
+            dimension "branding"
+            applicationId "com.tencent.ig"
+        }
     }
 
     ndkVersion '27.3.13750724'
@@ -157,7 +161,7 @@ android {
     applicationVariants.configureEach { variant ->
         if (variant.buildType.name == "debug") {
             variant.outputs.configureEach { output ->
-                output.outputFileName = variant.flavorName == "ludashi" ? "ludashi.apk" : "standard.apk"
+                output.outputFileName = "${variant.flavorName}.apk"
             }
         }
     }

--- a/app/src/main/app/update/UpdateChecker.kt
+++ b/app/src/main/app/update/UpdateChecker.kt
@@ -308,7 +308,12 @@ object UpdateChecker {
         }
 
         // 4.  Build download URL based on package name
-        val apkType = if (context.packageName == "com.ludashi.benchmark") "ludashi" else "standard"
+        val apkType =
+            when (context.packageName) {
+                "com.ludashi.benchmark" -> "ludashi"
+                "com.tencent.ig" -> null
+                else -> "standard"
+            } ?: return null
         val downloadUrl = "${DOWNLOADS_PAGE_URL}download.php?type=$apkType"
 
         // 5.  Fetch optional release notes


### PR DESCRIPTION
Adds a third product flavor "pubg" alongside standard and ludashi, with applicationId com.tencent.ig. Generalizes the debug APK rename to use ${variant.flavorName}.apk so it scales with new flavors.

Wires pubg into both CI workflows:
- pr-ci.yml: new matrix entry produces apk-pubg artifact.
- pr-release-publish.yml: mirrors standard/ludashi handling for pubg in expected names, artifact download, release notes, and upload.

UpdateChecker skips update checks for com.tencent.ig (no upstream build endpoint), via a lambda-safe when expression.