### PR TITLE
Fix FPS limiter frame pacing

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -239,6 +239,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private ImageFs imageFs;
     private FrameRating frameRating = null;
     private boolean effectiveShowFPS = false;
+    private int runtimeFpsLimit = 0;
     private String lastRendererName = "OpenGL";
     private String lastGpuName = null;
     private Runnable editInputControlsCallback;
@@ -442,7 +443,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         Runnable applyRefresh = () -> {
             if (isFinishing() || isDestroyed()) return;
 
-            RefreshRateUtils.applyPreferredRefreshRate(this, getRefreshRateOverride());
+            RefreshRateUtils.applyPreferredRefreshRate(this, getRefreshRateOverride(), runtimeFpsLimit);
         };
 
         if (Looper.myLooper() == Looper.getMainLooper()) {
@@ -2886,9 +2887,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
                     @Override
                     public void onFPSLimitChanged(int limit) {
+                        runtimeFpsLimit = Math.max(0, limit);
                         if (xServerView != null) {
-                            xServerView.getRenderer().setFpsLimit(limit);
+                            xServerView.getRenderer().setFpsLimit(runtimeFpsLimit);
                         }
+                        applyPreferredRefreshRate();
                         renderDrawerMenu();
                     }
                 };

--- a/app/src/main/shared/android/RefreshRateUtils.java
+++ b/app/src/main/shared/android/RefreshRateUtils.java
@@ -19,6 +19,7 @@ import java.util.WeakHashMap;
 public final class RefreshRateUtils {
   private static final String TAG = "RefreshRateUtils";
   private static final float DEFAULT_REFRESH_RATE = 60f;
+  private static final float FRAME_CADENCE_EPSILON = 0.01f;
   private static final Map<Activity, ViewTreeObserver.OnWindowFocusChangeListener>
       WINDOW_FOCUS_LISTENERS = new WeakHashMap<>();
 
@@ -180,6 +181,56 @@ public final class RefreshRateUtils {
     return requestedHz <= 0 ? currentMode.getModeId() : 0;
   }
 
+  public static int resolveFramePacedRefreshRate(Activity activity, int requestedHz, int fpsLimit) {
+    if (fpsLimit <= 0) {
+      return requestedHz;
+    }
+
+    float preferredRefreshRate = resolvePreferredRefreshRate(activity, requestedHz);
+    if (isFrameCadenceCompatible(preferredRefreshRate, fpsLimit)) {
+      return Math.round(preferredRefreshRate);
+    }
+
+    Display display = getDisplay(activity);
+    if (display == null) {
+      return fpsLimit;
+    }
+
+    Display.Mode currentMode = display.getMode();
+    Display.Mode bestMode = null;
+    float bestModeRate = 0f;
+
+    for (Display.Mode mode : display.getSupportedModes()) {
+      if (!isSameModeGroup(currentMode, mode)) continue;
+
+      float refreshRate = mode.getRefreshRate();
+      if (refreshRate <= 0f || refreshRate < fpsLimit) continue;
+      if (!isFrameCadenceCompatible(refreshRate, fpsLimit)) continue;
+
+      if (bestMode == null
+          || Math.round(refreshRate) == fpsLimit
+          || refreshRate < bestModeRate) {
+        bestMode = mode;
+        bestModeRate = refreshRate;
+      }
+    }
+
+    if (bestMode != null) {
+      return Math.round(bestModeRate);
+    }
+    return fpsLimit;
+  }
+
+  private static boolean isFrameCadenceCompatible(float refreshRate, int fpsLimit) {
+    if (refreshRate <= 0f || fpsLimit <= 0 || refreshRate < fpsLimit) {
+      return false;
+    }
+
+    float ratio = refreshRate / fpsLimit;
+    int nearestMultiple = Math.round(ratio);
+    return nearestMultiple >= 1 && Math.abs(ratio - nearestMultiple) <= FRAME_CADENCE_EPSILON;
+  }
+
   private static boolean isSameModeGroup(Display.Mode currentMode, Display.Mode candidateMode) {
     return currentMode.getPhysicalWidth() == candidateMode.getPhysicalWidth()
         && currentMode.getPhysicalHeight() == candidateMode.getPhysicalHeight();
@@ -239,11 +290,16 @@ public final class RefreshRateUtils {
   }
 
   public static void applyPreferredRefreshRate(Activity activity, int requestedHz) {
+    applyPreferredRefreshRate(activity, requestedHz, 0);
+  }
+
+  public static void applyPreferredRefreshRate(Activity activity, int requestedHz, int fpsLimit) {
     if (activity.isFinishing() || activity.isDestroyed()) return;
 
+    int effectiveRequestedHz = resolveFramePacedRefreshRate(activity, requestedHz, fpsLimit);
     WindowManager.LayoutParams params = activity.getWindow().getAttributes();
-    int modeId = resolvePreferredDisplayModeId(activity, requestedHz);
-    float refreshRate = resolvePreferredRefreshRate(activity, requestedHz);
+    int modeId = resolvePreferredDisplayModeId(activity, effectiveRequestedHz);
+    float refreshRate = resolvePreferredRefreshRate(activity, effectiveRequestedHz);
     params.preferredDisplayModeId = modeId;
     params.preferredRefreshRate = refreshRate;
     activity.getWindow().setAttributes(params);
@@ -252,6 +308,10 @@ public final class RefreshRateUtils {
         activity.getClass().getSimpleName()
             + " applyPreferredRefreshRate requestedHz="
             + requestedHz
+            + " fpsLimit="
+            + fpsLimit
+            + " effectiveRequestedHz="
+            + effectiveRequestedHz
             + " modeId="
             + modeId
             + " refreshRate="


### PR DESCRIPTION
## Summary
- Reapply the game window refresh-rate preference when the runtime FPS limiter changes.
- Prefer display modes that produce an even frame cadence for the selected FPS cap.
- Keep higher refresh modes when they are already cadence-compatible, such as 60 FPS on 120 Hz.

## Root Cause
- The runtime limiter could cap frames at rates like 90 FPS while the Android window remained on a 120 Hz mode.
- That produces uneven frame presentation cadence and can feel ghosty or laggy.

## Validation
- .\gradlew.bat :app:compileStandardDebugJavaWithJavac