### PR TITLE
Improve session teardown cleanup

### DIFF
--- a/app/src/main/runtime/audio/midi/MidiHandler.java
+++ b/app/src/main/runtime/audio/midi/MidiHandler.java
@@ -9,6 +9,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -18,12 +19,13 @@ import jp.kshoji.javax.sound.midi.ShortMessage;
 public class MidiHandler {
   private static final String TAG = "MidiHandler";
   private DatagramSocket socket;
+  private volatile ExecutorService receiveExecutor;
 
   public DatagramSocket getSocket() {
     return socket;
   }
 
-  private boolean running = false;
+  private volatile boolean running = false;
   private static final short SERVER_PORT = 7942;
   private static final short CLIENT_PORT = 7941;
   private static final int BUF_SIZE = 9;
@@ -44,32 +46,50 @@ public class MidiHandler {
     this.sf2SoundBank = soundBank;
   }
 
-  public void start() {
+  public synchronized void start() {
+    if (running) return;
     running = true;
-    Executors.newSingleThreadExecutor()
-        .execute(
+    receiveExecutor = Executors.newSingleThreadExecutor();
+    final ExecutorService activeExecutor = receiveExecutor;
+    activeExecutor.execute(
             () -> {
+              DatagramSocket localSocket = null;
               try {
-                socket = new DatagramSocket(null);
-                socket.setReuseAddress(true);
-                socket.bind(new InetSocketAddress((InetAddress) null, SERVER_PORT));
+                localSocket = new DatagramSocket(null);
+                localSocket.setReuseAddress(true);
+                localSocket.bind(new InetSocketAddress((InetAddress) null, SERVER_PORT));
+                socket = localSocket;
 
                 while (running) {
-                  socket.receive(receivePacket);
+                  localSocket.receive(receivePacket);
                   receiveData.rewind();
                   handleRequest(receiveData);
                 }
               } catch (IOException e) {
+              } finally {
+                if (receiveExecutor == activeExecutor) running = false;
+                if (localSocket != null) {
+                  localSocket.close();
+                }
+                if (socket == localSocket) {
+                  socket = null;
+                }
+                activeExecutor.shutdown();
               }
             });
   }
 
-  public void stop() {
+  public synchronized void stop() {
     running = false;
 
     if (socket != null) {
       socket.close();
       socket = null;
+    }
+
+    if (receiveExecutor != null) {
+      receiveExecutor.shutdownNow();
+      receiveExecutor = null;
     }
 
     clearRecv();

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -497,7 +497,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             preloaderDialog.showOnUiThread(getString(R.string.preloader_initializing));
         }
 
-        Executors.newSingleThreadExecutor().execute(() -> {
+        new Thread(() -> {
             performForcedSessionCleanup("switch launch target");
             runOnUiThread(() -> {
                 if (isFinishing() || isDestroyed()) {
@@ -507,7 +507,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 setIntent(relaunchIntent);
                 recreate();
             });
-        });
+        }, "XServerSwitchCleanup").start();
     }
 
     @Override

--- a/app/src/main/runtime/display/environment/XEnvironment.java
+++ b/app/src/main/runtime/display/environment/XEnvironment.java
@@ -67,6 +67,7 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
     // Stop in reverse order so dependent components (guest launcher) tear down before
     // their underlying services (audio sockets, XServer, shm).
     Log.d(TAG, "Stopping " + components.size() + " environment component(s)");
+    RuntimeException firstFailure = null;
     for (int i = components.size() - 1; i >= 0; i--) {
       EnvironmentComponent component = components.get(i);
       String name = component.getClass().getSimpleName();
@@ -76,8 +77,11 @@ public class XEnvironment implements Iterable<EnvironmentComponent> {
         Log.d(TAG, "Stopped component " + name);
       } catch (RuntimeException e) {
         Log.e(TAG, "Component stop failed for " + name, e);
-        throw e;
+        if (firstFailure == null) firstFailure = e;
       }
+    }
+    if (firstFailure != null) {
+      Log.e(TAG, "Environment component shutdown finished with failure(s)", firstFailure);
     }
     Log.d(TAG, "Environment component shutdown finished");
   }

--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -14,7 +14,6 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.Executors;
 
 public abstract class ProcessHelper {
   private static final String TAG = "ProcessHelper";
@@ -239,8 +238,7 @@ public abstract class ProcessHelper {
   }
 
   private static void createDebugThread(final InputStream inputStream) {
-    Executors.newSingleThreadExecutor()
-        .execute(
+    new Thread(
             () -> {
               try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
                 String line;
@@ -255,25 +253,26 @@ public abstract class ProcessHelper {
               } catch (IOException e) {
                 Log.e("ProcessHelper", "Error in debug thread", e);
               }
-            });
+            },
+            "ProcessDebugReader")
+        .start();
   }
 
   private static void createWaitForThread(
       java.lang.Process process, final Callback<Integer> terminationCallback) {
-    Executors.newSingleThreadExecutor()
-        .execute(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  int status = process.waitFor();
-                  drainDeadChildren("process waitFor");
-                  terminationCallback.call(status);
-                } catch (InterruptedException e) {
-                  Log.e("ProcessHelper", "Error waiting for process termination", e);
-                }
+    new Thread(
+            () -> {
+              try {
+                int status = process.waitFor();
+                drainDeadChildren("process waitFor");
+                terminationCallback.call(status);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Log.e("ProcessHelper", "Error waiting for process termination", e);
               }
-            });
+            },
+            "ProcessWaitFor")
+        .start();
   }
 
   public static void removeAllDebugCallbacks() {

--- a/app/src/main/runtime/wine/WineRequestHandler.java
+++ b/app/src/main/runtime/wine/WineRequestHandler.java
@@ -24,7 +24,9 @@ public class WineRequestHandler {
   }
 
   private Context context;
-  private ServerSocket serverSocket;
+  private volatile ServerSocket serverSocket;
+  private volatile boolean running;
+  private volatile ExecutorService executor;
 
   public ServerSocket getServerSocket() {
     return serverSocket;
@@ -34,30 +36,53 @@ public class WineRequestHandler {
     this.context = context;
   }
 
-  public void start() {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
-    executor.execute(
+  public synchronized void start() {
+    if (running) return;
+    running = true;
+    executor = Executors.newSingleThreadExecutor();
+    final ExecutorService activeExecutor = executor;
+    activeExecutor.execute(
         () -> {
+          ServerSocket localServerSocket = null;
           try {
-            serverSocket = new ServerSocket(20000);
-            while (true) {
-              Socket socket = serverSocket.accept();
-              DataInputStream inputStream = new DataInputStream(socket.getInputStream());
-              DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
-              int requestCode = inputStream.readInt();
-              handleRequest(inputStream, outputStream, requestCode);
+            localServerSocket = new ServerSocket(20000);
+            serverSocket = localServerSocket;
+            while (running) {
+              try (Socket socket = localServerSocket.accept();
+                  DataInputStream inputStream = new DataInputStream(socket.getInputStream());
+                  DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream())) {
+                int requestCode = inputStream.readInt();
+                handleRequest(inputStream, outputStream, requestCode);
+              }
             }
           } catch (IOException e) {
+            if (running) {
+              Log.e("WineRequestHandler", "Server error", e);
+            }
+          } finally {
+            if (executor == activeExecutor) running = false;
+            try {
+              if (localServerSocket != null) localServerSocket.close();
+            } catch (IOException ignored) {
+            }
+            if (serverSocket == localServerSocket) serverSocket = null;
+            activeExecutor.shutdown();
           }
         });
   }
 
-  public void stop() {
+  public synchronized void stop() {
+    running = false;
     if (serverSocket != null) {
       try {
         serverSocket.close();
       } catch (IOException e) {
       }
+      serverSocket = null;
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+      executor = null;
     }
   }
 


### PR DESCRIPTION
- Continue stopping remaining environment components if one component fails during session teardown.
- Replace single-use cleanup/process helper executors with short-lived named threads.
- Add explicit executor ownership and shutdown for the Wine request server.
- Close Wine request client sockets with try-with-resources after each request.
- Add explicit executor ownership and shutdown for the MIDI receive server.
- Guard Wine and MIDI server socket cleanup against quick relaunch races.
- Keep return-home behavior separate from app-wide store service shutdown.
- Validated with `./gradlew :app:compileStandardDebugJavaWithJavac`.