### PR TITLE
feat(shortcuts): add per-game FPS limiter setting

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -155,6 +155,7 @@ class GameSettingsStateHolder {
     val listArtworkSummary = mutableStateOf("")
     val refreshRateEntries = mutableStateOf<List<String>>(emptyList())
     val selectedRefreshRate = mutableIntStateOf(0)
+    val fpsLimit = mutableIntStateOf(0)
 
     // Display
     val graphicsDriverEntries = mutableStateOf<List<String>>(emptyList())
@@ -1183,6 +1184,51 @@ private fun GeneralSection(
             selectedIndex = state.selectedMidiSoundFont.intValue,
             onSelected = { state.selectedMidiSoundFont.intValue = it }
         )
+    }
+
+    if (!isContainer) {
+        Spacer(Modifier.height(16.dp))
+        SettingGroup {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "FPS Limiter",
+                    color = TextPrimary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                val limits = listOf(0, 30, 45, 60, 90, 120)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    limits.forEach { limit ->
+                        val isChecked = state.fpsLimit.intValue == limit
+                        val bgColor = if (isChecked) AccentBlue.copy(alpha = 0.15f) else ChipSurface
+                        val borderColor = if (isChecked) AccentBlue.copy(alpha = 0.4f) else ChipBorder
+                        val textColor = if (isChecked) AccentBlue else TextDim
+
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(bgColor)
+                                .border(1.dp, borderColor, RoundedCornerShape(8.dp))
+                                .clickable { state.fpsLimit.intValue = limit }
+                                .padding(horizontal = 14.dp, vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                if (limit == 0) "None" else "$limit",
+                                color = textColor,
+                                fontSize = 12.sp,
+                                fontWeight = if (isChecked) FontWeight.SemiBold else FontWeight.Normal
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -451,6 +451,10 @@ class ShortcutSettingsComposeDialog private constructor(
             Log.e(TAG, "Error loading refresh rate entries", e)
         }
 
+        // FPS Limit
+        val savedFpsLimit = shortcut.getExtra("fpsLimit", "0")
+        state.fpsLimit.intValue = savedFpsLimit.toIntOrNull() ?: 0
+
         // Graphics driver (basic entries - will be updated after contents sync)
         val graphicsDriverArr =
             context.resources.getStringArray(R.array.graphics_driver_entries).toList()
@@ -1170,6 +1174,10 @@ class ShortcutSettingsComposeDialog private constructor(
                     shortcut.putExtra("refreshRate", selectedRate.toString())
                 }
             }
+
+            // FPS Limit
+            val fpsLimit = state.fpsLimit.intValue
+            shortcut.putExtra("fpsLimit", if (fpsLimit > 0) fpsLimit.toString() else null)
 
             // Desktop Theme — stored as compound "THEME,TYPE,COLOR" string
             if (state.desktopThemeEntries.value.isNotEmpty()) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2902,6 +2902,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                             xServerView.getRenderer().setFpsLimit(runtimeFpsLimit);
                         }
                         applyPreferredRefreshRate();
+                        if (shortcut != null) {
+                            shortcut.putExtra("fpsLimit", runtimeFpsLimit > 0 ? String.valueOf(runtimeFpsLimit) : null);
+                            shortcut.saveData();
+                        }
                         renderDrawerMenu();
                     }
                 };
@@ -3748,6 +3752,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         if (shortcut != null) {
             renderer.setUnviewableWMClasses("explorer.exe");
+            String savedFpsLimit = shortcut.getExtra("fpsLimit", "0");
+            try {
+                runtimeFpsLimit = Integer.parseInt(savedFpsLimit);
+                renderer.setFpsLimit(runtimeFpsLimit);
+            } catch (NumberFormatException e) {
+                runtimeFpsLimit = 0;
+            }
         }
 
         xServer.setRenderer(renderer);


### PR DESCRIPTION
- Added FPS Limiter chips to the General tab of Shortcut Settings.
- Loaded and saved the fpsLimit property in ShortcutSettingsComposeDialog.
- Applied the saved fpsLimit to the renderer on startup in XServerDisplayActivity.
- Updated XServerDisplayActivity to save the modified FPS limit to the shortcut when adjusted in-game via the side menu.