### PR TITLE
fix: restore Range Button functionality in input controls

### DIFF
--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -774,14 +774,16 @@ public class ControlElement {
 
   public boolean handleTouchDown(int pointerId, float x, float y) {
     if (currentPointerId == -1 && containsPoint(x, y)) {
-      boolean hasBinding = false;
-      for (Binding binding : bindings) {
-        if (binding != Binding.NONE) {
-          hasBinding = true;
-          break;
+      if (type != Type.RANGE_BUTTON) {
+        boolean hasBinding = false;
+        for (Binding binding : bindings) {
+          if (binding != Binding.NONE) {
+            hasBinding = true;
+            break;
+          }
         }
+        if (!hasBinding) return false;
       }
-      if (!hasBinding) return false;
 
       currentPointerId = pointerId;
       if (type == Type.BUTTON) {


### PR DESCRIPTION
Exempt RANGE_BUTTON from the hasBinding check in handleTouchDown. Range Buttons generate bindings dynamically based on their range configuration, so they often have an empty fixed bindings array which was causing touch events to be incorrectly filtered out.