### PR TITLE
Update components settings layout and category copy

### DIFF
--- a/app/src/main/feature/settings/contents/ComponentsScreen.kt
+++ b/app/src/main/feature/settings/contents/ComponentsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -43,7 +42,6 @@ import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DeveloperBoard
 import androidx.compose.material.icons.outlined.Download
-import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Inbox
 import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.Science
@@ -186,16 +184,11 @@ fun ComponentsScreen(
             HeroHeader(
                 installedCount = state.installed.size,
                 availableCount = state.available.size,
+                currentType = state.currentType,
                 autoCreateContainer = state.autoCreateContainer,
+                onTypeSelected = onTypeSelected,
                 onInstallFromFile = onInstallFromFile,
                 onToggleAutoCreateContainer = onToggleAutoCreateContainer,
-            )
-        }
-
-        item(key = "type_tabs") {
-            TypeTabsCard(
-                currentType = state.currentType,
-                onTypeSelected = onTypeSelected,
             )
         }
 
@@ -259,11 +252,13 @@ fun ComponentsScreen(
 private fun HeroHeader(
     installedCount: Int,
     availableCount: Int,
+    currentType: ContentProfile.ContentType,
     autoCreateContainer: Boolean,
+    onTypeSelected: (ContentProfile.ContentType) -> Unit,
     onInstallFromFile: () -> Unit,
     onToggleAutoCreateContainer: (Boolean) -> Unit,
 ) {
-    BoxWithConstraints(
+    Box(
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -272,105 +267,24 @@ private fun HeroHeader(
                 .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
                 .padding(horizontal = 14.dp, vertical = 11.dp),
     ) {
-        val stackActionsBelowCounts = maxWidth < 620.dp
-
-        if (stackActionsBelowCounts) {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(34.dp)
-                                .clip(RoundedCornerShape(9.dp))
-                                .background(IconBoxBg),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Extension,
-                            contentDescription = null,
-                            tint = Accent,
-                            modifier = Modifier.size(17.dp),
-                        )
-                    }
-                    Spacer(Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.settings_content_components),
-                            color = TextPrimary,
-                            fontSize = 15.sp,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Spacer(Modifier.height(2.dp))
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
-                            Spacer(Modifier.width(6.dp))
-                            CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
-                        }
-                    }
-                }
-
-                Spacer(Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    ToggleChip(
-                        label = stringResource(R.string.settings_content_auto_create_container),
-                        enabled = autoCreateContainer,
-                        onToggle = { onToggleAutoCreateContainer(!autoCreateContainer) },
-                    )
-                    SmallPillButton(
-                        label = stringResource(R.string.settings_content_install),
-                        icon = Icons.Outlined.Upload,
-                        tint = Accent,
-                        onClick = onInstallFromFile,
-                    )
-                }
-            }
-        } else {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(34.dp)
-                            .clip(RoundedCornerShape(9.dp))
-                            .background(IconBoxBg),
-                    contentAlignment = Alignment.Center,
+                Row(
+                    modifier = Modifier.weight(1f),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Extension,
-                        contentDescription = null,
-                        tint = Accent,
-                        modifier = Modifier.size(17.dp),
-                    )
-                }
-                Spacer(Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.settings_content_components),
-                        color = TextPrimary,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
-                        Spacer(Modifier.width(6.dp))
-                        CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
-                    }
+                    CountPill(label = stringResource(R.string.common_ui_installed), count = installedCount)
+                    Spacer(Modifier.width(6.dp))
+                    CountPill(label = stringResource(R.string.common_ui_available), count = availableCount)
                 }
                 Spacer(Modifier.width(10.dp))
                 ToggleChip(
                     label = stringResource(R.string.settings_content_auto_create_container),
                     enabled = autoCreateContainer,
+                    compact = true,
                     onToggle = { onToggleAutoCreateContainer(!autoCreateContainer) },
                 )
                 Spacer(Modifier.width(8.dp))
@@ -378,9 +292,16 @@ private fun HeroHeader(
                     label = stringResource(R.string.settings_content_install),
                     icon = Icons.Outlined.Upload,
                     tint = Accent,
+                    compact = true,
                     onClick = onInstallFromFile,
                 )
             }
+
+            Spacer(Modifier.height(12.dp))
+            TypeTabsContent(
+                currentType = currentType,
+                onTypeSelected = onTypeSelected,
+            )
         }
     }
 }
@@ -389,11 +310,16 @@ private fun HeroHeader(
 private fun ToggleChip(
     label: String,
     enabled: Boolean,
+    compact: Boolean = false,
     onToggle: () -> Unit,
 ) {
     val tint = if (enabled) SuccessGreen else TextSecondary
     val background = if (enabled) SuccessGreen.copy(alpha = 0.14f) else SurfaceDark
     val borderColor = if (enabled) SuccessGreen.copy(alpha = 0.45f) else CardBorder
+    val horizontalPadding = if (compact) 8.dp else 10.dp
+    val verticalPadding = if (compact) 4.dp else 5.dp
+    val dotSize = if (compact) 5.dp else 6.dp
+    val fontSize = if (compact) 10.sp else 11.sp
     Row(
         modifier =
             Modifier
@@ -401,13 +327,13 @@ private fun ToggleChip(
                 .background(background)
                 .border(1.dp, borderColor, RoundedCornerShape(8.dp))
                 .noRippleClickable(onClick = onToggle)
-                .padding(horizontal = 10.dp, vertical = 5.dp),
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier =
                 Modifier
-                    .size(6.dp)
+                    .size(dotSize)
                     .clip(RoundedCornerShape(3.dp))
                     .background(tint),
         )
@@ -415,7 +341,7 @@ private fun ToggleChip(
         Text(
             text = label,
             color = tint,
-            fontSize = 11.sp,
+            fontSize = fontSize,
             fontWeight = FontWeight.SemiBold,
         )
     }
@@ -458,65 +384,55 @@ private fun CountPill(
 // ============================================================================
 
 @Composable
-private fun TypeTabsCard(
+private fun TypeTabsContent(
     currentType: ContentProfile.ContentType,
     onTypeSelected: (ContentProfile.ContentType) -> Unit,
 ) {
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
-                .background(CardDark)
-                .border(1.dp, CardBorder, RoundedCornerShape(12.dp))
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.settings_content_type).uppercase(),
+            color = TextSecondary,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.4.sp,
+            modifier = Modifier.padding(start = 2.dp, bottom = 8.dp),
+        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val types = ContentProfile.ContentType.values()
+            types.forEachIndexed { index, type ->
+                TypeTabChip(
+                    label = type.toString(),
+                    selected = type == currentType,
+                    onClick = { onTypeSelected(type) },
+                )
+                if (index < types.lastIndex) {
+                    Spacer(Modifier.width(8.dp))
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Crossfade(
+            targetState = currentType,
+            animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
+            label = "componentsTypeDescription",
+        ) { type ->
             Text(
-                text = stringResource(R.string.settings_content_type).uppercase(),
-                color = TextSecondary,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 1.4.sp,
-                modifier = Modifier.padding(start = 2.dp, bottom = 8.dp),
-            )
-            Row(
+                text = stringResource(descriptionResFor(type)),
+                color = TextPrimary,
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                textAlign = TextAlign.Center,
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                val types = ContentProfile.ContentType.values()
-                types.forEachIndexed { index, type ->
-                    TypeTabChip(
-                        label = type.toString(),
-                        selected = type == currentType,
-                        onClick = { onTypeSelected(type) },
-                    )
-                    if (index < types.lastIndex) {
-                        Spacer(Modifier.width(8.dp))
-                    }
-                }
-            }
-            Spacer(Modifier.height(8.dp))
-            Crossfade(
-                targetState = currentType,
-                animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
-                label = "componentsTypeDescription",
-            ) { type ->
-                Text(
-                    text = stringResource(descriptionResFor(type)),
-                    color = TextPrimary,
-                    fontSize = 11.sp,
-                    lineHeight = 15.sp,
-                    textAlign = TextAlign.Center,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 2.dp),
-                )
-            }
+                        .padding(horizontal = 2.dp),
+            )
         }
     }
 }
@@ -700,8 +616,13 @@ private fun SmallPillButton(
     label: String,
     icon: ImageVector?,
     tint: Color,
+    compact: Boolean = false,
     onClick: () -> Unit,
 ) {
+    val horizontalPadding = if (compact) 8.dp else 10.dp
+    val verticalPadding = if (compact) 4.dp else 6.dp
+    val iconSize = if (compact) 11.dp else 12.dp
+    val fontSize = if (compact) 10.sp else 11.sp
     Row(
         modifier =
             Modifier
@@ -709,7 +630,7 @@ private fun SmallPillButton(
                 .background(tint.copy(alpha = 0.14f))
                 .border(1.dp, tint.copy(alpha = 0.30f), RoundedCornerShape(8.dp))
                 .noRippleClickable(onClick = onClick)
-                .padding(horizontal = 10.dp, vertical = 6.dp),
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (icon != null) {
@@ -717,14 +638,14 @@ private fun SmallPillButton(
                 imageVector = icon,
                 contentDescription = null,
                 tint = tint,
-                modifier = Modifier.size(12.dp),
+                modifier = Modifier.size(iconSize),
             )
             Spacer(Modifier.width(5.dp))
         }
         Text(
             text = label,
             color = tint,
-            fontSize = 11.sp,
+            fontSize = fontSize,
             fontWeight = FontWeight.SemiBold,
         )
     }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -752,7 +752,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Installer indhold</string>
-    <string name="settings_content_type">Indholdstype</string>
+    <string name="settings_content_type">Kategori</string>
     <string name="settings_content_components">Komponenter</string>
     <string name="settings_content_auto_create_container">Auto-opret container</string>
     <string name="settings_content_remove_title">Fjern komponent?</string>
@@ -760,13 +760,13 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_content_container_created">Container oprettet: %1$s</string>
     <string name="settings_content_download_failed">Download mislykkedes.</string>
     <string name="common_ui_working">Arbejder…</string>
-    <string name="settings_content_desc_wine">Windows-kompatibilitetslaget der bruges til at køre spil og apps. Du skal have mindst én Wine- eller FEXCore-version installeret.</string>
-    <string name="settings_content_desc_proton">Valves Wine-baserede build med ekstra patches til spil. Nyttig til nogle titler, men standard-Wine fungerer normalt fint.</string>
-    <string name="settings_content_desc_dxvk">Oversætter DirectX 9, 10 og 11 til Vulkan. Dette forbedrer normalt ydeevnen i ældre Windows-spil.</string>
-    <string name="settings_content_desc_vkd3d">Oversætter DirectX 12 til Vulkan. Nødvendig for mange nyere Windows-spil.</string>
-    <string name="settings_content_desc_box64">Oversætter x86 / x64 Windows-kode så det kan køre på ARM-enheder. Box64 eller FEXCore kræves til de fleste spil.</string>
-    <string name="settings_content_desc_wowbox64">Et Box64-build til Wine WoW64-tilstand. Kun nødvendig ved brug af et 64-bit-præfiks med 32-bit app-understøttelse.</string>
-    <string name="settings_content_desc_fexcore">En alternativ x86 / x64-oversætter. Prøv den hvis et spil har problemer eller dårlig ydeevne med Box64.</string>
+    <string name="settings_content_desc_wine">Lavet af Wine-projektet; oversætter Win32-kald til native Linux/Android-tjenester.</string>
+    <string name="settings_content_desc_proton">Lavet af Valve; en Wine-baseret runtime med spilrettelser til Windows-spil.</string>
+    <string name="settings_content_desc_dxvk">Oversætter Direct3D 9-, 10- og 11-grafikkald til Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Oversætter Direct3D 12-grafikkald til Vulkan.</string>
+    <string name="settings_content_desc_box64">Oversætter x86_64 Linux-kode, så den kan køre på ARM64-enheder.</string>
+    <string name="settings_content_desc_wowbox64">Box64-build brugt af WoW64 til at køre 32-bit Windows-apps i 64-bit Wine.</string>
+    <string name="settings_content_desc_fexcore">Oversætter x86- og x86_64-kode, så den kan køre på ARM64-enheder.</string>
     <string name="settings_content_unable_to_install">Kan ikke installere indhold.</string>
     <string name="settings_content_install_failed">Installation mislykkedes</string>
     <string name="settings_content_file_cannot_be_recognized">Filen kan ikke genkendes.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -752,7 +752,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Inhalt installieren</string>
-    <string name="settings_content_type">Inhaltstyp</string>
+    <string name="settings_content_type">Kategorie</string>
     <string name="settings_content_components">Komponenten</string>
     <string name="settings_content_auto_create_container">Container automatisch erstellen</string>
     <string name="settings_content_remove_title">Komponente entfernen?</string>
@@ -760,13 +760,13 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_content_container_created">Container erstellt: %1$s</string>
     <string name="settings_content_download_failed">Download fehlgeschlagen.</string>
     <string name="common_ui_working">Arbeite…</string>
-    <string name="settings_content_desc_wine">Die Windows-Kompatibilitätsschicht zum Ausführen von Spielen und Apps. Du benötigst mindestens eine installierte Wine- oder FEXCore-Version.</string>
-    <string name="settings_content_desc_proton">Valves Wine-basierter Build mit zusätzlichen Patches für Spiele. Nützlich für einige Titel, aber Standard-Wine funktioniert meistens gut.</string>
-    <string name="settings_content_desc_dxvk">Übersetzt DirectX 9, 10 und 11 nach Vulkan. Dies verbessert normalerweise die Leistung älterer Windows-Spiele.</string>
-    <string name="settings_content_desc_vkd3d">Übersetzt DirectX 12 nach Vulkan. Wird für viele neuere Windows-Spiele benötigt.</string>
-    <string name="settings_content_desc_box64">Übersetzt x86/x64-Windows-Code, damit er auf ARM-Geräten läuft. Box64 oder FEXCore wird für die meisten Spiele benötigt.</string>
-    <string name="settings_content_desc_wowbox64">Ein Box64-Build für den Wine-WoW64-Modus. Nur nötig bei einem 64-Bit-Prefix mit 32-Bit-App-Unterstützung.</string>
-    <string name="settings_content_desc_fexcore">Ein alternativer x86/x64-Übersetzer. Probiere ihn aus, wenn ein Spiel Probleme oder schlechte Leistung mit Box64 hat.</string>
+    <string name="settings_content_desc_wine">Vom Wine-Projekt erstellt; übersetzt Win32-Aufrufe in native Linux/Android-Dienste.</string>
+    <string name="settings_content_desc_proton">Von Valve erstellt; eine Wine-basierte Runtime mit Spiel-Patches für Windows-Spiele.</string>
+    <string name="settings_content_desc_dxvk">Übersetzt Direct3D-9-, 10- und 11-Grafikaufrufe nach Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Übersetzt Direct3D-12-Grafikaufrufe nach Vulkan.</string>
+    <string name="settings_content_desc_box64">Übersetzt x86_64-Linux-Code, damit er auf ARM64-Geräten läuft.</string>
+    <string name="settings_content_desc_wowbox64">Box64-Build, den WoW64 zum Ausführen von 32-Bit-Windows-Apps in 64-Bit-Wine nutzt.</string>
+    <string name="settings_content_desc_fexcore">Übersetzt x86- und x86_64-Code, damit er auf ARM64-Geräten läuft.</string>
     <string name="settings_content_unable_to_install">Inhalt kann nicht installiert werden.</string>
     <string name="settings_content_install_failed">Installation fehlgeschlagen</string>
     <string name="settings_content_file_cannot_be_recognized">Datei kann nicht erkannt werden.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -752,7 +752,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Instalar contenido</string>
-    <string name="settings_content_type">Tipo de contenido</string>
+    <string name="settings_content_type">Categoría</string>
     <string name="settings_content_components">Componentes</string>
     <string name="settings_content_auto_create_container">Crear contenedor automáticamente</string>
     <string name="settings_content_remove_title">¿Eliminar componente?</string>
@@ -760,13 +760,13 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_content_container_created">Contenedor creado: %1$s</string>
     <string name="settings_content_download_failed">Descarga fallida.</string>
     <string name="common_ui_working">Trabajando…</string>
-    <string name="settings_content_desc_wine">La capa de compatibilidad de Windows usada para ejecutar juegos y aplicaciones. Necesitas al menos una versión de Wine o FEXCore instalada.</string>
-    <string name="settings_content_desc_proton">Compilación basada en Wine de Valve con parches adicionales para juegos. Útil para algunos títulos, pero Wine estándar suele funcionar bien.</string>
-    <string name="settings_content_desc_dxvk">Traduce DirectX 9, 10 y 11 a Vulkan. Esto suele mejorar el rendimiento en juegos antiguos de Windows.</string>
-    <string name="settings_content_desc_vkd3d">Traduce DirectX 12 a Vulkan. Necesario para muchos juegos recientes de Windows.</string>
-    <string name="settings_content_desc_box64">Traduce código x86 / x64 de Windows para que pueda ejecutarse en dispositivos ARM. Box64 o FEXCore son necesarios para la mayoría de los juegos.</string>
-    <string name="settings_content_desc_wowbox64">Una compilación de Box64 para el modo WoW64 de Wine. Solo se necesita al usar un prefijo de 64 bits con soporte para aplicaciones de 32 bits.</string>
-    <string name="settings_content_desc_fexcore">Un traductor x86 / x64 alternativo. Pruébalo si un juego tiene problemas o bajo rendimiento con Box64.</string>
+    <string name="settings_content_desc_wine">Creado por el proyecto Wine; traduce llamadas Win32 a servicios nativos de Linux/Android.</string>
+    <string name="settings_content_desc_proton">Creado por Valve; runtime basado en Wine con parches para juegos de Windows.</string>
+    <string name="settings_content_desc_dxvk">Traduce llamadas gráficas de Direct3D 9, 10 y 11 a Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Traduce llamadas gráficas de Direct3D 12 a Vulkan.</string>
+    <string name="settings_content_desc_box64">Traduce código Linux x86_64 para que se ejecute en dispositivos ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build de Box64 usado por WoW64 para ejecutar apps Windows de 32 bits en Wine de 64 bits.</string>
+    <string name="settings_content_desc_fexcore">Traduce código x86 y x86_64 para que se ejecute en dispositivos ARM64.</string>
     <string name="settings_content_unable_to_install">No se pudo instalar el contenido.</string>
     <string name="settings_content_install_failed">Error en la instalación</string>
     <string name="settings_content_file_cannot_be_recognized">No se puede reconocer el archivo.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -752,7 +752,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Installer du contenu</string>
-    <string name="settings_content_type">Type de contenu</string>
+    <string name="settings_content_type">Catégorie</string>
     <string name="settings_content_components">Composants</string>
     <string name="settings_content_auto_create_container">Créer le conteneur automatiquement</string>
     <string name="settings_content_remove_title">Supprimer le composant ?</string>
@@ -760,13 +760,13 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_content_container_created">Conteneur créé : %1$s</string>
     <string name="settings_content_download_failed">Échec du téléchargement.</string>
     <string name="common_ui_working">En cours…</string>
-    <string name="settings_content_desc_wine">La couche de compatibilité Windows utilisée pour exécuter jeux et applications. Vous devez avoir au moins une version de Wine ou FEXCore installée.</string>
-    <string name="settings_content_desc_proton">Build basé sur Wine de Valve avec des correctifs supplémentaires pour les jeux. Utile pour certains titres, mais Wine standard fonctionne généralement bien.</string>
-    <string name="settings_content_desc_dxvk">Traduit DirectX 9, 10 et 11 vers Vulkan. Cela améliore généralement les performances des anciens jeux Windows.</string>
-    <string name="settings_content_desc_vkd3d">Traduit DirectX 12 vers Vulkan. Nécessaire pour de nombreux jeux Windows récents.</string>
-    <string name="settings_content_desc_box64">Traduit le code Windows x86 / x64 pour qu\'il puisse s\'exécuter sur des appareils ARM. Box64 ou FEXCore est requis pour la plupart des jeux.</string>
-    <string name="settings_content_desc_wowbox64">Un build Box64 pour le mode Wine WoW64. Nécessaire uniquement avec un préfixe 64 bits prenant en charge les applications 32 bits.</string>
-    <string name="settings_content_desc_fexcore">Un traducteur x86 / x64 alternatif. Essayez-le si un jeu présente des problèmes ou de mauvaises performances avec Box64.</string>
+    <string name="settings_content_desc_wine">Créé par le projet Wine ; traduit les appels Win32 vers des services Linux/Android natifs.</string>
+    <string name="settings_content_desc_proton">Créé par Valve ; runtime basé sur Wine avec des correctifs pour les jeux Windows.</string>
+    <string name="settings_content_desc_dxvk">Traduit les appels graphiques Direct3D 9, 10 et 11 vers Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Traduit les appels graphiques Direct3D 12 vers Vulkan.</string>
+    <string name="settings_content_desc_box64">Traduit le code Linux x86_64 pour l’exécuter sur des appareils ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build Box64 utilisé par WoW64 pour exécuter des apps Windows 32 bits dans Wine 64 bits.</string>
+    <string name="settings_content_desc_fexcore">Traduit le code x86 et x86_64 pour l’exécuter sur des appareils ARM64.</string>
     <string name="settings_content_unable_to_install">Impossible d\'installer le contenu.</string>
     <string name="settings_content_install_failed">Échec de l\'installation</string>
     <string name="settings_content_file_cannot_be_recognized">Le fichier ne peut pas être reconnu.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -752,7 +752,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Installa contenuto</string>
-    <string name="settings_content_type">Tipo di contenuto</string>
+    <string name="settings_content_type">Categoria</string>
     <string name="settings_content_components">Componenti</string>
     <string name="settings_content_auto_create_container">Crea container automaticamente</string>
     <string name="settings_content_remove_title">Rimuovere il componente?</string>
@@ -760,13 +760,13 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_content_container_created">Container creato: %1$s</string>
     <string name="settings_content_download_failed">Download non riuscito.</string>
     <string name="common_ui_working">Elaborazione in corso…</string>
-    <string name="settings_content_desc_wine">Il livello di compatibilità Windows usato per eseguire giochi e app. È necessaria almeno una versione di Wine o FEXCore installata.</string>
-    <string name="settings_content_desc_proton">Build basata su Wine di Valve con patch aggiuntive per i giochi. Utile per alcuni titoli, ma Wine standard di solito funziona bene.</string>
-    <string name="settings_content_desc_dxvk">Traduce DirectX 9, 10 e 11 in Vulkan. Di solito migliora le prestazioni nei vecchi giochi Windows.</string>
-    <string name="settings_content_desc_vkd3d">Traduce DirectX 12 in Vulkan. Necessario per molti giochi Windows più recenti.</string>
-    <string name="settings_content_desc_box64">Traduce il codice Windows x86 / x64 in modo che possa essere eseguito su dispositivi ARM. Box64 o FEXCore è necessario per la maggior parte dei giochi.</string>
-    <string name="settings_content_desc_wowbox64">Una build Box64 per la modalità Wine WoW64. Necessaria solo quando si utilizza un prefisso a 64 bit con supporto per app a 32 bit.</string>
-    <string name="settings_content_desc_fexcore">Un traduttore x86 / x64 alternativo. Provalo se un gioco presenta problemi o prestazioni scarse con Box64.</string>
+    <string name="settings_content_desc_wine">Creato dal progetto Wine; traduce le chiamate Win32 in servizi Linux/Android nativi.</string>
+    <string name="settings_content_desc_proton">Creato da Valve; runtime basato su Wine con patch per i giochi Windows.</string>
+    <string name="settings_content_desc_dxvk">Traduce le chiamate grafiche Direct3D 9, 10 e 11 in Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Traduce le chiamate grafiche Direct3D 12 in Vulkan.</string>
+    <string name="settings_content_desc_box64">Traduce codice Linux x86_64 per eseguirlo su dispositivi ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build Box64 usata da WoW64 per eseguire app Windows a 32 bit in Wine a 64 bit.</string>
+    <string name="settings_content_desc_fexcore">Traduce codice x86 e x86_64 per eseguirlo su dispositivi ARM64.</string>
     <string name="settings_content_unable_to_install">Impossibile installare il contenuto.</string>
     <string name="settings_content_install_failed">Installazione fallita</string>
     <string name="settings_content_file_cannot_be_recognized">Impossibile riconoscere il file.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">콘텐츠 설치</string>
-    <string name="settings_content_type">콘텐츠 유형</string>
+    <string name="settings_content_type">카테고리</string>
     <string name="settings_content_components">구성 요소</string>
     <string name="settings_content_auto_create_container">컨테이너 자동 생성</string>
     <string name="settings_content_remove_title">구성 요소를 제거하시겠습니까?</string>
@@ -760,13 +760,13 @@
     <string name="settings_content_container_created">컨테이너 생성됨: %1$s</string>
     <string name="settings_content_download_failed">다운로드 실패.</string>
     <string name="common_ui_working">처리 중…</string>
-    <string name="settings_content_desc_wine">게임 및 앱을 실행하는 데 사용되는 Windows 호환성 계층입니다. 최소 하나의 Wine 또는 FEXCore 버전이 설치되어 있어야 합니다.</string>
-    <string name="settings_content_desc_proton">게임용 추가 패치가 포함된 Valve의 Wine 기반 빌드입니다. 일부 타이틀에 유용하지만 일반적으로 표준 Wine도 잘 작동합니다.</string>
-    <string name="settings_content_desc_dxvk">DirectX 9, 10 및 11을 Vulkan으로 변환합니다. 일반적으로 오래된 Windows 게임의 성능을 향상시킵니다.</string>
-    <string name="settings_content_desc_vkd3d">DirectX 12를 Vulkan으로 변환합니다. 많은 최신 Windows 게임에 필요합니다.</string>
-    <string name="settings_content_desc_box64">x86 / x64 Windows 코드를 변환하여 ARM 기기에서 실행할 수 있도록 합니다. 대부분의 게임에는 Box64 또는 FEXCore가 필요합니다.</string>
-    <string name="settings_content_desc_wowbox64">Wine WoW64 모드용 Box64 빌드입니다. 32비트 앱을 지원하는 64비트 프리픽스를 사용할 때만 필요합니다.</string>
-    <string name="settings_content_desc_fexcore">대체 x86 / x64 변환기입니다. Box64에서 게임에 문제가 있거나 성능이 좋지 않은 경우 시도해 보세요.</string>
+    <string name="settings_content_desc_wine">Wine 프로젝트에서 제작했으며 Win32 호출을 네이티브 Linux/Android 서비스로 변환합니다.</string>
+    <string name="settings_content_desc_proton">Valve에서 제작한 Wine 기반 런타임이며 Windows 게임용 패치를 포함합니다.</string>
+    <string name="settings_content_desc_dxvk">Direct3D 9, 10, 11 그래픽 호출을 Vulkan으로 변환합니다.</string>
+    <string name="settings_content_desc_vkd3d">Direct3D 12 그래픽 호출을 Vulkan으로 변환합니다.</string>
+    <string name="settings_content_desc_box64">x86_64 Linux 코드를 ARM64 기기에서 실행되도록 변환합니다.</string>
+    <string name="settings_content_desc_wowbox64">64비트 Wine에서 32비트 Windows 앱을 실행하기 위해 WoW64가 사용하는 Box64 빌드입니다.</string>
+    <string name="settings_content_desc_fexcore">x86 및 x86_64 코드를 ARM64 기기에서 실행되도록 변환합니다.</string>
     <string name="settings_content_unable_to_install">콘텐츠를 설치할 수 없습니다.</string>
     <string name="settings_content_install_failed">설치 실패</string>
     <string name="settings_content_file_cannot_be_recognized">파일을 인식할 수 없습니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -752,7 +752,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Zainstaluj zawartość</string>
-    <string name="settings_content_type">Typ zawartości</string>
+    <string name="settings_content_type">Kategoria</string>
     <string name="settings_content_components">Komponenty</string>
     <string name="settings_content_auto_create_container">Automatycznie utwórz kontener</string>
     <string name="settings_content_remove_title">Usunąć komponent?</string>
@@ -760,13 +760,13 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_content_container_created">Utworzono kontener: %1$s</string>
     <string name="settings_content_download_failed">Pobieranie nie powiodło się.</string>
     <string name="common_ui_working">Pracuję…</string>
-    <string name="settings_content_desc_wine">Warstwa kompatybilności Windows używana do uruchamiania gier i aplikacji. Wymagana jest co najmniej jedna zainstalowana wersja Wine lub FEXCore.</string>
-    <string name="settings_content_desc_proton">Oparta na Wine kompilacja Valve z dodatkowymi łatkami do gier. Przydatna w przypadku niektórych tytułów, ale standardowy Wine zwykle działa dobrze.</string>
-    <string name="settings_content_desc_dxvk">Tłumaczy DirectX 9, 10 i 11 na Vulkan. Zwykle poprawia wydajność w starszych grach Windows.</string>
-    <string name="settings_content_desc_vkd3d">Tłumaczy DirectX 12 na Vulkan. Wymagany dla wielu nowszych gier Windows.</string>
-    <string name="settings_content_desc_box64">Tłumaczy kod Windows x86 / x64 tak, aby mógł działać na urządzeniach ARM. Box64 lub FEXCore jest wymagany dla większości gier.</string>
-    <string name="settings_content_desc_wowbox64">Kompilacja Box64 dla trybu Wine WoW64. Wymagana tylko przy użyciu prefiksu 64-bitowego z obsługą aplikacji 32-bitowych.</string>
-    <string name="settings_content_desc_fexcore">Alternatywny tłumacz x86 / x64. Wypróbuj go, jeśli gra ma problemy lub słabą wydajność z Box64.</string>
+    <string name="settings_content_desc_wine">Stworzone przez projekt Wine; tłumaczy wywołania Win32 na natywne usługi Linux/Android.</string>
+    <string name="settings_content_desc_proton">Stworzone przez Valve; runtime oparty na Wine z łatkami dla gier Windows.</string>
+    <string name="settings_content_desc_dxvk">Tłumaczy wywołania graficzne Direct3D 9, 10 i 11 na Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Tłumaczy wywołania graficzne Direct3D 12 na Vulkan.</string>
+    <string name="settings_content_desc_box64">Tłumaczy kod Linuksa x86_64, aby działał na urządzeniach ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build Box64 używany przez WoW64 do uruchamiania 32-bitowych aplikacji Windows w 64-bitowym Wine.</string>
+    <string name="settings_content_desc_fexcore">Tłumaczy kod x86 i x86_64, aby działał na urządzeniach ARM64.</string>
     <string name="settings_content_unable_to_install">Nie można zainstalować zawartości.</string>
     <string name="settings_content_install_failed">Instalacja nie powiodła się</string>
     <string name="settings_content_file_cannot_be_recognized">Nie można rozpoznać pliku.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -752,7 +752,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Instalar Conteudo</string>
-    <string name="settings_content_type">Tipo de Conteudo</string>
+    <string name="settings_content_type">Categoria</string>
     <string name="settings_content_components">Componentes</string>
     <string name="settings_content_auto_create_container">Criar contêiner automaticamente</string>
     <string name="settings_content_remove_title">Remover componente?</string>
@@ -760,13 +760,13 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_content_container_created">Contêiner criado: %1$s</string>
     <string name="settings_content_download_failed">Falha no download.</string>
     <string name="common_ui_working">Processando…</string>
-    <string name="settings_content_desc_wine">A camada de compatibilidade do Windows usada para executar jogos e aplicativos. Você precisa de pelo menos uma versão do Wine ou FEXCore instalada.</string>
-    <string name="settings_content_desc_proton">Build da Valve baseada no Wine com patches extras para jogos. Útil para alguns títulos, mas o Wine padrão geralmente funciona bem.</string>
-    <string name="settings_content_desc_dxvk">Traduz DirectX 9, 10 e 11 para Vulkan. Geralmente melhora o desempenho em jogos antigos do Windows.</string>
-    <string name="settings_content_desc_vkd3d">Traduz DirectX 12 para Vulkan. Necessário para muitos jogos mais recentes do Windows.</string>
-    <string name="settings_content_desc_box64">Traduz código Windows x86 / x64 para que possa ser executado em dispositivos ARM. Box64 ou FEXCore é necessário para a maioria dos jogos.</string>
-    <string name="settings_content_desc_wowbox64">Uma build do Box64 para o modo Wine WoW64. Necessária apenas ao usar um prefixo de 64 bits com suporte a aplicativos de 32 bits.</string>
-    <string name="settings_content_desc_fexcore">Um tradutor x86 / x64 alternativo. Experimente se um jogo apresentar problemas ou desempenho ruim com o Box64.</string>
+    <string name="settings_content_desc_wine">Criado pelo projeto Wine; traduz chamadas Win32 para serviços nativos Linux/Android.</string>
+    <string name="settings_content_desc_proton">Criado pela Valve; runtime baseado no Wine com patches para jogos Windows.</string>
+    <string name="settings_content_desc_dxvk">Traduz chamadas gráficas Direct3D 9, 10 e 11 para Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Traduz chamadas gráficas Direct3D 12 para Vulkan.</string>
+    <string name="settings_content_desc_box64">Traduz código Linux x86_64 para execução em dispositivos ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build Box64 usado pelo WoW64 para executar apps Windows de 32 bits no Wine de 64 bits.</string>
+    <string name="settings_content_desc_fexcore">Traduz código x86 e x86_64 para execução em dispositivos ARM64.</string>
     <string name="settings_content_unable_to_install">Nao foi possivel instalar o conteudo.</string>
     <string name="settings_content_install_failed">Falha na Instalacao</string>
     <string name="settings_content_file_cannot_be_recognized">O arquivo nao pode ser reconhecido.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -752,7 +752,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Instaleaza continut</string>
-    <string name="settings_content_type">Tip continut</string>
+    <string name="settings_content_type">Categorie</string>
     <string name="settings_content_components">Componente</string>
     <string name="settings_content_auto_create_container">Creează container automat</string>
     <string name="settings_content_remove_title">Elimini componenta?</string>
@@ -760,13 +760,13 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_content_container_created">Container creat: %1$s</string>
     <string name="settings_content_download_failed">Descărcare eșuată.</string>
     <string name="common_ui_working">Se lucrează…</string>
-    <string name="settings_content_desc_wine">Stratul de compatibilitate Windows utilizat pentru a rula jocuri și aplicații. Ai nevoie de cel puțin o versiune Wine sau FEXCore instalată.</string>
-    <string name="settings_content_desc_proton">Build-ul Valve bazat pe Wine cu patch-uri suplimentare pentru jocuri. Util pentru unele titluri, dar Wine standard funcționează de obicei bine.</string>
-    <string name="settings_content_desc_dxvk">Traduce DirectX 9, 10 și 11 în Vulkan. De obicei îmbunătățește performanța în jocurile Windows mai vechi.</string>
-    <string name="settings_content_desc_vkd3d">Traduce DirectX 12 în Vulkan. Necesar pentru multe jocuri Windows mai noi.</string>
-    <string name="settings_content_desc_box64">Traduce codul Windows x86 / x64 astfel încât să poată rula pe dispozitive ARM. Box64 sau FEXCore este necesar pentru majoritatea jocurilor.</string>
-    <string name="settings_content_desc_wowbox64">O build Box64 pentru modul Wine WoW64. Necesară doar la utilizarea unui prefix pe 64 de biți cu suport pentru aplicații pe 32 de biți.</string>
-    <string name="settings_content_desc_fexcore">Un traducător x86 / x64 alternativ. Încearcă-l dacă un joc are probleme sau performanță slabă cu Box64.</string>
+    <string name="settings_content_desc_wine">Creat de proiectul Wine; traduce apelurile Win32 în servicii native Linux/Android.</string>
+    <string name="settings_content_desc_proton">Creat de Valve; runtime bazat pe Wine cu patch-uri pentru jocuri Windows.</string>
+    <string name="settings_content_desc_dxvk">Traduce apelurile grafice Direct3D 9, 10 și 11 în Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Traduce apelurile grafice Direct3D 12 în Vulkan.</string>
+    <string name="settings_content_desc_box64">Traduce cod Linux x86_64 pentru rulare pe dispozitive ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Build Box64 folosit de WoW64 pentru a rula aplicații Windows pe 32 de biți în Wine pe 64 de biți.</string>
+    <string name="settings_content_desc_fexcore">Traduce cod x86 și x86_64 pentru rulare pe dispozitive ARM64.</string>
     <string name="settings_content_unable_to_install">Nu se poate instala continutul.</string>
     <string name="settings_content_install_failed">Instalare esuata</string>
     <string name="settings_content_file_cannot_be_recognized">Fisierul nu poate fi recunoscut.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Встановити контент</string>
-    <string name="settings_content_type">Тип контенту</string>
+    <string name="settings_content_type">Категорія</string>
     <string name="settings_content_components">Компоненти</string>
     <string name="settings_content_auto_create_container">Автоматично створити контейнер</string>
     <string name="settings_content_remove_title">Видалити компонент?</string>
@@ -760,13 +760,13 @@
     <string name="settings_content_container_created">Створено контейнер: %1$s</string>
     <string name="settings_content_download_failed">Помилка завантаження.</string>
     <string name="common_ui_working">Зачекайте…</string>
-    <string name="settings_content_desc_wine">Рівень сумісності Windows для запуску ігор і застосунків. Потрібна принаймні одна встановлена версія Wine або FEXCore.</string>
-    <string name="settings_content_desc_proton">Збірка Valve на основі Wine з додатковими патчами для ігор. Корисна для деяких тайтлів, але стандартний Wine зазвичай працює добре.</string>
-    <string name="settings_content_desc_dxvk">Транслює DirectX 9, 10 та 11 у Vulkan. Зазвичай покращує продуктивність у старих іграх Windows.</string>
-    <string name="settings_content_desc_vkd3d">Транслює DirectX 12 у Vulkan. Потрібно для багатьох новіших ігор Windows.</string>
-    <string name="settings_content_desc_box64">Транслює код Windows x86 / x64 для роботи на пристроях ARM. Box64 або FEXCore потрібен для більшості ігор.</string>
-    <string name="settings_content_desc_wowbox64">Збірка Box64 для режиму Wine WoW64. Потрібна лише при використанні 64-бітного префіксу з підтримкою 32-бітних застосунків.</string>
-    <string name="settings_content_desc_fexcore">Альтернативний транслятор x86 / x64. Спробуйте, якщо гра має проблеми або низьку продуктивність з Box64.</string>
+    <string name="settings_content_desc_wine">Створено проєктом Wine; транслює виклики Win32 у нативні служби Linux/Android.</string>
+    <string name="settings_content_desc_proton">Створено Valve; runtime на основі Wine з патчами для Windows-ігор.</string>
+    <string name="settings_content_desc_dxvk">Транслює графічні виклики Direct3D 9, 10 та 11 у Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Транслює графічні виклики Direct3D 12 у Vulkan.</string>
+    <string name="settings_content_desc_box64">Транслює Linux-код x86_64 для запуску на пристроях ARM64.</string>
+    <string name="settings_content_desc_wowbox64">Збірка Box64, яку WoW64 використовує для запуску 32-бітних Windows-застосунків у 64-бітному Wine.</string>
+    <string name="settings_content_desc_fexcore">Транслює код x86 і x86_64 для запуску на пристроях ARM64.</string>
     <string name="settings_content_unable_to_install">Неможливо встановити контент.</string>
     <string name="settings_content_install_failed">Помилка встановлення</string>
     <string name="settings_content_file_cannot_be_recognized">Файл не розпізнано.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">安装内容</string>
-    <string name="settings_content_type">内容类型</string>
+    <string name="settings_content_type">类别</string>
     <string name="settings_content_components">组件</string>
     <string name="settings_content_auto_create_container">自动创建容器</string>
     <string name="settings_content_remove_title">移除组件？</string>
@@ -760,13 +760,13 @@
     <string name="settings_content_container_created">已创建容器：%1$s</string>
     <string name="settings_content_download_failed">下载失败。</string>
     <string name="common_ui_working">处理中…</string>
-    <string name="settings_content_desc_wine">用于运行游戏和应用的 Windows 兼容层。您至少需要安装一个 Wine 或 FEXCore 版本。</string>
-    <string name="settings_content_desc_proton">Valve 基于 Wine 的构建版本，带有针对游戏的额外补丁。对某些游戏有用，但标准 Wine 通常也能正常工作。</string>
-    <string name="settings_content_desc_dxvk">将 DirectX 9、10 和 11 转换为 Vulkan。通常可提升旧 Windows 游戏的性能。</string>
-    <string name="settings_content_desc_vkd3d">将 DirectX 12 转换为 Vulkan。许多较新的 Windows 游戏需要此组件。</string>
-    <string name="settings_content_desc_box64">转换 x86 / x64 Windows 代码，使其可在 ARM 设备上运行。大多数游戏都需要 Box64 或 FEXCore。</string>
-    <string name="settings_content_desc_wowbox64">用于 Wine WoW64 模式的 Box64 构建。仅在使用支持 32 位应用的 64 位前缀时需要。</string>
-    <string name="settings_content_desc_fexcore">备用的 x86 / x64 翻译器。如果游戏在 Box64 上出现问题或性能不佳，可以尝试使用。</string>
+    <string name="settings_content_desc_wine">由 Wine 项目制作；将 Win32 调用转换为原生 Linux/Android 服务。</string>
+    <string name="settings_content_desc_proton">由 Valve 制作；基于 Wine 的运行时，带有 Windows 游戏补丁。</string>
+    <string name="settings_content_desc_dxvk">将 Direct3D 9、10 和 11 图形调用转换为 Vulkan。</string>
+    <string name="settings_content_desc_vkd3d">将 Direct3D 12 图形调用转换为 Vulkan。</string>
+    <string name="settings_content_desc_box64">转换 x86_64 Linux 代码，使其可在 ARM64 设备上运行。</string>
+    <string name="settings_content_desc_wowbox64">WoW64 使用的 Box64 构建，用于在 64 位 Wine 中运行 32 位 Windows 应用。</string>
+    <string name="settings_content_desc_fexcore">转换 x86 和 x86_64 代码，使其可在 ARM64 设备上运行。</string>
     <string name="settings_content_unable_to_install">无法安装内容。</string>
     <string name="settings_content_install_failed">安装失败</string>
     <string name="settings_content_file_cannot_be_recognized">无法识别此文件。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -752,7 +752,7 @@
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">安裝內容</string>
-    <string name="settings_content_type">內容類型</string>
+    <string name="settings_content_type">類別</string>
     <string name="settings_content_components">元件</string>
     <string name="settings_content_auto_create_container">自動建立容器</string>
     <string name="settings_content_remove_title">移除元件？</string>
@@ -760,13 +760,13 @@
     <string name="settings_content_container_created">已建立容器：%1$s</string>
     <string name="settings_content_download_failed">下載失敗。</string>
     <string name="common_ui_working">處理中…</string>
-    <string name="settings_content_desc_wine">用於執行遊戲與應用的 Windows 相容層。您至少需要安裝一個 Wine 或 FEXCore 版本。</string>
-    <string name="settings_content_desc_proton">Valve 基於 Wine 的建置版本，附帶針對遊戲的額外修補程式。對某些遊戲有用，但標準 Wine 通常也能正常運作。</string>
-    <string name="settings_content_desc_dxvk">將 DirectX 9、10 與 11 轉譯為 Vulkan。通常可提升舊版 Windows 遊戲的效能。</string>
-    <string name="settings_content_desc_vkd3d">將 DirectX 12 轉譯為 Vulkan。許多較新的 Windows 遊戲需要此元件。</string>
-    <string name="settings_content_desc_box64">轉譯 x86 / x64 Windows 程式碼以便在 ARM 裝置上執行。大多數遊戲需要 Box64 或 FEXCore。</string>
-    <string name="settings_content_desc_wowbox64">用於 Wine WoW64 模式的 Box64 建置。僅在使用支援 32 位元應用程式的 64 位元前綴時需要。</string>
-    <string name="settings_content_desc_fexcore">替代的 x86 / x64 轉譯器。如果遊戲在 Box64 上出現問題或效能不佳，請嘗試使用。</string>
+    <string name="settings_content_desc_wine">由 Wine 專案製作；將 Win32 呼叫轉譯為原生 Linux/Android 服務。</string>
+    <string name="settings_content_desc_proton">由 Valve 製作；基於 Wine 的執行階段，包含 Windows 遊戲修補程式。</string>
+    <string name="settings_content_desc_dxvk">將 Direct3D 9、10 與 11 圖形呼叫轉譯為 Vulkan。</string>
+    <string name="settings_content_desc_vkd3d">將 Direct3D 12 圖形呼叫轉譯為 Vulkan。</string>
+    <string name="settings_content_desc_box64">轉譯 x86_64 Linux 程式碼，使其可在 ARM64 裝置上執行。</string>
+    <string name="settings_content_desc_wowbox64">WoW64 使用的 Box64 建置，用於在 64 位元 Wine 中執行 32 位元 Windows 應用程式。</string>
+    <string name="settings_content_desc_fexcore">轉譯 x86 與 x86_64 程式碼，使其可在 ARM64 裝置上執行。</string>
     <string name="settings_content_unable_to_install">無法安裝內容。</string>
     <string name="settings_content_install_failed">安裝失敗</string>
     <string name="settings_content_file_cannot_be_recognized">無法識別檔案。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,7 +804,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
 
     <!-- Settings > Content Packages -->
     <string name="settings_content_install">Install Content</string>
-    <string name="settings_content_type">Content Type</string>
+    <string name="settings_content_type">Category</string>
     <string name="settings_content_components">Components</string>
     <string name="settings_content_auto_create_container">Auto-create container</string>
     <string name="settings_content_remove_title">Remove component?</string>
@@ -812,13 +812,13 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_content_container_created">Created container: %1$s</string>
     <string name="settings_content_download_failed">Download failed.</string>
     <string name="common_ui_working">Working…</string>
-    <string name="settings_content_desc_wine">The Windows compatibility layer used to run games and apps. You need at least one Wine or FEXCore version installed.</string>
-    <string name="settings_content_desc_proton">Valve\'s Wine-based build with extra patches for games. Useful for some titles, but standard Wine usually works fine.</string>
-    <string name="settings_content_desc_dxvk">Translates DirectX 9, 10, and 11 to Vulkan. This usually improves performance in older Windows games.</string>
-    <string name="settings_content_desc_vkd3d">Translates DirectX 12 to Vulkan. Needed for many newer Windows games.</string>
-    <string name="settings_content_desc_box64">Translates x86 / x64 Windows code so it can run on ARM devices. Box64 or FEXCore is required for most games.</string>
-    <string name="settings_content_desc_wowbox64">A Box64 build for Wine WoW64 mode. Only needed when using a 64-bit prefix with 32-bit app support.</string>
-    <string name="settings_content_desc_fexcore">An alternative x86 / x64 translator. Try it if a game has issues or poor performance with Box64.</string>
+    <string name="settings_content_desc_wine">Made by the Wine project; translates Win32 calls to native Linux/Android services.</string>
+    <string name="settings_content_desc_proton">Made by Valve; a Wine-based runtime with game patches for Windows games.</string>
+    <string name="settings_content_desc_dxvk">Translates Direct3D 9, 10, and 11 graphics calls to Vulkan.</string>
+    <string name="settings_content_desc_vkd3d">Translates Direct3D 12 graphics calls to Vulkan.</string>
+    <string name="settings_content_desc_box64">Translates x86_64 Linux code so it can run on ARM64 devices.</string>
+    <string name="settings_content_desc_wowbox64">Box64 build used by WoW64 to run 32-bit Windows apps inside 64-bit Wine.</string>
+    <string name="settings_content_desc_fexcore">Translates x86 and x86_64 code so it can run on ARM64 devices.</string>
     <string name="settings_content_unable_to_install">Unable to install content.</string>
     <string name="settings_content_install_failed">Install Failed</string>
     <string name="settings_content_file_cannot_be_recognized">File cannot be recognized.</string>


### PR DESCRIPTION
- Combined the Components and Category cards into one settings card.
- Moved Auto-create container and Install Content controls to the top row.
- Removed the redundant Components icon/title block.
- Updated category descriptions in default and localized strings to explain what each component translates or runs.