### PR TITLE
fix(cpu): ensure correct CPU affinity for 32-bit apps and new containers

### DIFF
--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -322,8 +322,8 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
 
         val cpuCount = Runtime.getRuntime().availableProcessors()
         state.cpuCount.intValue = cpuCount
-        state.cpuChecked.value = parseCpuList(c?.getCPUList(true) ?: "", cpuCount)
-        state.cpuCheckedWoW64.value = parseCpuList(c?.getCPUListWoW64(true) ?: "", cpuCount)
+        state.cpuChecked.value = parseCpuList(c?.getCPUList(true) ?: Container.getFallbackCPUList(), cpuCount)
+        state.cpuCheckedWoW64.value = parseCpuList(c?.getCPUListWoW64(true) ?: Container.getFallbackCPUListWoW64(), cpuCount)
 
         val wincomponentsStr = c?.getWinComponents() ?: Container.DEFAULT_WINCOMPONENTS
         val directX = mutableListOf<WinComponentItem>()

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -1070,6 +1070,8 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
             )
 
         container.setGraphicsDriver(Container.DEFAULT_GRAPHICS_DRIVER)
+        container.setCPUList(Container.getFallbackCPUList())
+        container.setCPUListWoW64(Container.getFallbackCPUListWoW64())
         container.setDrives(normalizedDrives)
         container.setGraphicsDriverConfig(
             replaceDelimitedConfigValue(

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -267,8 +267,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private float globalCursorSpeed = 1.0f;
     private MagnifierView magnifierView;
     private DebugDialog debugDialog;
-    private short taskAffinityMask = 0;
-    private short taskAffinityMaskWoW64 = 0;
+    private int taskAffinityMask = 0;
+    private int taskAffinityMaskWoW64 = 0;
     private int frameRatingWindowId = -1;
     private boolean cursorLock; // Flag to track if pointer capture was requested
     private final float[] xform = XForm.getInstance();
@@ -810,8 +810,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         String containerCpuListWoW64 = container.getCPUListWoW64(true);
         String effectiveCpuList = containerCpuList;
         String effectiveCpuListWoW64 = containerCpuListWoW64;
-        taskAffinityMask = (short) ProcessHelper.getAffinityMask(containerCpuList);
-        taskAffinityMaskWoW64 = (short) ProcessHelper.getAffinityMask(containerCpuListWoW64);
+        taskAffinityMask = ProcessHelper.getAffinityMask(containerCpuList);
+        taskAffinityMaskWoW64 = ProcessHelper.getAffinityMask(containerCpuListWoW64);
 
         String rawShortcutCpuList = "";
         String rawShortcutCpuListWoW64 = "";
@@ -821,8 +821,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             rawShortcutCpuListWoW64 = cpuShortcutUsesDefaults ? "" : shortcut.getExtra("cpuListWoW64");
             effectiveCpuList = getShortcutSetting("cpuList", containerCpuList);
             effectiveCpuListWoW64 = getShortcutSetting("cpuListWoW64", containerCpuListWoW64);
-            taskAffinityMask = (short) ProcessHelper.getAffinityMask(effectiveCpuList);
-            taskAffinityMaskWoW64 = (short) ProcessHelper.getAffinityMask(effectiveCpuListWoW64);
+            taskAffinityMask = ProcessHelper.getAffinityMask(effectiveCpuList);
+            taskAffinityMaskWoW64 = ProcessHelper.getAffinityMask(effectiveCpuListWoW64);
         }
         Log.d("XServerDisplayActivity", "CPUList source=shortcutOrContainer shortcutRaw='" +
                 rawShortcutCpuList + "' container='" + containerCpuList +
@@ -7375,10 +7375,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     }
 
     private void assignTaskAffinity(Window window) {
-        if (taskAffinityMask == 0 || taskAffinityMaskWoW64 == 0) return;
+        if (taskAffinityMask == 0 && taskAffinityMaskWoW64 == 0) return;
         int processId = window.getProcessId();
         String className = window.getClassName();
         int processAffinity = window.isWoW64() ? taskAffinityMaskWoW64 : taskAffinityMask;
+
+        if (processAffinity == 0) return;
 
         if (processId > 0) {
             winHandler.setProcessAffinity(processId, processAffinity);

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -919,6 +919,14 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     envVars.put("BOX64_NORCFILES", "1");
     ImageFs imageFs = ImageFs.find(environment.getContext());
     envVars.put("BOX64_RCFILE", imageFs.getRootDir().getPath() + "/etc/config.box64rc");
+
+    if (container != null) {
+      String cpuList = container.getCPUList(true);
+      if (cpuList != null && !cpuList.isEmpty()) {
+        envVars.put("BOX64_CPULIST", cpuList);
+        envVars.put("BOX86_CPULIST", cpuList);
+      }
+    }
   }
 
   private void repairRuntimeExecutablePermissions(Context context, ImageFs imageFs) {


### PR DESCRIPTION
- Fix UI default for new containers to use correct fallback CPU lists.
- Explicitly set CPU lists in SetupWizardActivity.
- Use int instead of short for affinity masks to avoid truncation.
- Add BOX64_CPULIST and BOX86_CPULIST to ensure early affinity enforcement.