### PR TITLE
Fix shortcut upgrade refresh logic

### DIFF
--- a/app/src/main/runtime/container/ContainerManager.java
+++ b/app/src/main/runtime/container/ContainerManager.java
@@ -371,7 +371,6 @@ public class ContainerManager {
   }
 
   public void upgradeShortcuts(final Runnable onDone) {
-    if (!shortcutUpgradeAttempted.compareAndSet(false, true)) return;
     if (!shortcutUpgradeRunning.compareAndSet(false, true)) return;
 
     new Thread(() -> {


### PR DESCRIPTION
Removed shortcutUpgradeAttempted flag to allow refresh on return to library, while preserving shortcutUpgradeRunning for concurrency protection against looping.
Fixes shortcuts created inside container from having to exit app for them to work. 