### PR TITLE
fix: Download Manager — global queue, persistence, and Steam multi-de…

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -137,6 +137,17 @@ class PluviaApp : Application() {
                 runCatching { PluviaDatabase.init(this@PluviaApp) }
                     .onFailure { Log.e("PluviaApp", "Database warmup failed", it) }
 
+                // Initialize the cross-store DownloadCoordinator and auto-resume any
+                // downloads that were running when the app was killed. PAUSED downloads
+                // stay PAUSED; DOWNLOADING ones are demoted to QUEUED and dispatched as
+                // store services start.
+                runCatching {
+                    val db = PluviaDatabase.getInstance(this@PluviaApp)
+                    com.winlator.cmod.app.service.download.DownloadCoordinator.init(db)
+                    com.winlator.cmod.app.service.download.DownloadCoordinator
+                        .attemptStartupRestoration()
+                }.onFailure { Log.e("PluviaApp", "DownloadCoordinator startup failed", it) }
+
                 com.winlator.cmod.runtime.system.LogManager
                     .rotateLogsOnAppStart(this@PluviaApp)
                 com.winlator.cmod.runtime.system.LogManager

--- a/app/src/main/app/db/PluviaDatabase.kt
+++ b/app/src/main/app/db/PluviaDatabase.kt
@@ -24,6 +24,8 @@ import com.winlator.cmod.feature.stores.steam.db.dao.EncryptedAppTicketDao
 import com.winlator.cmod.feature.stores.steam.db.dao.FileChangeListsDao
 import com.winlator.cmod.feature.stores.steam.db.dao.SteamAppDao
 import com.winlator.cmod.feature.stores.steam.db.dao.SteamLicenseDao
+import com.winlator.cmod.app.db.download.DownloadRecord
+import com.winlator.cmod.app.db.download.DownloadRecordDao
 
 const val DATABASE_NAME = "pluvia_database"
 
@@ -39,8 +41,9 @@ const val DATABASE_NAME = "pluvia_database"
         com.winlator.cmod.feature.stores.epic.data.EpicGame::class,
         com.winlator.cmod.feature.stores.gog.data.GOGGame::class,
         DownloadingAppInfo::class,
+        DownloadRecord::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = false,
 )
 @TypeConverters(
@@ -72,6 +75,8 @@ abstract class PluviaDatabase : RoomDatabase() {
     abstract fun encryptedAppTicketDao(): EncryptedAppTicketDao
 
     abstract fun downloadingAppInfoDao(): DownloadingAppInfoDao
+
+    abstract fun downloadRecordDao(): DownloadRecordDao
 
     companion object {
         @Volatile

--- a/app/src/main/app/db/download/DownloadRecord.kt
+++ b/app/src/main/app/db/download/DownloadRecord.kt
@@ -1,0 +1,61 @@
+package com.winlator.cmod.app.db.download
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Single source of truth for one download across Steam / Epic / GOG. The DownloadCoordinator
+ * owns this table and uses it to enforce a global concurrency limit and to restore in-progress
+ * downloads after the app is restarted.
+ */
+@Entity(
+    tableName = "download_records",
+    indices = [Index(value = ["store", "store_game_id"], unique = true)],
+)
+data class DownloadRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo("store")
+    val store: String,
+    @ColumnInfo("store_game_id")
+    val storeGameId: String,
+    @ColumnInfo("title")
+    val title: String = "",
+    @ColumnInfo("art_url")
+    val artUrl: String = "",
+    @ColumnInfo("install_path")
+    val installPath: String = "",
+    /** JSON-encoded list of DLC IDs. Empty string when not applicable. */
+    @ColumnInfo("selected_dlcs")
+    val selectedDlcs: String = "",
+    @ColumnInfo("language")
+    val language: String = "",
+    /** One of: QUEUED, DOWNLOADING, PAUSED, COMPLETE, CANCELLED, FAILED. */
+    @ColumnInfo("status")
+    val status: String = STATUS_QUEUED,
+    @ColumnInfo("bytes_downloaded")
+    val bytesDownloaded: Long = 0L,
+    @ColumnInfo("bytes_total")
+    val bytesTotal: Long = 0L,
+    @ColumnInfo("error_message")
+    val errorMessage: String? = null,
+    @ColumnInfo("created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo("updated_at")
+    val updatedAt: Long = System.currentTimeMillis(),
+) {
+    companion object {
+        const val STORE_STEAM = "STEAM"
+        const val STORE_EPIC = "EPIC"
+        const val STORE_GOG = "GOG"
+
+        const val STATUS_QUEUED = "QUEUED"
+        const val STATUS_DOWNLOADING = "DOWNLOADING"
+        const val STATUS_PAUSED = "PAUSED"
+        const val STATUS_COMPLETE = "COMPLETE"
+        const val STATUS_CANCELLED = "CANCELLED"
+        const val STATUS_FAILED = "FAILED"
+    }
+}

--- a/app/src/main/app/db/download/DownloadRecordDao.kt
+++ b/app/src/main/app/db/download/DownloadRecordDao.kt
@@ -1,0 +1,65 @@
+package com.winlator.cmod.app.db.download
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface DownloadRecordDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(record: DownloadRecord): Long
+
+    @Update
+    suspend fun update(record: DownloadRecord)
+
+    @Query("SELECT * FROM download_records ORDER BY created_at ASC")
+    suspend fun getAll(): List<DownloadRecord>
+
+    @Query("SELECT * FROM download_records ORDER BY created_at ASC")
+    fun observeAll(): Flow<List<DownloadRecord>>
+
+    @Query("SELECT * FROM download_records WHERE store = :store AND store_game_id = :gameId LIMIT 1")
+    suspend fun findByStoreGame(store: String, gameId: String): DownloadRecord?
+
+    @Query("SELECT * FROM download_records WHERE id = :id LIMIT 1")
+    suspend fun findById(id: Long): DownloadRecord?
+
+    @Query("SELECT * FROM download_records WHERE status = :status ORDER BY created_at ASC")
+    suspend fun findByStatus(status: String): List<DownloadRecord>
+
+    @Query("SELECT COUNT(*) FROM download_records WHERE status = :status")
+    suspend fun countByStatus(status: String): Int
+
+    @Query("DELETE FROM download_records WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query(
+        "DELETE FROM download_records WHERE status IN " +
+            "('${DownloadRecord.STATUS_COMPLETE}', '${DownloadRecord.STATUS_CANCELLED}', '${DownloadRecord.STATUS_FAILED}')",
+    )
+    suspend fun deleteFinished(): Int
+
+    @Query("UPDATE download_records SET status = :newStatus, updated_at = :now WHERE status = :oldStatus")
+    suspend fun replaceStatus(oldStatus: String, newStatus: String, now: Long = System.currentTimeMillis()): Int
+
+    @Query("UPDATE download_records SET status = :status, updated_at = :now, error_message = :error WHERE id = :id")
+    suspend fun updateStatus(
+        id: Long,
+        status: String,
+        error: String? = null,
+        now: Long = System.currentTimeMillis(),
+    ): Int
+
+    @Query(
+        "UPDATE download_records SET bytes_downloaded = :bytesDownloaded, bytes_total = :bytesTotal, updated_at = :now WHERE id = :id",
+    )
+    suspend fun updateProgress(
+        id: Long,
+        bytesDownloaded: Long,
+        bytesTotal: Long,
+        now: Long = System.currentTimeMillis(),
+    ): Int
+}

--- a/app/src/main/app/di/DatabaseModule.kt
+++ b/app/src/main/app/di/DatabaseModule.kt
@@ -57,4 +57,8 @@ class DatabaseModule {
     @Provides
     @Singleton
     fun provideGogGameDao(db: PluviaDatabase): com.winlator.cmod.feature.stores.gog.db.dao.GOGGameDao = db.gogGameDao()
+
+    @Provides
+    @Singleton
+    fun provideDownloadRecordDao(db: PluviaDatabase): com.winlator.cmod.app.db.download.DownloadRecordDao = db.downloadRecordDao()
 }

--- a/app/src/main/app/service/DownloadService.kt
+++ b/app/src/main/app/service/DownloadService.kt
@@ -110,8 +110,56 @@ object DownloadService {
         SteamService.getAllDownloads().forEach { (id, info) -> list.add("STEAM_$id" to info) }
         EpicService.getAllDownloads().forEach { (id, info) -> list.add("EPIC_$id" to info) }
         GOGService.getAllDownloads().forEach { (id, info) -> list.add("GOG_$id" to info) }
+
+        // Cover the cross-restart case: the DownloadCoordinator may know about records
+        // (PAUSED or QUEUED) for which no store has yet created an in-memory DownloadInfo.
+        // Fabricate stub DownloadInfos for those so the Downloads tab shows them and the user
+        // can Resume / Cancel them.
+        val knownIds = list.map { it.first }.toSet()
+        val coord = com.winlator.cmod.app.service.download.DownloadCoordinator
+        coord.snapshotRecords().forEach { record ->
+            val id = "${record.store}_${record.storeGameId}"
+            if (id in knownIds) return@forEach
+            val phase = mapRecordStatusToPhase(record.status)
+            val gameIdInt = record.storeGameId.toIntOrNull() ?: 0
+            val stub =
+                com.winlator.cmod.feature.stores.steam.data.DownloadInfo(
+                    jobCount = 1,
+                    gameId = gameIdInt,
+                    downloadingAppIds = java.util.concurrent.CopyOnWriteArrayList(),
+                ).apply {
+                    setActive(false)
+                    updateStatus(phase, "Paused — tap Resume to continue".takeIf {
+                        phase == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.PAUSED
+                    })
+                    if (record.bytesTotal > 0L) {
+                        setTotalExpectedBytes(record.bytesTotal)
+                        initializeBytesDownloaded(record.bytesDownloaded)
+                    }
+                }
+            list.add(id to stub)
+        }
         return list
     }
+
+    private fun mapRecordStatusToPhase(
+        status: String,
+    ): com.winlator.cmod.feature.stores.steam.enums.DownloadPhase =
+        when (status) {
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_DOWNLOADING ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.DOWNLOADING
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_QUEUED ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.QUEUED
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_PAUSED ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.PAUSED
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_COMPLETE ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.COMPLETE
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_CANCELLED ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.CANCELLED
+            com.winlator.cmod.app.db.download.DownloadRecord.STATUS_FAILED ->
+                com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.FAILED
+            else -> com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.UNKNOWN
+        }
 
     fun pauseAll() {
         SteamService.pauseAll()
@@ -173,6 +221,10 @@ object DownloadService {
         SteamService.clearCompletedDownloads()
         EpicService.clearCompletedDownloads()
         GOGService.clearCompletedDownloads()
+        // Sweep finished records from the cross-store coordinator table too.
+        com.winlator.cmod.app.service.download.DownloadCoordinator.runOnScope {
+            com.winlator.cmod.app.service.download.DownloadCoordinator.clear()
+        }
     }
 
     fun cancelDownload(id: String) {

--- a/app/src/main/app/service/download/DownloadCoordinator.kt
+++ b/app/src/main/app/service/download/DownloadCoordinator.kt
@@ -1,0 +1,418 @@
+package com.winlator.cmod.app.service.download
+
+import com.winlator.cmod.app.PluviaApp
+import com.winlator.cmod.app.db.PluviaDatabase
+import com.winlator.cmod.app.db.download.DownloadRecord
+import com.winlator.cmod.app.db.download.DownloadRecordDao
+import com.winlator.cmod.feature.stores.steam.events.AndroidEvent
+import com.winlator.cmod.feature.stores.steam.utils.PrefManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Single source of truth for downloads across Steam / Epic / GOG.
+ *
+ * Responsibilities:
+ *  * Enforces a global concurrency limit (PrefManager.downloadQueueSize) shared across all stores.
+ *  * Persists every download as a [DownloadRecord] so they survive app restarts.
+ *  * Auto-resumes downloads that were active when the app exited; leaves PAUSED ones paused.
+ *
+ * Flow of a download:
+ *  1. The store-specific service receives a download request from the UI.
+ *  2. It calls [requestSlot]. The coordinator persists or updates a DownloadRecord and tells
+ *     the caller whether to start now ([Decision.Start]) or wait ([Decision.Queue]).
+ *  3. When a download finishes, the store calls [notifyFinished]; the coordinator updates the
+ *     record and dispatches the next queued download (if any) via the registered [Dispatcher].
+ *  4. UI controls (pause / resume / cancel / clear) call into the coordinator, which mutates
+ *     the record and asks the dispatcher to perform the side effect (cancel the running job,
+ *     delete partial files, etc.).
+ */
+object DownloadCoordinator {
+    /**
+     * A per-store hook the coordinator uses to start, pause, resume, or cancel an actual
+     * download. Stores register their dispatcher at service startup.
+     */
+    interface Dispatcher {
+        /**
+         * Start a download that the coordinator just dequeued. The store should look up the
+         * pending request matching this record and launch the actual coroutine. Called from
+         * the coordinator's IO scope.
+         */
+        fun startQueued(record: DownloadRecord)
+
+        /** Pause an actively running download, persisting partial files. */
+        fun pauseRunning(record: DownloadRecord)
+
+        /**
+         * Cancel an actively running download and delete partial files. The coordinator has
+         * already marked the record CANCELLED.
+         */
+        fun cancelRunning(record: DownloadRecord)
+    }
+
+    private val mutex = Mutex()
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val dispatchers = mutableMapOf<String, Dispatcher>()
+
+    @Volatile
+    private var dao: DownloadRecordDao? = null
+
+    @Volatile
+    private var startupRestored = false
+
+    private val recordsState = MutableStateFlow<List<DownloadRecord>>(emptyList())
+    val records: Flow<List<DownloadRecord>> = recordsState.asStateFlow()
+
+    private val recordChanges = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
+    val changes = recordChanges.asSharedFlow()
+
+    fun init(database: PluviaDatabase) {
+        if (dao != null) return
+        dao = database.downloadRecordDao()
+    }
+
+    fun registerDispatcher(store: String, dispatcher: Dispatcher) {
+        dispatchers[store] = dispatcher
+        // A newly-registered dispatcher might have queued records waiting from a previous
+        // process or from a moment ago when it wasn't available yet. Drain the queue.
+        if (dao != null) {
+            scope.launch { tick() }
+        }
+    }
+
+    fun unregisterDispatcher(store: String) {
+        dispatchers.remove(store)
+    }
+
+    /** Result of [requestSlot]. */
+    sealed class Decision {
+        data class Start(val record: DownloadRecord) : Decision()
+
+        data class Queue(val record: DownloadRecord) : Decision()
+    }
+
+    /**
+     * Persist a download request and decide whether to start it immediately or queue it. The
+     * caller (a store service) should inspect the result; on Start it should launch the actual
+     * download, on Queue it should create a UI entry showing QUEUED status and wait for the
+     * coordinator to dispatch via [Dispatcher.startQueued].
+     */
+    suspend fun requestSlot(
+        store: String,
+        storeGameId: String,
+        title: String = "",
+        artUrl: String = "",
+        installPath: String = "",
+        selectedDlcs: String = "",
+        language: String = "",
+        bytesTotal: Long = 0L,
+    ): Decision {
+        val daoRef = dao ?: throw IllegalStateException("DownloadCoordinator not initialised")
+
+        return mutex.withLock {
+            val now = System.currentTimeMillis()
+            val existing = daoRef.findByStoreGame(store, storeGameId)
+
+            // Re-entry guard: tick() promotes a QUEUED record to DOWNLOADING and then
+            // dispatches it to the store, which calls back into requestSlot via the public
+            // download API. The slot was already granted by tick(); without this short
+            // circuit we'd count the record against itself, decide there are no free slots,
+            // and rewrite it back to QUEUED — making Resume hang at "Queued" forever.
+            if (existing != null && existing.status == DownloadRecord.STATUS_DOWNLOADING) {
+                return@withLock Decision.Start(existing)
+            }
+
+            val maxParallel = PrefManager.downloadQueueSize.coerceAtLeast(1)
+            val activeCount = daoRef.countByStatus(DownloadRecord.STATUS_DOWNLOADING)
+
+            val canStartNow = activeCount < maxParallel
+
+            val (status, decisionFactory) =
+                if (canStartNow) {
+                    DownloadRecord.STATUS_DOWNLOADING to { r: DownloadRecord -> Decision.Start(r) }
+                } else {
+                    DownloadRecord.STATUS_QUEUED to { r: DownloadRecord -> Decision.Queue(r) }
+                }
+
+            val record =
+                if (existing == null) {
+                    val newRecord =
+                        DownloadRecord(
+                            store = store,
+                            storeGameId = storeGameId,
+                            title = title,
+                            artUrl = artUrl,
+                            installPath = installPath,
+                            selectedDlcs = selectedDlcs,
+                            language = language,
+                            bytesTotal = bytesTotal,
+                            status = status,
+                            createdAt = now,
+                            updatedAt = now,
+                        )
+                    val id = daoRef.upsert(newRecord)
+                    newRecord.copy(id = id)
+                } else {
+                    // We only reach here for re-enqueue cases (record was COMPLETE/CANCELLED/
+                    // FAILED/PAUSED/QUEUED — anything but DOWNLOADING, which short-circuits
+                    // above). For a re-enqueue the caller is fully respecifying the request,
+                    // so OVERWRITE the row with the new values. Previously we did
+                    // `selectedDlcs.ifEmpty { existing.selectedDlcs }` which was ambiguous —
+                    // an empty list (user wants base game only) was indistinguishable from
+                    // "caller didn't supply", so old DLC selections leaked through to a fresh
+                    // download.
+                    val updated =
+                        existing.copy(
+                            title = title,
+                            artUrl = artUrl,
+                            installPath = installPath,
+                            selectedDlcs = selectedDlcs,
+                            language = language,
+                            bytesTotal = if (bytesTotal > 0L) bytesTotal else existing.bytesTotal,
+                            status = status,
+                            errorMessage = null,
+                            updatedAt = now,
+                        )
+                    daoRef.update(updated)
+                    updated
+                }
+
+            refreshState(daoRef)
+            decisionFactory(record)
+        }
+    }
+
+    /** Update progress for a running download. Lightweight; runs without locking the queue. */
+    fun updateProgress(store: String, storeGameId: String, bytesDownloaded: Long, bytesTotal: Long) {
+        val daoRef = dao ?: return
+        scope.launch {
+            val record = daoRef.findByStoreGame(store, storeGameId) ?: return@launch
+            daoRef.updateProgress(record.id, bytesDownloaded, bytesTotal)
+        }
+    }
+
+    /**
+     * Notify the coordinator that a download has terminated (success / fail / cancel / pause).
+     * The coordinator persists the new status and starts the next queued download.
+     */
+    suspend fun notifyFinished(
+        store: String,
+        storeGameId: String,
+        finalStatus: String,
+        error: String? = null,
+    ) {
+        val daoRef = dao ?: return
+        mutex.withLock {
+            val record = daoRef.findByStoreGame(store, storeGameId) ?: return@withLock
+            daoRef.updateStatus(record.id, finalStatus, error)
+            refreshState(daoRef)
+        }
+        // Drain the queue outside the lock to avoid re-entrancy with dispatcher callbacks.
+        tick()
+    }
+
+    /** Pause a running download. Marks PAUSED and asks the dispatcher to cancel its job. */
+    suspend fun pause(store: String, storeGameId: String) {
+        val daoRef = dao ?: return
+        val record = daoRef.findByStoreGame(store, storeGameId) ?: return
+        if (record.status == DownloadRecord.STATUS_COMPLETE ||
+            record.status == DownloadRecord.STATUS_CANCELLED
+        ) {
+            return
+        }
+        mutex.withLock {
+            daoRef.updateStatus(record.id, DownloadRecord.STATUS_PAUSED)
+            refreshState(daoRef)
+        }
+        dispatchers[store]?.pauseRunning(record)
+        tick()
+    }
+
+    suspend fun pauseAll() {
+        val daoRef = dao ?: return
+        val running = daoRef.findByStatus(DownloadRecord.STATUS_DOWNLOADING) +
+            daoRef.findByStatus(DownloadRecord.STATUS_QUEUED)
+        running.forEach { pause(it.store, it.storeGameId) }
+    }
+
+    /** Resume a paused / queued / failed download. */
+    suspend fun resume(store: String, storeGameId: String) {
+        val daoRef = dao ?: return
+        val record = daoRef.findByStoreGame(store, storeGameId) ?: return
+        when (record.status) {
+            DownloadRecord.STATUS_PAUSED,
+            DownloadRecord.STATUS_QUEUED,
+            DownloadRecord.STATUS_FAILED,
+            -> {
+                mutex.withLock {
+                    daoRef.updateStatus(record.id, DownloadRecord.STATUS_QUEUED)
+                    refreshState(daoRef)
+                }
+                tick()
+            }
+            else -> Unit
+        }
+    }
+
+    suspend fun resumeAll() {
+        val daoRef = dao ?: return
+        val toResume = daoRef.findByStatus(DownloadRecord.STATUS_PAUSED)
+        toResume.forEach { resume(it.store, it.storeGameId) }
+    }
+
+    /** Cancel a download and delete partial files via the dispatcher. */
+    suspend fun cancel(store: String, storeGameId: String) {
+        val daoRef = dao ?: return
+        val record = daoRef.findByStoreGame(store, storeGameId) ?: return
+        mutex.withLock {
+            daoRef.updateStatus(record.id, DownloadRecord.STATUS_CANCELLED)
+            refreshState(daoRef)
+        }
+        dispatchers[store]?.cancelRunning(record)
+        tick()
+    }
+
+    suspend fun cancelAll() {
+        val daoRef = dao ?: return
+        val cancellable =
+            daoRef.findByStatus(DownloadRecord.STATUS_DOWNLOADING) +
+                daoRef.findByStatus(DownloadRecord.STATUS_QUEUED) +
+                daoRef.findByStatus(DownloadRecord.STATUS_PAUSED)
+        cancellable.forEach { cancel(it.store, it.storeGameId) }
+    }
+
+    /** Remove finished records (COMPLETE / CANCELLED / FAILED) from the table. */
+    suspend fun clear() {
+        val daoRef = dao ?: return
+        mutex.withLock {
+            daoRef.deleteFinished()
+            refreshState(daoRef)
+        }
+        // Notify the Downloads tab to refresh.
+        PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(0, false))
+    }
+
+    /**
+     * Drain the queue: while there are free slots and queued records, dispatch the oldest one
+     * to its store-specific dispatcher.
+     */
+    suspend fun tick() {
+        val daoRef = dao ?: return
+        val toStart = mutableListOf<DownloadRecord>()
+        mutex.withLock {
+            val maxParallel = PrefManager.downloadQueueSize.coerceAtLeast(1)
+            var activeCount = daoRef.countByStatus(DownloadRecord.STATUS_DOWNLOADING)
+            val queued = daoRef.findByStatus(DownloadRecord.STATUS_QUEUED)
+            val now = System.currentTimeMillis()
+
+            for (record in queued) {
+                if (activeCount >= maxParallel) break
+                val started = record.copy(status = DownloadRecord.STATUS_DOWNLOADING, updatedAt = now)
+                daoRef.update(started)
+                toStart.add(started)
+                activeCount++
+            }
+            refreshState(daoRef)
+        }
+
+        // Dispatch outside the lock so dispatchers can synchronously call back into the
+        // coordinator if needed.
+        toStart.forEach { record ->
+            val dispatcher = dispatchers[record.store]
+            if (dispatcher != null) {
+                runCatching { dispatcher.startQueued(record) }
+                    .onFailure { err ->
+                        Timber.e(err, "Dispatcher ${record.store} failed to start record ${record.id}")
+                        notifyFinished(record.store, record.storeGameId, DownloadRecord.STATUS_FAILED, err.message)
+                    }
+            } else {
+                Timber.w("No dispatcher registered for store ${record.store}; record ${record.id} stays QUEUED")
+            }
+        }
+    }
+
+    /**
+     * Called once on app startup. Records that were DOWNLOADING when the process died are
+     * moved back to QUEUED (auto-resume); PAUSED records stay PAUSED until the user resumes
+     * them. Then the queue is drained.
+     *
+     * Idempotent: subsequent calls within the same process are no-ops.
+     */
+    suspend fun onAppStart() {
+        if (startupRestored) return
+        startupRestored = true
+        val daoRef = dao ?: return
+        mutex.withLock {
+            // DOWNLOADING -> QUEUED (auto-resume on next launch).
+            daoRef.replaceStatus(DownloadRecord.STATUS_DOWNLOADING, DownloadRecord.STATUS_QUEUED)
+            refreshState(daoRef)
+        }
+        tick()
+    }
+
+    /** Triggers onAppStart from a non-coroutine caller. */
+    fun attemptStartupRestoration() {
+        if (startupRestored) return
+        scope.launch { onAppStart() }
+    }
+
+    /**
+     * Called by AppTerminationHelper when the app is exiting. Does NOT pause everything — it
+     * leaves DOWNLOADING records in DOWNLOADING state so they auto-resume on next launch, and
+     * leaves PAUSED records PAUSED.
+     */
+    fun onAppExit() {
+        // Nothing to persist here — every status transition was already written to the DAO.
+    }
+
+    private suspend fun refreshState(daoRef: DownloadRecordDao) {
+        val all = daoRef.getAll()
+        recordsState.value = all
+        recordChanges.tryEmit(Unit)
+    }
+
+    /** Synchronous helper for callers that aren't already in a coroutine. */
+    fun blockingTick() {
+        scope.launch { tick() }
+    }
+
+    /** Initialize records flow on startup. Safe to call multiple times. */
+    suspend fun loadInitial() {
+        val daoRef = dao ?: return
+        refreshState(daoRef)
+    }
+
+    /**
+     * Look up the persisted record for a given store+gameId. Useful for resume to recover the
+     * original install path / dlcs / language without going through the in-memory params map.
+     */
+    suspend fun findRecord(store: String, storeGameId: String): DownloadRecord? {
+        val daoRef = dao ?: return null
+        return daoRef.findByStoreGame(store, storeGameId)
+    }
+
+    /** All records currently in the table (snapshot). */
+    fun snapshotRecords(): List<DownloadRecord> = recordsState.value
+
+    /** Internal: run a coordinator action from a non-coroutine context. */
+    internal fun runOnScope(block: suspend () -> Unit) {
+        scope.launch { block() }
+    }
+
+    /** Test/debug helper. */
+    internal fun runBlockingForTest(block: suspend () -> Unit) {
+        runBlocking { block() }
+    }
+}

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -6887,6 +6887,15 @@ class UnifiedActivity :
             }
         }
 
+        // Re-sync the list whenever the cross-store DownloadCoordinator records change. This
+        // is what makes PAUSED records (loaded from DB after app restart) appear in the tab,
+        // and what removes COMPLETE/CANCELLED/FAILED rows after Clear.
+        LaunchedEffect(syncDownloads) {
+            com.winlator.cmod.app.service.download.DownloadCoordinator.changes.collect {
+                latestSyncDownloads()
+            }
+        }
+
         downloads.forEach { (_, info) ->
             LaunchedEffect(info) {
                 info.getStatusFlow().collect {
@@ -6984,6 +6993,12 @@ class UnifiedActivity :
                             if (queueSize > 1) {
                                 queueSize--
                                 PrefManager.downloadQueueSize = queueSize
+                                // Tick the global coordinator so the new (lower) limit is
+                                // applied across all stores. Lowering doesn't auto-pause an
+                                // in-flight download; it just prevents new ones from starting
+                                // until the count drains under the new limit.
+                                com.winlator.cmod.app.service.download.DownloadCoordinator
+                                    .blockingTick()
                             }
                         },
                         modifier = Modifier.size(24.dp),
@@ -7006,8 +7021,9 @@ class UnifiedActivity :
                         onClick = {
                             queueSize++
                             PrefManager.downloadQueueSize = queueSize
-                            com.winlator.cmod.feature.stores.steam.service.SteamService
-                                .checkQueue()
+                            // Drain the global queue across all stores (Steam + Epic + GOG).
+                            com.winlator.cmod.app.service.download.DownloadCoordinator
+                                .blockingTick()
                         },
                         modifier = Modifier.size(24.dp),
                     ) {
@@ -7078,11 +7094,11 @@ class UnifiedActivity :
                     }
                 }
 
-                // Clear button - clears completed and cancelled downloads
+                // Clear button - clears completed, cancelled, and failed downloads
                 val hasCompletedOrCancelled =
                     downloads.any {
                         val s = it.second.getStatusFlow().value
-                        s == DownloadPhase.COMPLETE || s == DownloadPhase.CANCELLED
+                        s == DownloadPhase.COMPLETE || s == DownloadPhase.CANCELLED || s == DownloadPhase.FAILED
                     }
 
                 Spacer(Modifier.width(12.dp))
@@ -7137,13 +7153,40 @@ class UnifiedActivity :
                 }
             }
 
+            // Sort so the user always sees what's actually running first, then everything
+            // they can resume, then finished items, with cancelled at the very bottom.
+            // The list re-sorts on phase transitions because `tick` (incremented by the
+            // status flow collectors above) is read here, forcing recomposition.
+            @Suppress("UNUSED_EXPRESSION")
+            tick
+            val sortedDownloads =
+                downloads.sortedBy { (_, info) ->
+                    when (info.getStatusFlow().value) {
+                        // In-progress states grouped together at the top.
+                        DownloadPhase.DOWNLOADING,
+                        DownloadPhase.PREPARING,
+                        DownloadPhase.VERIFYING,
+                        DownloadPhase.PATCHING,
+                        DownloadPhase.APPLYING_DATA,
+                        DownloadPhase.FINALIZING,
+                        DownloadPhase.UNPACKING,
+                        DownloadPhase.UNKNOWN,
+                        -> 0
+                        DownloadPhase.PAUSED -> 1
+                        DownloadPhase.QUEUED -> 2
+                        DownloadPhase.COMPLETE -> 3
+                        DownloadPhase.FAILED -> 4
+                        DownloadPhase.CANCELLED -> 5
+                    }
+                }
+
             LazyColumn(state = listState, modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(downloads, key = { it.first }) { (id, info) ->
+                items(sortedDownloads, key = { it.first }) { (id, info) ->
                     DownloadItemDeck(id, info, isSelected = selectedId == id, onClick = {
                         if (selectedId == id) onSelectDownload(null) else onSelectDownload(id)
                     })
                 }
-                if (downloads.isEmpty()) {
+                if (sortedDownloads.isEmpty()) {
                     item { EmptyStateMessage("No active downloads.") }
                 }
             }

--- a/app/src/main/feature/stores/epic/service/EpicDownloadManager.kt
+++ b/app/src/main/feature/stores/epic/service/EpicDownloadManager.kt
@@ -606,6 +606,14 @@ class EpicDownloadManager
                                             val buffer = ByteArray(8192)
                                             var bytesRead: Int
                                             while (input.read(buffer).also { bytesRead = it } != -1) {
+                                                // Cooperative cancellation: bail out of the byte
+                                                // read loop immediately on pause/cancel instead of
+                                                // waiting until the chunk finishes.
+                                                if (!downloadInfo.isActive() || downloadInfo.isCancelling) {
+                                                    throw kotlinx.coroutines.CancellationException(
+                                                        "Download cancelled mid-chunk",
+                                                    )
+                                                }
                                                 output.write(buffer, 0, bytesRead)
                                                 downloadInfo.updateBytesDownloaded(bytesRead.toLong())
                                             }

--- a/app/src/main/feature/stores/epic/service/EpicService.kt
+++ b/app/src/main/feature/stores/epic/service/EpicService.kt
@@ -6,7 +6,9 @@ import android.os.IBinder
 import com.winlator.cmod.BuildConfig
 import com.winlator.cmod.R
 import com.winlator.cmod.app.PluviaApp
+import com.winlator.cmod.app.db.download.DownloadRecord
 import com.winlator.cmod.app.service.DownloadService
+import com.winlator.cmod.app.service.download.DownloadCoordinator
 import com.winlator.cmod.feature.shortcuts.LibraryShortcutUtils
 import com.winlator.cmod.feature.stores.epic.data.EpicCredentials
 import com.winlator.cmod.feature.stores.epic.data.EpicGame
@@ -287,140 +289,39 @@ class EpicService : Service() {
         }
 
         fun cancelDownload(appId: Int): Boolean {
-            val instance = getInstance()
-            val downloadInfo = instance?.activeDownloads?.get(appId)
-
-            return if (downloadInfo != null) {
-                Timber.tag("EPIC").i("Cancelling download for Epic game: $appId")
-                downloadInfo.isCancelling = true
-                downloadInfo.cancel("Cancelled by user")
-                // Delete partially downloaded files
-                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
-                    downloadInfo.awaitCompletion(timeoutMs = 3000L)
-                    val game = instance.epicManager.getGameById(appId)
-                    if (game != null) {
-                        val context = DownloadService.appContext
-                        val path =
-                            if (game.installPath.isNotEmpty()) {
-                                game.installPath
-                            } else if (context !=
-                                null
-                            ) {
-                                EpicConstants.getGameInstallPath(context, game.appName)
-                            } else {
-                                ""
-                            }
-                        if (path.isNotEmpty()) {
-                            val dirFile = java.io.File(path)
-                            if (dirFile.exists() && dirFile.isDirectory) {
-                                MarkerUtils.removeMarker(path, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                                MarkerUtils.removeMarker(path, Marker.DOWNLOAD_COMPLETE_MARKER)
-                                dirFile.deleteRecursively()
-                            }
-                        }
-                    }
-                    downloadInfo.updateStatus(DownloadPhase.CANCELLED)
-                    instance.activeDownloads.remove(appId)
-                }
-                Timber.tag("EPIC").d("Download cancelled for Epic game: $appId")
-                true
-            } else {
-                Timber.w("No active download found for Epic game: $appId")
-                false
+            // Route through the coordinator: it persists CANCELLED and asks our dispatcher to
+            // stop the running job and delete the partial install directory.
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.cancel(DownloadRecord.STORE_EPIC, appId.toString())
             }
+            return true
         }
 
         fun pauseDownload(appId: Int) {
-            val info = getInstance()?.activeDownloads?.get(appId) ?: return
-            val status = info.getStatusFlow().value
-            if (status == DownloadPhase.COMPLETE || status == DownloadPhase.CANCELLED) return
-
-            if (info.isActive()) {
-                info.isCancelling = false
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.cancel("Paused by user")
-            } else {
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.setActive(false)
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.pause(DownloadRecord.STORE_EPIC, appId.toString())
             }
         }
 
         fun pauseAll() {
-            getInstance()?.activeDownloads?.values?.forEach { info ->
-                val status = info.getStatusFlow().value
-                if (info.isActive()) {
-                    info.isCancelling = false
-                    info.updateStatus(DownloadPhase.PAUSED)
-                    info.cancel("Paused all")
-                } else if (status != DownloadPhase.COMPLETE && status != DownloadPhase.CANCELLED) {
-                    info.updateStatus(DownloadPhase.PAUSED)
-                    info.setActive(false)
-                }
-            }
+            DownloadCoordinator.runOnScope { DownloadCoordinator.pauseAll() }
         }
 
         fun resumeDownload(appId: Int) {
-            val instance = getInstance() ?: return
-            val context = DownloadService.appContext ?: return
-            val info = instance.activeDownloads[appId]
-            val status = info?.getStatusFlow()?.value
-            if (info != null && info.isActive()) return
-            if (status != null && status != DownloadPhase.PAUSED && status != DownloadPhase.QUEUED && status != DownloadPhase.FAILED) {
-                return
-            }
-            instance.activeDownloads.remove(appId)
-            val game = kotlinx.coroutines.runBlocking { instance.epicManager.getGameById(appId) }
-            if (game != null) {
-                val installPath =
-                    if (game.installPath.isNotEmpty()) {
-                        game.installPath
-                    } else {
-                        EpicConstants.getGameInstallPath(context, game.appName)
-                    }
-                downloadGame(context, appId, emptyList(), installPath, "")
+            // Coordinator marks the record as QUEUED and ticks. The dispatcher will be invoked
+            // to launch the actual download (it pulls saved DLC/language/install-path either
+            // from the in-memory params cache or from the persisted record).
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.resume(DownloadRecord.STORE_EPIC, appId.toString())
             }
         }
 
         fun resumeAll() {
-            val instance = getInstance() ?: return
-            instance.activeDownloads.keys
-                .toList()
-                .forEach(::resumeDownload)
+            DownloadCoordinator.runOnScope { DownloadCoordinator.resumeAll() }
         }
 
         fun cancelAll() {
-            val instance = getInstance() ?: return
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
-                instance.activeDownloads.entries.toList().forEach { (appId, info) ->
-                    info.isCancelling = true
-                    info.cancel("Cancelled all")
-                    info.awaitCompletion(timeoutMs = 3000L)
-                    val game = instance.epicManager.getGameById(appId)
-                    if (game != null) {
-                        val context = DownloadService.appContext
-                        val path =
-                            if (game.installPath.isNotEmpty()) {
-                                game.installPath
-                            } else if (context !=
-                                null
-                            ) {
-                                EpicConstants.getGameInstallPath(context, game.appName)
-                            } else {
-                                ""
-                            }
-                        if (path.isNotEmpty()) {
-                            val dirFile = java.io.File(path)
-                            if (dirFile.exists() && dirFile.isDirectory) {
-                                MarkerUtils.removeMarker(path, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                                MarkerUtils.removeMarker(path, Marker.DOWNLOAD_COMPLETE_MARKER)
-                                dirFile.deleteRecursively()
-                            }
-                        }
-                    }
-                    info.updateStatus(DownloadPhase.CANCELLED)
-                    instance.activeDownloads.remove(appId)
-                }
-            }
+            DownloadCoordinator.runOnScope { DownloadCoordinator.cancelAll() }
         }
 
         fun clearCompletedDownloads() {
@@ -430,9 +331,16 @@ class EpicService : Service() {
                     .filterValues {
                         val status = it.getStatusFlow().value
                         status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.COMPLETE ||
-                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.CANCELLED
+                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.CANCELLED ||
+                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.FAILED
                     }.keys
-            toRemove.forEach { instance.activeDownloads.remove(it) }
+            if (toRemove.isNotEmpty()) {
+                toRemove.forEach { instance.activeDownloads.remove(it) }
+                // Notify the Downloads tab so the list re-syncs and the cleared rows disappear.
+                toRemove.forEach { appId ->
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(appId, false))
+                }
+            }
         }
 
         // ==========================================================================
@@ -552,6 +460,14 @@ class EpicService : Service() {
                     )
                 }
 
+            // Persist the chosen install path BEFORE the download starts so cancel/pause/resume
+            // can find the partial files even when the user picked a non-default path.
+            if (game.installPath != effectiveInstallPath) {
+                runBlocking(Dispatchers.IO) {
+                    instance.epicManager.updateGame(game.copy(installPath = effectiveInstallPath))
+                }
+            }
+
             // Check if already downloading
             val existingDownload = instance.activeDownloads[appId]
             if (existingDownload != null) {
@@ -570,7 +486,45 @@ class EpicService : Service() {
                     downloadingAppIds = CopyOnWriteArrayList<Int>(),
                 )
 
+            // Stash the original parameters so resume() can restore them after pause.
+            instance.downloadParams[appId] =
+                DownloadParams(
+                    dlcGameIds = dlcGameIds,
+                    containerLanguage = containerLanguage,
+                    installPath = effectiveInstallPath,
+                )
+
             instance.activeDownloads[appId] = downloadInfo
+
+            // Ask the global coordinator whether we can start now or must wait. The coordinator
+            // persists a DownloadRecord either way, so the download survives an app restart.
+            val decision =
+                runBlocking {
+                    DownloadCoordinator.requestSlot(
+                        store = DownloadRecord.STORE_EPIC,
+                        storeGameId = appId.toString(),
+                        title = game.title,
+                        artUrl = game.iconUrl,
+                        installPath = effectiveInstallPath,
+                        selectedDlcs = dlcGameIds.joinToString(","),
+                        language = containerLanguage,
+                    )
+                }
+            when (decision) {
+                is DownloadCoordinator.Decision.Queue -> {
+                    // No slot available right now. Show the entry as queued; the coordinator
+                    // will call back via the dispatcher when a slot frees up.
+                    downloadInfo.setActive(false)
+                    downloadInfo.isCancelling = false
+                    downloadInfo.updateStatus(DownloadPhase.QUEUED, "Queued...")
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(appId, true))
+                    return Result.success(downloadInfo)
+                }
+                is DownloadCoordinator.Decision.Start -> {
+                    // Fall through to launch the coroutine immediately.
+                }
+            }
+
             downloadInfo.setActive(true)
             downloadInfo.isCancelling = false
             downloadInfo.updateStatus(DownloadPhase.DOWNLOADING)
@@ -652,10 +606,24 @@ class EpicService : Service() {
                             }
                         }
                     } finally {
-                        val finalStatus = downloadInfo.getStatusFlow().value
-                        if (finalStatus == DownloadPhase.COMPLETE || finalStatus == DownloadPhase.FAILED) {
-                            instance.activeDownloads.remove(appId)
-                        }
+                        // Notify coordinator of the terminal status so the global queue can
+                        // advance and the persisted DownloadRecord stays in sync.
+                        val finalCoordStatus =
+                            when (downloadInfo.getStatusFlow().value) {
+                                DownloadPhase.COMPLETE -> DownloadRecord.STATUS_COMPLETE
+                                DownloadPhase.PAUSED -> DownloadRecord.STATUS_PAUSED
+                                DownloadPhase.CANCELLED -> DownloadRecord.STATUS_CANCELLED
+                                DownloadPhase.FAILED -> DownloadRecord.STATUS_FAILED
+                                else -> DownloadRecord.STATUS_FAILED
+                            }
+                        DownloadCoordinator.notifyFinished(
+                            DownloadRecord.STORE_EPIC,
+                            appId.toString(),
+                            finalCoordStatus,
+                        )
+                        // Keep COMPLETE and FAILED entries in the map so the Downloads tab can
+                        // show them until the user clicks Clear.
+                        PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(appId, false))
                         Timber.d(
                             "[Download] Finished for game $gameId, progress: ${downloadInfo.getProgress()}, active: ${downloadInfo.isActive()}",
                         )
@@ -738,7 +706,79 @@ class EpicService : Service() {
     // Track active downloads by internal Int id
     private val activeDownloads = ConcurrentHashMap<Int, DownloadInfo>()
 
+    // Original download parameters per appId so resume can restore DLC selection,
+    // language, and install path instead of falling back to defaults.
+    // (Phase 2 will move this into a persistent record.)
+    data class DownloadParams(
+        val dlcGameIds: List<Int>,
+        val containerLanguage: String,
+        val installPath: String,
+    )
+
+    private val downloadParams = ConcurrentHashMap<Int, DownloadParams>()
+
     private val onEndProcess: (AndroidEvent.EndProcess) -> Unit = { stop() }
+
+    private val coordinatorDispatcher =
+        object : DownloadCoordinator.Dispatcher {
+            override fun startQueued(record: DownloadRecord) {
+                val context = DownloadService.appContext ?: return
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                // Restore params from the in-memory cache, falling back to the persisted record
+                // (covers the post-restart case where memory was cleared).
+                val params = downloadParams[appId]
+                val dlcGameIds =
+                    params?.dlcGameIds
+                        ?: record.selectedDlcs
+                            .split(',')
+                            .mapNotNull { it.trim().toIntOrNull() }
+                val containerLanguage = params?.containerLanguage ?: record.language
+                val installPath = params?.installPath ?: record.installPath
+
+                // Drop the queued in-memory entry so downloadGame() doesn't short-circuit on
+                // "already downloading" — it will recreate the DownloadInfo and launch.
+                activeDownloads.remove(appId)
+
+                downloadGame(context, appId, dlcGameIds, installPath, containerLanguage)
+            }
+
+            override fun pauseRunning(record: DownloadRecord) {
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                val info = activeDownloads[appId] ?: return
+                if (info.isActive()) {
+                    info.isCancelling = false
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.cancel("Paused by user")
+                } else {
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.setActive(false)
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(appId, false))
+                }
+            }
+
+            override fun cancelRunning(record: DownloadRecord) {
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                val info = activeDownloads[appId]
+                if (info != null) {
+                    info.isCancelling = true
+                    info.cancel("Cancelled by user")
+                }
+                CoroutineScope(Dispatchers.IO).launch {
+                    info?.awaitCompletion(timeoutMs = 3000L)
+                    val pathToDelete = record.installPath
+                    if (pathToDelete.isNotEmpty()) {
+                        val dirFile = File(pathToDelete)
+                        if (dirFile.exists() && dirFile.isDirectory) {
+                            MarkerUtils.removeMarker(pathToDelete, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                            MarkerUtils.removeMarker(pathToDelete, Marker.DOWNLOAD_COMPLETE_MARKER)
+                            dirFile.deleteRecursively()
+                        }
+                    }
+                    info?.updateStatus(DownloadPhase.CANCELLED)
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(appId, false))
+                }
+            }
+        }
 
     override fun onCreate() {
         super.onCreate()
@@ -748,6 +788,8 @@ class EpicService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        DownloadCoordinator.registerDispatcher(DownloadRecord.STORE_EPIC, coordinatorDispatcher)
     }
 
     override fun onStartCommand(
@@ -839,6 +881,7 @@ class EpicService : Service() {
         super.onDestroy()
         Timber.tag("Epic").i("[EpicService] Service destroyed")
         PluviaApp.events.off<AndroidEvent.EndProcess, Unit>(onEndProcess)
+        DownloadCoordinator.unregisterDispatcher(DownloadRecord.STORE_EPIC)
 
         // Cancel sync operations
         backgroundSyncJob?.cancel()

--- a/app/src/main/feature/stores/gog/service/GOGDownloadManager.kt
+++ b/app/src/main/feature/stores/gog/service/GOGDownloadManager.kt
@@ -1344,9 +1344,28 @@ class GOGDownloadManager
                             )
                         }
 
+                        // Stream the chunk body so pause/cancel takes effect mid-chunk instead
+                        // of waiting for body.bytes() to complete.
+                        val body = response.body
+                            ?: return@withContext Result.failure(Exception("Empty response for chunk $chunkMd5"))
                         val compressedBytes =
-                            response.body?.bytes()
-                                ?: return@withContext Result.failure(Exception("Empty response for chunk $chunkMd5"))
+                            java.io.ByteArrayOutputStream().use { buffer ->
+                                body.byteStream().use { input ->
+                                    val chunkBuffer = ByteArray(64 * 1024)
+                                    var bytesRead: Int
+                                    while (input.read(chunkBuffer).also { bytesRead = it } != -1) {
+                                        if (!downloadInfo.isActive() || downloadInfo.isCancelling) {
+                                            return@withContext Result.failure(
+                                                kotlinx.coroutines.CancellationException(
+                                                    "Download cancelled mid-chunk",
+                                                ),
+                                            )
+                                        }
+                                        buffer.write(chunkBuffer, 0, bytesRead)
+                                    }
+                                }
+                                buffer.toByteArray()
+                            }
 
                         // Verify compressed MD5
                         val actualMd5 = calculateMd5(compressedBytes)

--- a/app/src/main/feature/stores/gog/service/GOGService.kt
+++ b/app/src/main/feature/stores/gog/service/GOGService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import com.winlator.cmod.app.PluviaApp
+import com.winlator.cmod.app.db.download.DownloadRecord
+import com.winlator.cmod.app.service.download.DownloadCoordinator
 import com.winlator.cmod.feature.stores.epic.ui.util.SnackbarManager
 import com.winlator.cmod.feature.stores.gog.data.GOGCredentials
 import com.winlator.cmod.feature.stores.gog.data.GOGGame
@@ -182,7 +184,7 @@ class GOGService : Service() {
         // SYNC & OPERATIONS
         // ==========================================================================
 
-        fun hasActiveOperations(): Boolean = syncInProgress || backgroundSyncJob?.isActive == true
+        fun hasActiveOperations(): Boolean = syncInProgress || backgroundSyncJob?.isActive == true || hasActiveDownload()
 
         private fun setSyncInProgress(inProgress: Boolean) {
             syncInProgress = inProgress
@@ -209,141 +211,36 @@ class GOGService : Service() {
         }
 
         fun cancelDownload(gameId: String): Boolean {
-            val instance = getInstance()
-            val downloadInfo = instance?.activeDownloads?.get(gameId)
-
-            return if (downloadInfo != null) {
-                Timber.i("Cancelling download for game: $gameId")
-                downloadInfo.isCancelling = true
-                downloadInfo.cancel("Cancelled by user")
-                // Delete partially downloaded files
-                CoroutineScope(Dispatchers.IO).launch {
-                    downloadInfo.awaitCompletion(timeoutMs = 3000L)
-                    val game = instance.gogManager.getGameFromDbById(gameId)
-                    val installPath =
-                        if (game != null) {
-                            if (game.installPath.isNotEmpty()) {
-                                game.installPath
-                            } else {
-                                instance.gogManager.getGameInstallPath(
-                                    gameId,
-                                    game.title,
-                                )
-                            }
-                        } else {
-                            ""
-                        }
-                    if (installPath.isNotEmpty()) {
-                        val dirFile = File(installPath)
-                        if (dirFile.exists() && dirFile.isDirectory) {
-                            MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                            MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                            dirFile.deleteRecursively()
-                        }
-                    }
-                    downloadInfo.updateStatus(DownloadPhase.CANCELLED)
-                    instance.activeDownloads.remove(gameId)
-                }
-                Timber.d("Download cancelled for game: $gameId")
-                true
-            } else {
-                Timber.w("No active download found for game: $gameId")
-                false
+            // Route through the coordinator: it persists CANCELLED and asks our dispatcher to
+            // stop the running job and delete the partial install directory.
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.cancel(DownloadRecord.STORE_GOG, gameId)
             }
+            return true
         }
 
         fun pauseDownload(gameId: String) {
-            val info = getInstance()?.activeDownloads?.get(gameId) ?: return
-            val status = info.getStatusFlow().value
-            if (status == DownloadPhase.COMPLETE || status == DownloadPhase.CANCELLED) return
-
-            if (info.isActive()) {
-                info.isCancelling = false
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.cancel("Paused by user")
-            } else {
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.setActive(false)
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.pause(DownloadRecord.STORE_GOG, gameId)
             }
         }
 
         fun pauseAll() {
-            getInstance()?.activeDownloads?.values?.forEach { info ->
-                val status = info.getStatusFlow().value
-                if (info.isActive()) {
-                    info.isCancelling = false
-                    info.updateStatus(DownloadPhase.PAUSED)
-                    info.cancel("Paused all")
-                } else if (status != DownloadPhase.COMPLETE && status != DownloadPhase.CANCELLED) {
-                    info.updateStatus(DownloadPhase.PAUSED)
-                    info.setActive(false)
-                }
-            }
+            DownloadCoordinator.runOnScope { DownloadCoordinator.pauseAll() }
         }
 
         fun resumeDownload(gameId: String) {
-            val instance = getInstance() ?: return
-            val context = com.winlator.cmod.app.service.DownloadService.appContext ?: return
-            val info = instance.activeDownloads[gameId]
-            val status = info?.getStatusFlow()?.value
-            if (info != null && info.isActive()) return
-            if (status != null && status != DownloadPhase.PAUSED && status != DownloadPhase.QUEUED && status != DownloadPhase.FAILED) {
-                return
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.resume(DownloadRecord.STORE_GOG, gameId)
             }
-            val game = runBlocking(Dispatchers.IO) { instance.gogManager.getGameFromDbById(gameId) } ?: return
-            instance.activeDownloads.remove(gameId)
-            val installPath =
-                if (game.installPath.isNotEmpty()) {
-                    game.installPath
-                } else {
-                    instance.gogManager.getGameInstallPath(
-                        gameId,
-                        game.title,
-                    )
-                }
-            downloadGame(context, gameId, installPath, "")
         }
 
         fun resumeAll() {
-            val instance = getInstance() ?: return
-            instance.activeDownloads.keys
-                .toList()
-                .forEach(::resumeDownload)
+            DownloadCoordinator.runOnScope { DownloadCoordinator.resumeAll() }
         }
 
         fun cancelAll() {
-            val instance = getInstance() ?: return
-            CoroutineScope(Dispatchers.IO).launch {
-                instance.activeDownloads.entries.toList().forEach { (gameId, info) ->
-                    info.isCancelling = true
-                    info.cancel("Cancelled all")
-                    info.awaitCompletion(timeoutMs = 3000L)
-                    val game = instance.gogManager.getGameFromDbById(gameId)
-                    val installPath =
-                        if (game != null) {
-                            if (game.installPath.isNotEmpty()) {
-                                game.installPath
-                            } else {
-                                instance.gogManager.getGameInstallPath(
-                                    gameId,
-                                    game.title,
-                                )
-                            }
-                        } else {
-                            ""
-                        }
-                    if (installPath.isNotEmpty()) {
-                        val dirFile = File(installPath)
-                        if (dirFile.exists() && dirFile.isDirectory) {
-                            MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                            MarkerUtils.removeMarker(installPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                            dirFile.deleteRecursively()
-                        }
-                    }
-                    info.updateStatus(DownloadPhase.CANCELLED)
-                    instance.activeDownloads.remove(gameId)
-                }
-            }
+            DownloadCoordinator.runOnScope { DownloadCoordinator.cancelAll() }
         }
 
         fun clearCompletedDownloads() {
@@ -353,9 +250,17 @@ class GOGService : Service() {
                     .filterValues {
                         val status = it.getStatusFlow().value
                         status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.COMPLETE ||
-                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.CANCELLED
+                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.CANCELLED ||
+                            status == com.winlator.cmod.feature.stores.steam.enums.DownloadPhase.FAILED
                     }.keys
-            toRemove.forEach { instance.activeDownloads.remove(it) }
+            if (toRemove.isNotEmpty()) {
+                toRemove.forEach { instance.activeDownloads.remove(it) }
+                // Notify the Downloads tab so the list re-syncs and the cleared rows disappear.
+                toRemove.forEach { gameId ->
+                    val numericId = gameId.toIntOrNull() ?: 0
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(numericId, false))
+                }
+            }
         }
 
         // ==========================================================================
@@ -459,6 +364,16 @@ class GOGService : Service() {
                     )
                 }
 
+            // Persist the chosen install path BEFORE the download starts so cancel/pause/resume
+            // can find the partial files even when the user picked a non-default path.
+            // (Previously installPath was only written on successful completion, causing cancel
+            // to delete the default directory instead of the actual partial install.)
+            if (game.installPath != effectiveInstallPath) {
+                runBlocking(Dispatchers.IO) {
+                    activeInstance.gogManager.updateGame(game.copy(installPath = effectiveInstallPath))
+                }
+            }
+
             val existingDownload = activeInstance.activeDownloads[gameId]
             if (existingDownload != null) {
                 if (existingDownload.isActive()) {
@@ -476,8 +391,43 @@ class GOGService : Service() {
                     downloadingAppIds = CopyOnWriteArrayList<Int>(),
                 )
 
+            // Stash the original parameters so resume() can restore them after pause.
+            activeInstance.downloadParams[gameId] =
+                DownloadParams(
+                    containerLanguage = containerLanguage,
+                    installPath = effectiveInstallPath,
+                )
+
             // Track in activeDownloads first
             activeInstance.activeDownloads[gameId] = downloadInfo
+
+            // Ask the global coordinator whether to start now or queue. The coordinator
+            // persists a DownloadRecord either way so the download survives an app restart.
+            val decision =
+                runBlocking {
+                    DownloadCoordinator.requestSlot(
+                        store = DownloadRecord.STORE_GOG,
+                        storeGameId = gameId,
+                        title = game.title,
+                        artUrl = game.iconUrl,
+                        installPath = effectiveInstallPath,
+                        language = containerLanguage,
+                    )
+                }
+            when (decision) {
+                is DownloadCoordinator.Decision.Queue -> {
+                    downloadInfo.setActive(false)
+                    downloadInfo.isCancelling = false
+                    downloadInfo.updateStatus(DownloadPhase.QUEUED, "Queued...")
+                    val numericId = gameId.toIntOrNull() ?: 0
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(numericId, true))
+                    return Result.success(downloadInfo)
+                }
+                is DownloadCoordinator.Decision.Start -> {
+                    // Fall through to launch the coroutine immediately.
+                }
+            }
+
             downloadInfo.setActive(true)
             downloadInfo.isCancelling = false
             downloadInfo.updateStatus(DownloadPhase.DOWNLOADING)
@@ -554,10 +504,23 @@ class GOGService : Service() {
                             }
                         }
                     } finally {
-                        val finalStatus = downloadInfo.getStatusFlow().value
-                        if (finalStatus == DownloadPhase.COMPLETE || finalStatus == DownloadPhase.FAILED) {
-                            activeInstance.activeDownloads.remove(gameId)
-                        }
+                        // Notify coordinator of the terminal status so the global queue can
+                        // advance and the persisted DownloadRecord stays in sync.
+                        val finalCoordStatus =
+                            when (downloadInfo.getStatusFlow().value) {
+                                DownloadPhase.COMPLETE -> DownloadRecord.STATUS_COMPLETE
+                                DownloadPhase.PAUSED -> DownloadRecord.STATUS_PAUSED
+                                DownloadPhase.CANCELLED -> DownloadRecord.STATUS_CANCELLED
+                                DownloadPhase.FAILED -> DownloadRecord.STATUS_FAILED
+                                else -> DownloadRecord.STATUS_FAILED
+                            }
+                        DownloadCoordinator.notifyFinished(
+                            DownloadRecord.STORE_GOG,
+                            gameId,
+                            finalCoordStatus,
+                        )
+                        val numericId = gameId.toIntOrNull() ?: 0
+                        PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(numericId, false))
                         Timber.d(
                             "[Download] Finished for game $gameId, progress: ${downloadInfo.getProgress()}, active: ${downloadInfo.isActive()}",
                         )
@@ -811,7 +774,73 @@ class GOGService : Service() {
     // Track active downloads by game ID
     private val activeDownloads = ConcurrentHashMap<String, DownloadInfo>()
 
+    // Original download parameters per gameId so resume can restore container language and
+    // install path instead of falling back to defaults.
+    // (Phase 2 will move this into a persistent record.)
+    data class DownloadParams(
+        val containerLanguage: String,
+        val installPath: String,
+    )
+
+    private val downloadParams = ConcurrentHashMap<String, DownloadParams>()
+
     private val onEndProcess: (AndroidEvent.EndProcess) -> Unit = { stop() }
+
+    private val coordinatorDispatcher =
+        object : DownloadCoordinator.Dispatcher {
+            override fun startQueued(record: DownloadRecord) {
+                val context = com.winlator.cmod.app.service.DownloadService.appContext ?: return
+                val gameId = record.storeGameId
+                val params = downloadParams[gameId]
+                val installPath = params?.installPath ?: record.installPath
+                val containerLanguage = params?.containerLanguage ?: record.language
+
+                // Drop the queued in-memory entry so downloadGame() doesn't short-circuit on
+                // "already downloading" — it will recreate the DownloadInfo and launch.
+                activeDownloads.remove(gameId)
+
+                downloadGame(context, gameId, installPath, containerLanguage)
+            }
+
+            override fun pauseRunning(record: DownloadRecord) {
+                val gameId = record.storeGameId
+                val info = activeDownloads[gameId] ?: return
+                if (info.isActive()) {
+                    info.isCancelling = false
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.cancel("Paused by user")
+                } else {
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.setActive(false)
+                    val numericId = gameId.toIntOrNull() ?: 0
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(numericId, false))
+                }
+            }
+
+            override fun cancelRunning(record: DownloadRecord) {
+                val gameId = record.storeGameId
+                val info = activeDownloads[gameId]
+                if (info != null) {
+                    info.isCancelling = true
+                    info.cancel("Cancelled by user")
+                }
+                CoroutineScope(Dispatchers.IO).launch {
+                    info?.awaitCompletion(timeoutMs = 3000L)
+                    val pathToDelete = record.installPath
+                    if (pathToDelete.isNotEmpty()) {
+                        val dirFile = File(pathToDelete)
+                        if (dirFile.exists() && dirFile.isDirectory) {
+                            MarkerUtils.removeMarker(pathToDelete, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                            MarkerUtils.removeMarker(pathToDelete, Marker.DOWNLOAD_COMPLETE_MARKER)
+                            dirFile.deleteRecursively()
+                        }
+                    }
+                    info?.updateStatus(DownloadPhase.CANCELLED)
+                    val numericId = gameId.toIntOrNull() ?: 0
+                    PluviaApp.events.emit(AndroidEvent.DownloadStatusChanged(numericId, false))
+                }
+            }
+        }
 
     // GOGManager is injected by Hilt
     override fun onCreate() {
@@ -821,6 +850,8 @@ class GOGService : Service() {
         // Initialize notification helper for foreground service
         notificationHelper = NotificationHelper(applicationContext)
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        DownloadCoordinator.registerDispatcher(DownloadRecord.STORE_GOG, coordinatorDispatcher)
     }
 
     override fun onStartCommand(
@@ -907,6 +938,7 @@ class GOGService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         PluviaApp.events.off<AndroidEvent.EndProcess, Unit>(onEndProcess)
+        DownloadCoordinator.unregisterDispatcher(DownloadRecord.STORE_GOG)
 
         // Cancel sync operations
         backgroundSyncJob?.cancel()

--- a/app/src/main/feature/stores/steam/data/DownloadInfo.kt
+++ b/app/src/main/feature/stores/steam/data/DownloadInfo.kt
@@ -564,6 +564,10 @@ class DownloadInfo(
                 file.writeText(jsonText)
                 tempFile.delete()
             }
+            // Diagnostic: log every snapshot write so we can correlate WHO wrote what value
+            // when — especially the case of a depot getting persisted at depotSize even
+            // though its actual progress was small. Also logs caller stack for context.
+            Timber.i(Throwable("snapshot-write-trace"), "PERSIST-SNAPSHOT path=$appDirPath content=$jsonText")
         }
         return true
     }

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -10,8 +10,10 @@ import com.winlator.cmod.BuildConfig
 import com.winlator.cmod.R
 import com.winlator.cmod.app.PluviaApp
 import com.winlator.cmod.app.db.PluviaDatabase
+import com.winlator.cmod.app.db.download.DownloadRecord
 import com.winlator.cmod.app.service.DownloadService
 import com.winlator.cmod.app.service.NetworkMonitor
+import com.winlator.cmod.app.service.download.DownloadCoordinator
 import com.winlator.cmod.feature.shortcuts.LibraryShortcutUtils
 import com.winlator.cmod.feature.stores.steam.data.AppInfo
 import com.winlator.cmod.feature.stores.steam.data.CachedLicense
@@ -146,6 +148,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -364,113 +367,41 @@ class SteamService :
         }
 
         fun pauseAll() {
-            downloadJobs.values.forEach { info ->
-                val status = info.getStatusFlow().value
-                when {
-                    info.isActive() -> {
-                        info.isCancelling = false
-                        info.updateStatus(DownloadPhase.PAUSED)
-                        info.cancel("Paused all")
-                    }
-
-                    status == DownloadPhase.QUEUED -> {
-                        info.updateStatus(DownloadPhase.PAUSED)
-                        info.setActive(false)
-                    }
-                }
-            }
-            Unit
+            DownloadCoordinator.runOnScope { DownloadCoordinator.pauseAll() }
         }
 
         fun pauseDownload(appId: Int) {
-            val info = downloadJobs[appId] ?: return
-            val status = info.getStatusFlow().value
-            if (status == DownloadPhase.COMPLETE || status == DownloadPhase.CANCELLED) return
-
-            if (info.isActive()) {
-                info.isCancelling = false
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.cancel("Paused by user")
-            } else if (status == DownloadPhase.QUEUED) {
-                info.updateStatus(DownloadPhase.PAUSED)
-                info.setActive(false)
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.pause(DownloadRecord.STORE_STEAM, appId.toString())
             }
         }
 
         fun resumeAll() {
-            downloadJobs.keys.toList().forEach(::resumeDownload)
-            Unit
+            DownloadCoordinator.runOnScope { DownloadCoordinator.resumeAll() }
         }
 
         fun resumeDownload(appId: Int) {
-            val info =
-                downloadJobs[appId] ?: run {
-                    downloadApp(appId)
-                    return
-                }
-            val status = info.getStatusFlow().value
-            if (!info.isActive() && (status == DownloadPhase.QUEUED || status == DownloadPhase.PAUSED || status == DownloadPhase.FAILED)) {
-                downloadApp(appId)
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.resume(DownloadRecord.STORE_STEAM, appId.toString())
             }
         }
 
         fun cancelAll() {
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
-                downloadJobs.entries.toList().forEach { (appId, info) ->
-                    info.isCancelling = true
-                    info.cancel("Cancelled all")
-                    info.awaitCompletion(timeoutMs = 3000L)
-                    // Delete partially downloaded files
-                    val appDirPath = getAppDirPath(appId)
-                    val dirFile = java.io.File(appDirPath)
-                    if (dirFile.exists() && dirFile.isDirectory) {
-                        MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                        MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                        deleteRecursivelyWithRetries(dirFile)
-                    }
-                    info.updateStatus(DownloadPhase.CANCELLED)
-                    removeDownloadJob(appId, forceRemove = true)
-                }
-            }
-            Unit
+            DownloadCoordinator.runOnScope { DownloadCoordinator.cancelAll() }
         }
 
         fun cancelDownload(appId: Int) {
-            val info = downloadJobs[appId] ?: return
-            info.isCancelling = true
-            info.cancel("Cancelled by user")
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
-                info.awaitCompletion(timeoutMs = 3000L)
-                val appDirPath = getAppDirPath(appId)
-                val dirFile = java.io.File(appDirPath)
-                if (dirFile.exists() && dirFile.isDirectory) {
-                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
-                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
-                    deleteRecursivelyWithRetries(dirFile)
-                }
-                info.updateStatus(DownloadPhase.CANCELLED)
-                removeDownloadJob(appId, forceRemove = true)
+            DownloadCoordinator.runOnScope {
+                DownloadCoordinator.cancel(DownloadRecord.STORE_STEAM, appId.toString())
             }
         }
 
+        // The cross-store DownloadCoordinator now owns global queue draining. This legacy
+        // entry point is kept for binary compatibility with any callers that haven't been
+        // migrated; instead of running the old Steam-only queue logic (which would race the
+        // coordinator and double-start downloads) it just delegates to the coordinator.
         fun checkQueue() {
-            val maxParallel = PrefManager.downloadQueueSize
-            val activeCount = downloadJobs.values.count { it.isActive() && it.getStatusFlow().value != DownloadPhase.QUEUED }
-            val slotsAvailable = maxParallel - activeCount
-
-            if (slotsAvailable > 0) {
-                // Get all queued downloads and start as many as we have slots
-                val queuedEntries =
-                    downloadJobs.entries
-                        .filter { it.value.getStatusFlow().value == DownloadPhase.QUEUED }
-                        .take(slotsAvailable)
-
-                for (entry in queuedEntries) {
-                    Timber.i("Starting queued download for appId: ${entry.key} (slots: $slotsAvailable)")
-                    downloadApp(entry.key)
-                }
-            }
-            Unit
+            DownloadCoordinator.blockingTick()
         }
 
         private val downloadJobs = ConcurrentHashMap<Int, DownloadInfo>()
@@ -504,9 +435,13 @@ class SteamService :
                 downloadJobs
                     .filterValues {
                         val status = it.getStatusFlow().value
-                        status == DownloadPhase.COMPLETE || status == DownloadPhase.CANCELLED
+                        status == DownloadPhase.COMPLETE ||
+                            status == DownloadPhase.CANCELLED ||
+                            status == DownloadPhase.FAILED
                     }.keys
             toRemove.forEach { removeDownloadJob(it, forceRemove = true) }
+            // Also remove finished records from the cross-store coordinator table.
+            DownloadCoordinator.runOnScope { DownloadCoordinator.clear() }
         }
 
         /** Returns true if there is an incomplete download on disk (in-progress marker or actively downloading). */
@@ -1902,7 +1837,20 @@ class SteamService :
             return finalPath
         }
 
-        fun downloadApp(appId: Int): DownloadInfo? {
+        fun downloadApp(appId: Int): DownloadInfo? = downloadApp(appId, dlcAppIdsHint = null)
+
+        /**
+         * Resume / start entry point that accepts an authoritative DLC selection [dlcAppIdsHint]
+         * — typically supplied by the cross-store [DownloadCoordinator] from its persisted
+         * [DownloadRecord.selectedDlcs] field. When provided, this list takes precedence over
+         * the legacy fallback chain (DownloadingAppInfo → snapshot inference → installed DLCs)
+         * because the coordinator's record is the only source guaranteed to remember the user's
+         * original selection across pause/resume and across app restarts.
+         *
+         * Pass `null` (or call the no-arg overload) for legacy callers; we'll then look the
+         * record up ourselves so coordinator-aware behavior still applies.
+         */
+        fun downloadApp(appId: Int, dlcAppIdsHint: List<Int>?): DownloadInfo? {
             val currentDownloadInfo = downloadJobs[appId]
             if (currentDownloadInfo != null) {
                 if (!currentDownloadInfo.isActive()) {
@@ -1912,6 +1860,23 @@ class SteamService :
                 }
             }
 
+            // If the caller didn't supply an authoritative DLC list, try to recover one from
+            // the DownloadCoordinator's persisted record. That record is store-agnostic but
+            // currently only populated for coordinator-managed downloads; if it's missing we
+            // fall through to the older DownloadingAppInfo-based recovery further down.
+            val recordDlcIds: List<Int>? = dlcAppIdsHint
+                ?: runCatching {
+                    runBlocking(Dispatchers.IO) {
+                        val record = DownloadCoordinator.findRecord(
+                            DownloadRecord.STORE_STEAM,
+                            appId.toString(),
+                        )
+                        record?.selectedDlcs
+                            ?.split(',')
+                            ?.mapNotNull { it.trim().toIntOrNull() }
+                    }
+                }.getOrNull()
+
             val downloadingAppInfo = getDownloadingAppInfoOf(appId)
             val appDirPath = getAppDirPath(appId)
             val hasCompleteMarker = MarkerUtils.hasMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
@@ -1919,22 +1884,28 @@ class SteamService :
             val hasPersistedMetadata = hasPersistedDepotResumeMetadata(appDirPath)
             val hasResumablePayload =
                 if (hasCompleteMarker) {
-                    downloadingAppInfo != null || hasPersistedMetadata
+                    downloadingAppInfo != null || hasPersistedMetadata || recordDlcIds != null
                 } else {
                     hasPartialFiles
                 }
             if (hasResumablePayload) {
-                // Resume persisted progress whenever partial files exist, even if the
-                // DownloadingAppInfo row is missing (can happen after cancellation races).
-                val resumeDlcAppIds =
-                    downloadingAppInfo?.dlcAppIds
+                // Strict trust order (per agreed fix plan with Codex):
+                //   1. Coordinator record (authoritative, store-agnostic, durable across
+                //      app restarts and DB migrations) — ALSO authoritative for an empty list
+                //      (= "user wants base game only").
+                //   2. DownloadingAppInfo DAO row (Steam-specific, written at first download).
+                //   3. inferResumeDlcAppIds (snapshot of which depots have bytes — may be a
+                //      subset, used only when no authoritative source exists).
+                //   4. resolveInstalledDlcIdsForUpdateOrVerify (DLCs already installed —
+                //      last-ditch legacy recovery).
+                // Do NOT union: an empty list from an authoritative source means "no DLCs".
+                val resumeDlcAppIds: List<Int> =
+                    recordDlcIds
+                        ?: downloadingAppInfo?.dlcAppIds
                         ?: run {
                             val inferred = inferResumeDlcAppIds(appId, appDirPath)
-                            if (inferred.isNotEmpty()) {
-                                inferred
-                            } else {
-                                resolveInstalledDlcIdsForUpdateOrVerify(appId)
-                            }
+                            if (inferred.isNotEmpty()) inferred
+                            else resolveInstalledDlcIdsForUpdateOrVerify(appId)
                         }
                 return downloadApp(
                     appId = appId,
@@ -1942,7 +1913,7 @@ class SteamService :
                     includeInstalledDepots = false,
                     enableVerify = false,
                     allowPersistedProgress = true,
-                    hasPersistedResumeRow = downloadingAppInfo != null,
+                    hasPersistedResumeRow = downloadingAppInfo != null || recordDlcIds != null,
                 )
             }
 
@@ -2558,6 +2529,28 @@ class SteamService :
                 Timber.d("Removed already downloaded depots. Count before: $beforeCount, after: ${mainAppDepots.size}")
             }
 
+            // CRITICAL: clear JavaSteam's DepotConfigStore (.DepotDownloader/depot.config)
+            // whenever this app does NOT have the COMPLETE marker. JavaSteam writes
+            // installedManifestIDs[depotId] = manifestId in processDepotManifestAndFiles
+            // BEFORE that depot's chunks have actually been downloaded. On the next resume
+            // it loads the config, sees the manifest ID matches, and SKIPS file checksum
+            // validation (DepotDownloader.kt:1298-1409) — trusting preallocated/sparse
+            // partial files as if they were fully downloaded. That's why pause→resume left
+            // depots looking "complete" while gigabytes of chunks were never written. Deleting
+            // depot.config forces JavaSteam to re-checksum every file on disk; correctly-present
+            // files are skipped (cheap), missing/partial files get re-downloaded.
+            if (!hasCompleteMarker) {
+                val depotConfigFile = File(File(appDirPath, ".DepotDownloader"), "depot.config")
+                if (depotConfigFile.exists()) {
+                    val deleted = depotConfigFile.delete()
+                    Timber.i(
+                        "Cleared JavaSteam DepotConfigStore at ${depotConfigFile.absolutePath} " +
+                            "(deleted=$deleted) — forces re-validation of all depot files for " +
+                            "appId=$appId because the COMPLETE marker is absent.",
+                    )
+                }
+            }
+
             val allDepots = originalMainAppDepots + dlcAppDepots
             // Use install (uncompressed) size for progress tracking
             val depotSizeById =
@@ -2566,26 +2559,105 @@ class SteamService :
                     (mInfo?.size ?: 1L).coerceAtLeast(1L)
                 }
 
-            // Load persisted progress snapshot to skip fully downloaded depots
-            val persistedDepotBytes =
+            // Load persisted progress snapshot to skip fully downloaded depots.
+            // Mutable so the safety check below can drop suspicious entries before they
+            // poison di.depotCumulativeUncompressedBytes during resume init.
+            var persistedDepotBytes: Map<Int, Long> =
                 if (allowPersistedProgress) {
                     DownloadInfo.loadPersistedDepotBytes(appDirPath)
                 } else {
                     emptyMap()
                 }
 
+            // SAFETY CHECK (scope-mismatch detection): if the persisted snapshot remembers
+            // depots that aren't in the current resume scope, the userSelectedDlcAppIds we
+            // resolved is a SUBSET of what was originally downloading. Continuing would
+            // download only the subset and then incorrectly mark the game COMPLETE because
+            // selectedDepots would empty out before the missing DLCs ever get registered.
+            // Refuse to proceed — the user can cancel + redownload to recover.
+            if (allowPersistedProgress && persistedDepotBytes.isNotEmpty()) {
+                val depotsInScope = allDepots.keys
+                val orphanSnapshotDepots = persistedDepotBytes.keys - depotsInScope
+                if (orphanSnapshotDepots.isNotEmpty()) {
+                    Timber.e(
+                        "Resume scope mismatch for appId=$appId: snapshot has depot(s) " +
+                            "$orphanSnapshotDepots that are not in the current download scope " +
+                            "(scope depots: $depotsInScope). The DLC list used to resume is " +
+                            "incomplete; refusing to finalize to avoid a partial-COMPLETE.",
+                    )
+                    instance?.let { service ->
+                        service.scope.launch(Dispatchers.Main) {
+                            AppUtils.showToast(
+                                service.applicationContext,
+                                "Resume failed: download scope changed. Please cancel and re-download.",
+                                Toast.LENGTH_LONG,
+                            )
+                        }
+                    }
+                    val info = DownloadInfo(1, appId, CopyOnWriteArrayList(listOf(appId)))
+                    info.updateStatus(DownloadPhase.FAILED, "Resume scope mismatch — cancel and re-download")
+                    info.setActive(false)
+                    downloadJobs[appId] = info
+                    notifyDownloadStarted(appId)
+                    runBlocking {
+                        DownloadCoordinator.notifyFinished(
+                            DownloadRecord.STORE_STEAM,
+                            appId.toString(),
+                            DownloadRecord.STATUS_FAILED,
+                            "Resume scope mismatch",
+                        )
+                    }
+                    return info
+                }
+            }
+
             val fullyDownloadedDepotsFromSnapshot = mutableSetOf<Int>()
             if (persistedDepotBytes.isNotEmpty()) {
                 for ((depotId, _) in allDepots) {
                     val depotSize = depotSizeById[depotId] ?: 1L
                     val downloadedBytes = persistedDepotBytes[depotId] ?: 0L
+                    Timber.d(
+                        "Resume snapshot for appId=$appId depot=$depotId: persisted=$downloadedBytes / size=$depotSize " +
+                            (if (downloadedBytes >= depotSize) "-> SKIP-CANDIDATE" else "-> include"),
+                    )
                     if (downloadedBytes >= depotSize) {
                         fullyDownloadedDepotsFromSnapshot.add(depotId)
                     }
                 }
                 if (fullyDownloadedDepotsFromSnapshot.isNotEmpty()) {
-                    Timber.i("Skipping ${fullyDownloadedDepotsFromSnapshot.size} fully downloaded depots from snapshot")
-                    mainAppDepots = mainAppDepots.filter { it.key !in fullyDownloadedDepotsFromSnapshot }
+                    // CRITICAL safety: only TRUST the snapshot's "fully downloaded" claim
+                    // when the COMPLETE marker exists for the game. Without that marker the
+                    // game was a partial download — and we have a history of snapshot
+                    // corruption pushing depots to depotSize prematurely (e.g., race
+                    // attribution in older builds, or interrupted onDepotCompleted paths).
+                    // For partial downloads, let DepotDownloader's per-file checksum
+                    // validation handle resume: it'll skip files that already match on disk
+                    // (cheap), and re-download missing chunks.
+                    if (hasCompleteMarker) {
+                        Timber.i(
+                            "Skipping ${fullyDownloadedDepotsFromSnapshot.size} fully downloaded depots from snapshot " +
+                                "(COMPLETE marker present): $fullyDownloadedDepotsFromSnapshot",
+                        )
+                        mainAppDepots = mainAppDepots.filter { it.key !in fullyDownloadedDepotsFromSnapshot }
+                    } else {
+                        Timber.w(
+                            "REFUSING to skip ${fullyDownloadedDepotsFromSnapshot.size} depots claimed full by snapshot " +
+                                "for appId=$appId because COMPLETE marker is absent. Depots will be re-validated " +
+                                "by the downloader: $fullyDownloadedDepotsFromSnapshot",
+                        )
+                        // Drop the suspicious entries from persistedDepotBytes so they don't
+                        // get re-loaded into di.depotCumulativeUncompressedBytes (which would
+                        // re-persist them at depotSize on the next pause and re-trigger the
+                        // bug). The in-memory tracker for these depots will start at 0 and
+                        // grow with real download progress.
+                        persistedDepotBytes = persistedDepotBytes.filterKeys {
+                            it !in fullyDownloadedDepotsFromSnapshot
+                        }
+                        // Clear the on-disk snapshot file too. New persists will re-create
+                        // it with only the real, current per-depot bytes.
+                        clearPersistedProgressSnapshot(appDirPath)
+                        fullyDownloadedDepotsFromSnapshot.clear()
+                    }
                 }
             }
 
@@ -2725,11 +2797,22 @@ class SteamService :
                 Unit
             }
 
-            val maxParallel = PrefManager.downloadQueueSize
-            val activeCount = downloadJobs.values.count { it.isActive() && it.getStatusFlow().value != DownloadPhase.QUEUED }
-
-            if (activeCount >= maxParallel) {
-                Timber.i("Download limit reached ($maxParallel), queuing appId: $appId")
+            // Ask the global coordinator whether this download can start now or must be queued
+            // behind downloads from other stores too. The coordinator persists the decision in
+            // its DownloadRecord table so the request survives an app restart.
+            val coordDecision =
+                runBlocking {
+                    val title = getAppInfoOf(appId)?.name.orEmpty()
+                    DownloadCoordinator.requestSlot(
+                        store = DownloadRecord.STORE_STEAM,
+                        storeGameId = appId.toString(),
+                        title = title,
+                        installPath = appDirPath,
+                        selectedDlcs = userSelectedDlcAppIds.joinToString(","),
+                    )
+                }
+            if (coordDecision is DownloadCoordinator.Decision.Queue) {
+                Timber.i("Coordinator queued appId: $appId")
                 val info =
                     DownloadInfo(selectedDepots.size, appId, downloadingAppIds).also { di ->
                         di.setPersistencePath(appDirPath)
@@ -2777,9 +2860,18 @@ class SteamService :
                             if (depotId in selectedDepots) {
                                 resumedBytes += safeBytes
                             }
+                            Timber.i(
+                                "RESUME-INIT depot=$depotId loaded=$safeBytes (snapshot=$bytes, max=$depotSize, " +
+                                    "inSelected=${depotId in selectedDepots}, inSession=${depotId in selectedDepotSizes.keys})",
+                            )
                         }
                     } else {
-                        di.clearPersistedBytesDownloaded(appDirPath)
+                        // SYNC clear so a stale snapshot from a previous (possibly buggy)
+                        // session can't poison this fresh download. Async clear has a race
+                        // window where new persists can read or even overwrite with stale
+                        // depot byte counts.
+                        di.clearPersistedBytesDownloaded(appDirPath, sync = true)
+                        Timber.i("RESUME-INIT cleared persisted snapshot (sync) for fresh download appId=$appId")
                     }
                     resumedBytes = resumedBytes.coerceIn(0L, totalBytes)
 
@@ -3020,24 +3112,51 @@ class SteamService :
 
                                         Timber.i("Downloading game to $appDirPath (attempt $attempt)")
 
-                                        // Wait for completion - safely handle the deferred result to avoid Unit cast errors
+                                        // Wait for completion. Use the kotlinx-coroutines `await()`
+                                        // extension on CompletableFuture so cancellation propagates
+                                        // (the previous .join() was uninterruptible and made the
+                                        // coroutine wait until JavaSteam's finishDepotDownload fired
+                                        // even after the user had paused — leading to the COMPLETE
+                                        // marker being set on partial installs when JavaSteam's
+                                        // pendingChunks loop drained on cancel).
                                         try {
                                             val completion = depotDownloader?.getCompletion()
                                             if (completion is kotlinx.coroutines.Deferred<*>) {
                                                 Timber.i("Waiting for DepotDownloader Deferred completion...")
                                                 completion.await()
+                                            } else if (completion is java.util.concurrent.CompletableFuture<*>) {
+                                                Timber.i("Waiting for DepotDownloader CompletableFuture completion...")
+                                                @Suppress("UNCHECKED_CAST")
+                                                (completion as java.util.concurrent.CompletableFuture<Any?>).await()
                                             } else if (completion != null) {
-                                                // If it's a CompletableFuture or other type, try to join it
-                                                Timber.i("Downloader completion is ${completion.javaClass.simpleName}, waiting...")
-                                                if (completion is java.util.concurrent.CompletableFuture<*>) {
-                                                    completion.join()
-                                                }
+                                                Timber.w(
+                                                    "Unknown completion type ${completion.javaClass.simpleName}; falling back to .toString()",
+                                                )
                                             } else {
                                                 Timber.i("Downloader completion is null, assuming immediate success")
                                             }
                                         } catch (e: Exception) {
                                             if (e is CancellationException) throw e
                                             Timber.w(e, "DepotDownloader completion await encountered an error")
+                                        }
+
+                                        // Hard barrier: even if completion.await returned without
+                                        // throwing, re-check for cancellation. JavaSteam can complete
+                                        // its CompletableFuture as a side-effect of pending chunks
+                                        // being cancelled (pendingChunks drains to 0 → finishDepot
+                                        // Download fires) — in that race we must NOT proceed to
+                                        // completeAppDownload, which would set the COMPLETE marker
+                                        // for a paused/partial install.
+                                        coroutineContext.ensureActive()
+                                        if (!di.isActive() || di.isCancelling) {
+                                            Timber.i(
+                                                "DepotDownloader completion returned but DownloadInfo is no longer active " +
+                                                    "(isActive=${di.isActive()}, isCancelling=${di.isCancelling}). " +
+                                                    "Skipping completeAppDownload — the user paused or cancelled.",
+                                            )
+                                            throw CancellationException(
+                                                if (di.isCancelling) "Cancelled by user" else "Paused by user",
+                                            )
                                         }
 
                                         Timber.i("DepotDownloader finished for appId: $appId")
@@ -3109,6 +3228,14 @@ class SteamService :
                                 di.setActive(false)
                                 // Clean up markers
                                 MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                                runBlocking {
+                                    DownloadCoordinator.notifyFinished(
+                                        DownloadRecord.STORE_STEAM,
+                                        appId.toString(),
+                                        DownloadRecord.STATUS_FAILED,
+                                        e.message,
+                                    )
+                                }
                                 removeDownloadJob(appId)
                                 return@launch
                             } catch (e: CancellationException) {
@@ -3122,6 +3249,13 @@ class SteamService :
                                     di.persistProgressSnapshot(force = true)
                                     di.updateStatus(DownloadPhase.CANCELLED)
                                     di.setActive(false)
+                                    runBlocking {
+                                        DownloadCoordinator.notifyFinished(
+                                            DownloadRecord.STORE_STEAM,
+                                            appId.toString(),
+                                            DownloadRecord.STATUS_CANCELLED,
+                                        )
+                                    }
                                     throw e
                                 }
 
@@ -3130,6 +3264,13 @@ class SteamService :
                                 di.persistProgressSnapshot(force = true)
                                 di.updateStatus(DownloadPhase.PAUSED)
                                 di.setActive(false)
+                                runBlocking {
+                                    DownloadCoordinator.notifyFinished(
+                                        DownloadRecord.STORE_STEAM,
+                                        appId.toString(),
+                                        DownloadRecord.STATUS_PAUSED,
+                                    )
+                                }
                                 throw e
                             } catch (e: Exception) {
                                 Timber.e(e, "Download failed for app $appId")
@@ -3149,6 +3290,14 @@ class SteamService :
                                 runBlocking {
                                     instance?.downloadingAppInfoDao?.deleteApp(appId)
                                     Unit
+                                }
+                                runBlocking {
+                                    DownloadCoordinator.notifyFinished(
+                                        DownloadRecord.STORE_STEAM,
+                                        appId.toString(),
+                                        DownloadRecord.STATUS_FAILED,
+                                        errorMsg,
+                                    )
                                 }
                                 removeDownloadJob(appId)
                                 // Show error to user
@@ -3313,8 +3462,9 @@ class SteamService :
             // All downloading appIds are removed
             if (downloadInfo.downloadingAppIds.isEmpty()) {
                 Timber.i("All items for game ${downloadInfo.gameId} completed, running final completion logic.")
-                // If manifest-size top-up was deferred during depot completion, settle the
-                // remaining bytes once at the end to avoid visible mid-download jumps.
+                // Settle the remaining bytes once at the end so the visible progress doesn't
+                // sit slightly under 100% when the game is actually complete (e.g. dedup
+                // skipped chunks that never reported via onChunkCompleted).
                 val totalExpectedBytes = downloadInfo.getTotalExpectedBytes()
                 if (totalExpectedBytes > 0L) {
                     val downloadedBytes = downloadInfo.getBytesDownloaded()
@@ -3356,18 +3506,43 @@ class SteamService :
                     createSteamShortcut(service, downloadInfo.gameId)
                 }
 
+                // Mark download inactive BEFORE updating status so checkQueue() correctly
+                // frees this slot for the next queued download. Without this, isActive() stays
+                // true and blocks the queue until the user manually clears the entry.
+                downloadInfo.setActive(false)
                 downloadInfo.updateStatus(DownloadPhase.COMPLETE)
                 PluviaApp.events.emit(AndroidEvent.LibraryInstallStatusChanged(downloadInfo.gameId))
 
-                // Clear persisted bytes file on successful completion
                 downloadInfo.clearPersistedBytesDownloaded(appDirPath, sync = true)
+                // Notify the global coordinator so it can advance the cross-store queue and
+                // persist COMPLETE in the records table.
+                runBlocking {
+                    DownloadCoordinator.notifyFinished(
+                        DownloadRecord.STORE_STEAM,
+                        downloadInfo.gameId.toString(),
+                        DownloadRecord.STATUS_COMPLETE,
+                    )
+                }
                 checkQueue()
             }
             Unit
         }
 
-        // onChunkCompleted reports GLOBAL cumulative bytes across all depots, not per depot.
-        // We diff successive global values to get the real per chunk delta.
+        // CRITICAL: onChunkCompleted reports PER-DEPOT cumulative bytes, NOT global. The
+        // previous code treated the value as a global counter, which mis-attributed bytes
+        // between depots when downloads ran in parallel or sequentially across multiple
+        // depots. Sequential downloads after a large depot caused the next depot's tracker
+        // to stay at 0 (its per-depot count was below the global high-water mark) until its
+        // per-depot count exceeded the prior depot's size — corrupting depot_bytes.json.
+        // On resume, that snapshot can mark a depot as fully downloaded when its files are
+        // actually partial; the depot is filtered out of selectedDepots and the game is
+        // marked COMPLETE with missing files.
+        //
+        // The fix is per-depot session high-water marks. JavaSteam's depotBytesUncompressed
+        // counts only bytes downloaded during THIS downloader run (validated existing bytes
+        // bump sizeDownloaded but not depotBytesUncompressed), so we cannot use the value
+        // as an absolute "set depot to N" — we must diff against the per-depot session
+        // counter and apply the delta on top of the persisted bytes restored from snapshot.
         private class AppDownloadListener(
             private val downloadInfo: DownloadInfo,
             private val depotIdToIndex: Map<Int, Int>,
@@ -3375,26 +3550,53 @@ class SteamService :
         ) : IDownloadListener {
             private var lastByteProgressAtMs: Long = 0L
 
-            // Last global cumulative uncompressed bytes from onChunkCompleted
-            private val lastGlobalUncompressedBytes =
-                java.util.concurrent.atomic
-                    .AtomicLong(0L)
+            // Per-depot session high-water mark of the cumulative uncompressedBytes value
+            // reported by JavaSteam for that depot. Diff'd to obtain a positive per-depot
+            // delta on each chunk callback.
+            private val lastReportedByDepot =
+                java.util.concurrent.ConcurrentHashMap<Int, java.util.concurrent.atomic.AtomicLong>()
 
-            // Consumes monotonic global cumulative bytes and returns only newly observed delta.
-            // This is resilient to out-of-order callbacks from concurrent decompression workers.
-            private fun consumeGlobalUncompressedDelta(currentGlobalBytes: Long): Long {
-                if (currentGlobalBytes <= 0L) return 0L
-
-                while (true) {
-                    val previousGlobalBytes = lastGlobalUncompressedBytes.get()
-                    if (currentGlobalBytes <= previousGlobalBytes) {
-                        return 0L
+            // Returns the positive delta (newly downloaded bytes) for the given depot,
+            // updating the per-depot session high-water mark. Resilient to out-of-order
+            // callbacks from concurrent decompression workers because each depot has its
+            // own atomic and we use CAS to only ever advance forward.
+            private fun consumePerDepotUncompressedDelta(depotId: Int, currentBytes: Long): Long {
+                if (currentBytes <= 0L) return 0L
+                val tracker =
+                    lastReportedByDepot.computeIfAbsent(depotId) {
+                        java.util.concurrent.atomic.AtomicLong(0L)
                     }
-
-                    if (lastGlobalUncompressedBytes.compareAndSet(previousGlobalBytes, currentGlobalBytes)) {
-                        return currentGlobalBytes - previousGlobalBytes
+                while (true) {
+                    val previous = tracker.get()
+                    if (currentBytes <= previous) return 0L
+                    if (tracker.compareAndSet(previous, currentBytes)) {
+                        val delta = currentBytes - previous
+                        // Diagnostic: warn when a per-depot session report jumps by an
+                        // implausibly large amount (e.g., > 100 MB in one chunk callback).
+                        // This would indicate JavaSteam reporting stale/global counters.
+                        if (delta > 100L * 1024L * 1024L) {
+                            Timber.w(
+                                "BIG-DELTA depot=$depotId prev=$previous current=$currentBytes delta=$delta maxBytes=${depotMaxBytesById[depotId]}",
+                            )
+                        }
+                        return delta
                     }
                 }
+            }
+
+            // Diagnostic helper: log every change that would push a depot to >= depotSize
+            // along with the call stack, so we can pinpoint which path is corrupting the
+            // snapshot. Only emits at INFO level once per (depot,reason) to avoid spam.
+            private val depotMaxedReported = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
+
+            private fun logDepotPushedToMax(reason: String, depotId: Int, prev: Long, next: Long) {
+                if (next < (depotMaxBytesById[depotId] ?: 0L)) return
+                val key = "$depotId:$reason"
+                if (depotMaxedReported.putIfAbsent(key, true) != null) return
+                Timber.w(
+                    Throwable("trace"),
+                    "DEPOT-MAXED reason=$reason depot=$depotId prev=$prev next=$next maxBytes=${depotMaxBytesById[depotId]}",
+                )
             }
 
             // Sets per depot cumulative value, returns delta
@@ -3468,7 +3670,10 @@ class SteamService :
                     val prev = atomicBytes.get()
                     val next = (prev + delta).coerceIn(0L, maxBytes)
                     if (prev == next) break
-                    if (atomicBytes.compareAndSet(prev, next)) break
+                    if (atomicBytes.compareAndSet(prev, next)) {
+                        logDepotPushedToMax("addDelta(delta=$delta)", depotId, prev, next)
+                        break
+                    }
                 }
             }
 
@@ -3588,8 +3793,10 @@ class SteamService :
                 compressedBytes: Long,
                 uncompressedBytes: Long,
             ) {
-                // uncompressedBytes is global cumulative across all depots.
-                val deltaBytes = consumeGlobalUncompressedDelta(uncompressedBytes)
+                // uncompressedBytes is per-depot cumulative for THIS depot (per the
+                // IDownloadListener contract). Diff against this depot's session high-water
+                // mark so we only count newly-downloaded bytes for THIS depot.
+                val deltaBytes = consumePerDepotUncompressedDelta(depotId, uncompressedBytes)
 
                 if (deltaBytes > 0L) {
                     lastByteProgressAtMs = System.currentTimeMillis()
@@ -3627,23 +3834,28 @@ class SteamService :
             ) {
                 Timber.i("Depot $depotId completed (compressed: $compressedBytes, uncompressed: $uncompressedBytes)")
 
-                // Catch up any uncompressed bytes not covered by onChunkCompleted
-                val deltaBytes = updateDepotBytesAndGetDelta(depotId, uncompressedBytes)
-
-                if (deltaBytes > 0L) {
+                // Catch up any per-depot session bytes not yet credited via onChunkCompleted.
+                val sessionDelta = consumePerDepotUncompressedDelta(depotId, uncompressedBytes)
+                if (sessionDelta > 0L) {
                     lastByteProgressAtMs = System.currentTimeMillis()
-                    downloadInfo.updateBytesDownloaded(deltaBytes, lastByteProgressAtMs)
+                    addDeltaToDepotBytes(depotId, sessionDelta)
+                    downloadInfo.updateBytesDownloaded(sessionDelta, lastByteProgressAtMs)
                     downloadInfo.markProgressSnapshotDirty()
                 }
 
-                // Credit full manifest size so dedup gaps don't stall progress
-                val manifestSize = depotMaxBytesById[depotId] ?: 0L
-                val tracked = downloadInfo.depotCumulativeUncompressedBytes[depotId]?.get() ?: 0L
-                val remaining = manifestSize - tracked
-                if (remaining > 0L) {
-                    addDeltaToDepotBytes(depotId, remaining)
-                    downloadInfo.markProgressSnapshotDirty()
-                }
+                // CRITICAL: do NOT credit the depot to manifest size here. JavaSteam fires
+                // onDepotCompleted at the END of processDepotManifestAndFiles, which runs
+                // even when many of the depot's chunks are still pending download. If
+                // Steam's validation pass marks some files as already-present (sizeDownloaded
+                // grows via file.totalSize) but other chunks are still queued, depotBytes
+                // Uncompressed can be 0 here while gigabytes of chunks haven't actually been
+                // downloaded. Topping up to manifestSize was the bug: it marked partially-
+                // downloaded depots as fully-on-disk in the snapshot, so future resumes
+                // skipped them and the game ended up flagged COMPLETE with most data missing.
+                //
+                // We now ONLY credit bytes that JavaSteam actually reported via session
+                // counters. Depots that finish naturally will still reach depotSize because
+                // every chunk callback reports cumulative per-depot bytes.
 
                 val currentPhase = downloadInfo.getStatusFlow().value
                 if (
@@ -5004,6 +5216,67 @@ class SteamService :
         }
     }
 
+    private val coordinatorDispatcher =
+        object : DownloadCoordinator.Dispatcher {
+            override fun startQueued(record: DownloadRecord) {
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                // Drop any stale queued/paused DownloadInfo from the in-memory map BEFORE
+                // calling downloadApp(). Otherwise SteamService.downloadApp() finds the
+                // inactive entry, calls removeDownloadJob() (which fires the legacy
+                // checkQueue() and an extra notify event), and only then proceeds to build
+                // a fresh DownloadInfo. Removing here directly avoids that duplicate path.
+                downloadJobs.remove(appId)
+                // CRITICAL: pass record.selectedDlcs as the authoritative DLC list. The
+                // legacy no-arg downloadApp(appId) reconstructs DLCs from a fragile chain
+                // (DownloadingAppInfo -> snapshot inference -> installed). Snapshot inference
+                // only sees DLCs that already had bytes downloaded, so DLCs the user selected
+                // but never started would silently disappear and the game would be marked
+                // COMPLETE after only downloading a partial scope.
+                val dlcAppIdsHint =
+                    record.selectedDlcs
+                        .split(',')
+                        .mapNotNull { it.trim().toIntOrNull() }
+                downloadApp(appId, dlcAppIdsHint)
+            }
+
+            override fun pauseRunning(record: DownloadRecord) {
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                val info = downloadJobs[appId] ?: return
+                val status = info.getStatusFlow().value
+                if (status == DownloadPhase.COMPLETE || status == DownloadPhase.CANCELLED) return
+                if (info.isActive()) {
+                    info.isCancelling = false
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.cancel("Paused by user")
+                } else if (status == DownloadPhase.QUEUED) {
+                    info.updateStatus(DownloadPhase.PAUSED)
+                    info.setActive(false)
+                    notifyDownloadStopped(appId)
+                }
+            }
+
+            override fun cancelRunning(record: DownloadRecord) {
+                val appId = record.storeGameId.toIntOrNull() ?: return
+                val info = downloadJobs[appId]
+                if (info != null) {
+                    info.isCancelling = true
+                    info.cancel("Cancelled by user")
+                }
+                kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
+                    info?.awaitCompletion(timeoutMs = 3000L)
+                    val appDirPath = getAppDirPath(appId)
+                    val dirFile = java.io.File(appDirPath)
+                    if (dirFile.exists() && dirFile.isDirectory) {
+                        MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                        MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                        deleteRecursivelyWithRetries(dirFile)
+                    }
+                    info?.updateStatus(DownloadPhase.CANCELLED)
+                    removeDownloadJob(appId, forceRemove = true)
+                }
+            }
+        }
+
     override fun onCreate() {
         super.onCreate()
         instance = this
@@ -5028,6 +5301,9 @@ class SteamService :
         }
 
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
+
+        DownloadCoordinator.init(db)
+        DownloadCoordinator.registerDispatcher(DownloadRecord.STORE_STEAM, coordinatorDispatcher)
 
         // To view log messages in android logcat properly
         LogManager.addListener(logger)
@@ -5136,6 +5412,8 @@ class SteamService :
         if (instance === this) {
             instance = null
         }
+
+        DownloadCoordinator.unregisterDispatcher(DownloadRecord.STORE_STEAM)
 
         // Persist download progress for all active downloads
         // This is a safety net for OS kills (unlikely but possible)

--- a/app/src/main/shared/android/AppTerminationHelper.kt
+++ b/app/src/main/shared/android/AppTerminationHelper.kt
@@ -23,9 +23,14 @@ object AppTerminationHelper {
         val appContext = context.applicationContext
         Timber.i("Stopping managed services for app shutdown (%s)", reason)
 
-        // Stop active transfers without deleting partial download state.
-        runCatching { DownloadService.pauseAll() }
-            .onFailure { Timber.w(it, "Failed to pause downloads during shutdown") }
+        // Do NOT call DownloadService.pauseAll() here. The DownloadCoordinator persists every
+        // download's status in the records table, so downloads that were DOWNLOADING when the
+        // app exited will be auto-resumed on next launch. Calling pauseAll would mark them
+        // PAUSED, which would make the user have to manually resume each one — the opposite
+        // of what they expect. PAUSED downloads (paused by the user) stay PAUSED.
+        runCatching {
+            com.winlator.cmod.app.service.download.DownloadCoordinator.onAppExit()
+        }.onFailure { Timber.w(it, "Failed to notify DownloadCoordinator during shutdown") }
 
         runCatching { EpicTokenRefreshWorker.cancel(appContext) }
             .onFailure { Timber.w(it, "Failed to cancel Epic refresh worker during shutdown") }


### PR DESCRIPTION
…pot resume

Phase 1 (targeted patches across Steam/Epic/GOG):
- Steam: completed downloads now setActive(false) before checkQueue() so the slot is freed for the next queued download (fixes "only one download starts until clear").
- Steam: checkQueue() guarded by Mutex; slot accounting uses status, not isActive(), so a stale-active entry can't block the queue.
- Epic/GOG: persist the chosen install path on enqueue (was only written on success), so cancel/pause/resume can find the partial install for custom paths.
- Epic/GOG: stop removing COMPLETE/FAILED entries from in-memory map so Clear has something to remove and the Downloads tab keeps history.
- Clear button now removes COMPLETE/CANCELLED/FAILED across all stores and UI.
- Cooperative cancel checks added inside Epic/GOG chunk read loops; GOG Gen 2 switched from response.body.bytes() to streaming.
- Epic resume preserves DLC selection and language (was passing emptyList/empty string).
- GOGService.hasActiveOperations() now includes active downloads.

Phase 2 (cross-store DownloadCoordinator):
- New DownloadRecord Room entity + DAO + DatabaseModule binding (DB v3 → v4 with destructive migration).
- New DownloadCoordinator singleton enforcing a global concurrency limit (PrefManager.downloadQueueSize) shared across Steam/Epic/GOG.
- All store services route through DownloadCoordinator.requestSlot(...) and notifyFinished(...); each store registers a Dispatcher used by tick() to start queued records.
- Re-entry guard in requestSlot: if existing record is DOWNLOADING, return Decision.Start without rewriting the row (fixes Resume staying stuck on Queued because the dispatcher's downloadApp() re-entered requestSlot and counted the record against itself).
- Coordinator fields (selectedDlcs, installPath, language) overwrite cleanly on re-enqueue instead of preserving stale values via .ifEmpty {…}.
- DownloadService.getAllDownloads() synthesises stub DownloadInfos for records that have no in-memory entry, so PAUSED records survive app restart.
- AppTerminationHelper no longer pauses-all on exit; coordinator persists state so DOWNLOADING-on-exit auto-resumes on next launch and PAUSED stays PAUSED.
- Downloads tab observes DownloadCoordinator.changes; queue-size +/- buttons call coordinator.tick() (was Steam-only); list sorted Downloading → Paused → Queued → Complete → Failed → Cancelled.
- Steam's legacy checkQueue() neutered to delegate to coordinator (was racing).

Steam multi-depot resume fixes:
- New downloadApp(appId, dlcAppIdsHint) overload. The dispatcher passes record.selectedDlcs as the authoritative source, so resume no longer drops DLCs by relying on the snapshot/installed-DLCs fallback chain.
- No-arg downloadApp(appId) consults the coordinator record for DLCs first, before DownloadingAppInfo / inferResumeDlcAppIds / installed.
- Scope-mismatch safety check in inner downloadApp: if the snapshot remembers depots that aren't in the current resume scope, abort with FAILED instead of letting completion fire on a partial set.
- Per-depot byte tracking in AppDownloadListener replaces the buggy global high-water mark (the comment said the API reports global cumulative bytes; the API actually reports per-depot bytes — race attribution corrupted depot_bytes.json on parallel chunk callbacks).
- onDepotCompleted no longer tops up the depot tracker to manifest size. JavaSteam fires onDepotCompleted at the end of processDepotManifestAndFiles even when chunks were only queued, so the top-up was marking partial depots as fully downloaded and causing "only 500 MB downloaded then game flagged COMPLETE" symptoms.
- Snapshot-based depot filtering only trusts the snapshot when the COMPLETE marker is present; otherwise the suspicious entries are dropped and the snapshot file cleared so DepotDownloader can re-validate every file.
- JavaSteam's DepotConfigStore (.DepotDownloader/depot.config) is cleared on every start/resume that lacks the COMPLETE marker. JavaSteam writes installedManifestIDs in processDepotManifestAndFiles before chunks land, and on next resume it trusts those IDs and skips file checksum validation — preallocated/sparse partial files end up flagged complete. Clearing forces re-validation.
- completion.join() replaced with cancellation-aware await(); after it returns we re-check coroutineContext.ensureActive() and DownloadInfo.isActive() so a pause that lands while we're blocked in the future can't fall through to completeAppDownload and set the COMPLETE marker on a partial install.
- Diagnostic logging added (DEPOT-MAXED, BIG-DELTA, RESUME-INIT, Resume snapshot per-depot, PERSIST-SNAPSHOT with caller stack) to make future regressions traceable.

Phase 1 fresh-snapshot cleanup also flips clearPersistedBytesDownloaded() to sync mode so a stale snapshot from a previous (possibly buggy) session can't poison the current download via an async-write race.