### PR TITLE
fix: persist CPU core selection in Shortcut Advanced and Edit Container

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -3253,9 +3253,15 @@ private fun AdvancedSection(
                     index = i,
                     isChecked = isChecked,
                     onClick = {
-                        val mutable = checkedList.toMutableList()
-                        mutable[i] = !isChecked
-                        state.cpuChecked.value = mutable
+                        // Block unchecking the last remaining core: zero-selected
+                        // and all-selected would otherwise serialize identically,
+                        // and runtime skips affinity for a zero mask.
+                        val wouldLeaveNone = isChecked && checkedList.count { it } <= 1
+                        if (!wouldLeaveNone) {
+                            val mutable = checkedList.toMutableList()
+                            mutable[i] = !isChecked
+                            state.cpuChecked.value = mutable
+                        }
                     }
                 )
             }
@@ -3280,9 +3286,12 @@ private fun AdvancedSection(
                     index = i,
                     isChecked = isChecked,
                     onClick = {
-                        val mutable = checkedList.toMutableList()
-                        mutable[i] = !isChecked
-                        state.cpuCheckedWoW64.value = mutable
+                        val wouldLeaveNone = isChecked && checkedList.count { it } <= 1
+                        if (!wouldLeaveNone) {
+                            val mutable = checkedList.toMutableList()
+                            mutable[i] = !isChecked
+                            state.cpuCheckedWoW64.value = mutable
+                        }
                     }
                 )
             }

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1254,9 +1254,11 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         return merged.joinToString(" ") { "${it.key}=${it.value}" }
     }
 
+    // Always emit the enumerated list. An empty string means "no override" at
+    // the Container layer and would fall back to getFallbackCPUList* — the
+    // WoW64 fallback is only upper-half cores, so saving "all checked" on the
+    // 32-bit chip row would silently reopen as half the cores.
     private fun buildCpuListString(checked: List<Boolean>): String {
-        val allChecked = checked.all { it }
-        if (allChecked) return ""
         return checked.mapIndexedNotNull { i, c -> if (c) "$i" else null }.joinToString(",")
     }
 

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -1577,9 +1577,12 @@ class ShortcutSettingsComposeDialog private constructor(
         return merged.joinToString(" ") { "${it.key}=${it.value}" }
     }
 
+    // Emit the enumerated list even when all cores are checked. Returning "" for
+    // all-checked collides with the "fallback / no override" sentinel used by
+    // Container.setCPUList*, Shortcut.getSettingExtra, and the WoW64 fallback
+    // (which is only upper-half cores) — so a user's "all cores" selection
+    // would silently decay on reload.
     private fun buildCpuListString(checked: List<Boolean>): String {
-        val allChecked = checked.all { it }
-        if (allChecked) return "" // empty means all cores
         return checked.mapIndexedNotNull { i, isChecked ->
             if (isChecked) "$i" else null
         }.joinToString(",")


### PR DESCRIPTION
buildCpuListString returned "" for all-checked, which collided with the empty=fallback sentinel downstream. Container.getFallbackCPUListWoW64 returns only upper-half cores, so saving all 32-bit cores in Edit Container silently reopened as half. Shortcut.getSettingExtra treats an empty extra as unset, so an "all cores" shortcut override was lost whenever the container had a restricted cpuList. The same empty output was also produced by zero-selected, indistinguishable from all-selected and ignored by ProcessHelper.getAffinityMask.

- Always emit the enumerated list in buildCpuListString in both dialogs.
- Block unchecking the last remaining chip so zero-selected is unreachable.