### PR TITLE
Keep wine session and component installs alive across screen lock

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,18 @@
             </intent-filter>
         </receiver>
 
+        <!-- Keeps the app process alive while a wine session is paused in the
+             background or while a component download/install is in flight, so
+             screen lock does not kill the container or interrupt the install.
+             stopWithTask=false lets us see onTaskRemoved on user swipe-away,
+             which is the only path that should tear the session down. -->
+        <service
+            android:name="com.winlator.cmod.runtime.system.SessionKeepAliveService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:stopWithTask="false" />
+
         <service
             android:name="com.winlator.cmod.feature.stores.steam.service.SteamService"
             android:enabled="true"

--- a/app/src/main/feature/settings/contents/ContentsFragment.kt
+++ b/app/src/main/feature/settings/contents/ContentsFragment.kt
@@ -510,14 +510,25 @@ class ContentsFragment : Fragment() {
                 )
             }
 
+        // Hold the keep-alive across the extraction/install so screen lock
+        // doesn't kill the process mid-extract. The callback above can chain
+        // into finishInstallContent() asynchronously; we release after the
+        // install pipeline finishes (success, failure, or terminal callback).
+        val installKeepAliveTag = "components_install_${uri}_${System.currentTimeMillis()}"
+        val appCtx = requireContext().applicationContext
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(appCtx, installKeepAliveTag)
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            runCatching { manager.extraContentFile(uri, callback, extractionProgress) }
-                .onFailure {
-                    runOnMain {
-                        clearDownloadProgress()
-                        AppUtils.showToast(requireContext(), R.string.input_controls_editor_unable_to_import)
+            try {
+                runCatching { manager.extraContentFile(uri, callback, extractionProgress) }
+                    .onFailure {
+                        runOnMain {
+                            clearDownloadProgress()
+                            AppUtils.showToast(requireContext(), R.string.input_controls_editor_unable_to_import)
+                        }
                     }
-                }
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(appCtx, installKeepAliveTag)
+            }
         }
     }
 
@@ -543,6 +554,12 @@ class ContentsFragment : Fragment() {
             indeterminate = true,
         )
 
+        // Keep the app process alive while the download/install runs so screen
+        // lock doesn't tear it down. installSelectedContent() owns its own
+        // keep-alive scope; this one covers the download step alone.
+        val keepAliveTag = "components_download_${remoteUrl}"
+        val appCtx = requireContext().applicationContext
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(appCtx, keepAliveTag)
         viewLifecycleOwner.lifecycleScope.launch {
             val output = File(requireContext().cacheDir, "temp_${System.currentTimeMillis()}")
             val success =
@@ -567,26 +584,30 @@ class ContentsFragment : Fragment() {
                     }
                 }
 
-            if (!isAdded || view == null) {
-                output.delete()
-                clearDownloadProgress()
-                return@launch
-            }
+            try {
+                if (!isAdded || view == null) {
+                    output.delete()
+                    clearDownloadProgress()
+                    return@launch
+                }
 
-            if (success) {
-                updateDownloadProgress(
-                    title = getString(R.string.settings_content_extracting_title),
-                    message = profile.verName,
-                    indeterminate = true,
-                )
-                installSelectedContent(
-                    Uri.parse(output.absolutePath),
-                    getString(R.string.settings_content_download_complete),
-                    remoteUrl,
-                )
-            } else if (isAdded) {
-                clearDownloadProgress()
-                AppUtils.showToast(requireContext(), R.string.settings_content_download_failed)
+                if (success) {
+                    updateDownloadProgress(
+                        title = getString(R.string.settings_content_extracting_title),
+                        message = profile.verName,
+                        indeterminate = true,
+                    )
+                    installSelectedContent(
+                        Uri.parse(output.absolutePath),
+                        getString(R.string.settings_content_download_complete),
+                        remoteUrl,
+                    )
+                } else if (isAdded) {
+                    clearDownloadProgress()
+                    AppUtils.showToast(requireContext(), R.string.settings_content_download_failed)
+                }
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(appCtx, keepAliveTag)
             }
         }
     }

--- a/app/src/main/feature/settings/drivers/DriversFragment.kt
+++ b/app/src/main/feature/settings/drivers/DriversFragment.kt
@@ -440,6 +440,11 @@ class DriversFragment : Fragment() {
             )
         publishState()
 
+        // Hold the app process alive across this download so screen lock can't
+        // interrupt it. installDriverPackage owns its own keep-alive scope.
+        val keepAliveTag = "drivers_download_${asset.downloadUrl}"
+        val appCtx = requireContext().applicationContext
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(appCtx, keepAliveTag)
         viewLifecycleOwner.lifecycleScope.launch {
             val output = File(requireContext().cacheDir, "driver_${System.currentTimeMillis()}.zip")
             val success =
@@ -469,24 +474,28 @@ class DriversFragment : Fragment() {
                     }
                 }
 
-            if (!isAdded || view == null) {
-                output.delete()
-                clearDownloadProgress()
-                return@launch
-            }
+            try {
+                if (!isAdded || view == null) {
+                    output.delete()
+                    clearDownloadProgress()
+                    return@launch
+                }
 
-            if (!success) {
-                output.delete()
-                clearDownloadProgress()
-                AppUtils.showToast(requireContext(), R.string.settings_drivers_repo_download_failed)
-                return@launch
-            }
+                if (!success) {
+                    output.delete()
+                    clearDownloadProgress()
+                    AppUtils.showToast(requireContext(), R.string.settings_drivers_repo_download_failed)
+                    return@launch
+                }
 
-            installDriverPackage(
-                uri = Uri.fromFile(output),
-                sourceAssetName = asset.name,
-                onComplete = { output.delete() },
-            )
+                installDriverPackage(
+                    uri = Uri.fromFile(output),
+                    sourceAssetName = asset.name,
+                    onComplete = { output.delete() },
+                )
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(appCtx, keepAliveTag)
+            }
         }
     }
 
@@ -505,31 +514,40 @@ class DriversFragment : Fragment() {
             ),
         )
 
+        // Keep the process alive across the install (driver extraction +
+        // move). Released after the lifecycleScope coroutine finishes.
+        val installKeepAliveTag = "drivers_install_${sourceAssetName ?: uri}"
+        val appCtx = requireContext().applicationContext
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(appCtx, installKeepAliveTag)
         viewLifecycleOwner.lifecycleScope.launch {
-            val installedDriverId =
-                withContext(Dispatchers.IO) {
-                    runCatching {
-                        adrenotoolsManager.installDriver(uri, sourceAssetName)
-                    }.getOrDefault("")
+            try {
+                val installedDriverId =
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            adrenotoolsManager.installDriver(uri, sourceAssetName)
+                        }.getOrDefault("")
+                    }
+
+                if (!isAdded || view == null) {
+                    clearDownloadProgress()
+                    onComplete?.invoke()
+                    return@launch
                 }
 
-            if (!isAdded || view == null) {
                 clearDownloadProgress()
                 onComplete?.invoke()
-                return@launch
+
+                if (installedDriverId.isBlank()) {
+                    AppUtils.showToast(requireContext(), R.string.settings_drivers_install_failed)
+                    return@launch
+                }
+
+                SetupWizardActivity.recordInstalledDriver(requireContext(), installedDriverId)
+                refreshInstalledDrivers()
+                publishState()
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(appCtx, installKeepAliveTag)
             }
-
-            clearDownloadProgress()
-            onComplete?.invoke()
-
-            if (installedDriverId.isBlank()) {
-                AppUtils.showToast(requireContext(), R.string.settings_drivers_install_failed)
-                return@launch
-            }
-
-            SetupWizardActivity.recordInstalledDriver(requireContext(), installedDriverId)
-            refreshInstalledDrivers()
-            publishState()
         }
     }
 

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -694,6 +694,11 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
         val imageFs = ImageFs.find(this)
         val rootDir = imageFs.rootDir
 
+        // Keep the process alive while the imagefs extraction runs; the user
+        // can lock the screen during this multi-minute step without losing it.
+        val keepAliveTag = "imagefs_install"
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(this, keepAliveTag)
+
         Executors.newSingleThreadExecutor().execute {
             try {
                 clearRootDir(rootDir)
@@ -779,6 +784,11 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                     imageFsInstalling.value = false
                     wizardError.value = "ImageFS install failed: ${e.message}"
                 }
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(
+                    applicationContext,
+                    keepAliveTag,
+                )
             }
         }
     }
@@ -1283,8 +1293,11 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                 .filter { isRecommendedSpec(it) && it.verName !in advancedInstalledSet }
         if (pending.isEmpty()) return
 
+        val keepAliveTag = "install_recommended_${System.currentTimeMillis()}"
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(this, keepAliveTag)
         lifecycleScope.launch {
             wizardError.value = null
+            try {
             for ((index, spec) in pending.withIndex()) {
                 val profile =
                     withContext(Dispatchers.IO) {
@@ -1344,11 +1357,19 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
             transferState.value = null
             refreshAdvancedInstalledSet()
             refreshWizardState()
+            } finally {
+                com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(
+                    applicationContext,
+                    keepAliveTag,
+                )
+            }
         }
     }
 
     private fun installAdvancedComponent(spec: RemotePackageSpec) {
         if (transferState.value != null) return
+        val keepAliveTag = "install_advanced_${spec.remoteUrl}"
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startDownload(this, keepAliveTag)
         lifecycleScope.launch {
             wizardError.value = null
             val profile =
@@ -1408,6 +1429,10 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                 refreshAdvancedInstalledSet()
                 refreshWizardState()
             }
+            com.winlator.cmod.runtime.system.SessionKeepAliveService.stopDownload(
+                applicationContext,
+                keepAliveTag,
+            )
         }
     }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -333,6 +333,15 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private final AtomicBoolean activityDestroyed = new AtomicBoolean(false);
     private final AtomicBoolean sessionCleanupStarted = new AtomicBoolean(false);
     private final AtomicBoolean switchLaunchInProgress = new AtomicBoolean(false);
+    // True while the activity is in the background (between onPause and onResume).
+    // Used to defer exit() requests that arrive while the user can't see the screen
+    // — e.g. the wine launcher's waitFor returning during a long screen-lock window
+    // when the OS reaped a transient launcher process. We re-evaluate on resume.
+    private final AtomicBoolean activityBackgrounded = new AtomicBoolean(false);
+    // Holds an exit reason captured while the activity was backgrounded.
+    // Cleared on resume after deciding whether to honor it.
+    private final java.util.concurrent.atomic.AtomicReference<String> pendingBackgroundedExit =
+            new java.util.concurrent.atomic.AtomicReference<>(null);
 
     private boolean isDarkMode;
     private boolean enableLogsMenu;
@@ -1625,6 +1634,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
+        activityBackgrounded.set(false);
         applyPreferredRefreshRate();
         boolean gyroEnabled = preferences.getBoolean("gyro_enabled", false);
 
@@ -1638,6 +1648,26 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         if (!cleaningUp && environment != null) {
             xServerView.onResume();
             environment.onResume();
+        }
+
+        // If an async exit was deferred while we were backgrounded (launcher
+        // waitFor returned during screen lock, or steam exit watch decided to
+        // drain), reconcile it now that we can see the real process state.
+        // If wine session processes are still alive the trigger was spurious
+        // and we leave the session intact; otherwise honor the original exit.
+        String deferred = pendingBackgroundedExit.getAndSet(null);
+        if (deferred != null && !cleaningUp) {
+            ArrayList<String> alive = ProcessHelper.listRunningWineProcesses();
+            if (alive.isEmpty()) {
+                Log.i("XServerDisplayActivity",
+                        "Honoring deferred exit (" + deferred + "); no wine processes remain on resume");
+                exit();
+                return;
+            }
+            Log.w("XServerDisplayActivity",
+                    "Dropping spurious background exit (" + deferred + "); "
+                            + alive.size() + " wine process(es) still alive: "
+                            + ProcessHelper.listRunningWineProcessDetails());
         }
         if (inputControlsView != null && touchpadView != null) {
             ControlsProfile activeProfile = inputControlsView.getProfile();
@@ -1655,6 +1685,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     @Override
     public void onPause() {
         super.onPause();
+        activityBackgrounded.set(true);
         boolean gyroEnabled = preferences.getBoolean("gyro_enabled", false);
 
         if (gyroEnabled) {
@@ -1896,6 +1927,20 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         runOnUiThread(() -> {
             if (activityDestroyed.get() || isFinishing() || isDestroyed()) {
                 Log.d("XServerDisplayActivity", "Skipping exit request after teardown: " + reason);
+                return;
+            }
+            // Defer if the user can't see the screen. The steam exit watch
+            // polls via WinHandler IPC, which times out while wine processes
+            // are SIGSTOP'd by onPause — that can be misread as "drained" and
+            // fire a false-positive exit. The resume-side reconciliation in
+            // onResume() rechecks via /proc and drops spurious triggers.
+            if (activityBackgrounded.get()
+                    && !exitRequested.get()
+                    && !sessionCleanupStarted.get()) {
+                if (pendingBackgroundedExit.compareAndSet(null, reason)) {
+                    Log.w("XServerDisplayActivity",
+                            "Deferring exit until resume — " + reason);
+                }
                 return;
             }
             exit();
@@ -3797,6 +3842,25 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             // Removed MoveSteamExe cleanup hook from termination callback.
 
             if (shouldWatchSteamTermination(status)) {
+                return;
+            }
+
+            // The activity may be backgrounded (screen locked, app minimized).
+            // If so, defer the exit until onResume can re-check whether the
+            // wine session truly ended. Locking the phone shouldn't tear the
+            // container down; if the launcher waitFor returned spuriously
+            // (e.g. because the OS reaped a transient outer process while
+            // wine itself was still alive), the resume-side reconciliation
+            // will see live processes and keep the session running.
+            if (activityBackgrounded.get()
+                    && !exitRequested.get()
+                    && !sessionCleanupStarted.get()
+                    && !activityDestroyed.get()) {
+                String reason = "guest launcher terminated (status=" + status + ") while backgrounded";
+                if (pendingBackgroundedExit.compareAndSet(null, reason)) {
+                    Log.w("XServerDisplayActivity",
+                            "Deferring exit until resume — " + reason);
+                }
                 return;
             }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1646,8 +1646,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         boolean cleaningUp = exitRequested.get() || sessionCleanupStarted.get() || activityDestroyed.get();
 
         if (!cleaningUp && environment != null) {
+            // Resume GL rendering for the foreground X surface. We intentionally
+            // do NOT auto-resume wine processes here: we no longer auto-pause
+            // them on background, so there is nothing to flip back. The drawer
+            // "Pause all Wine processes" toggle remains the user-controlled
+            // path for explicit suspend/resume.
             xServerView.onResume();
-            environment.onResume();
         }
 
         // If an async exit was deferred while we were backgrounded (launcher
@@ -1677,9 +1681,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
         startTime = System.currentTimeMillis();
         handler.postDelayed(savePlaytimeRunnable, SAVE_INTERVAL_MS);
-        if (!cleaningUp) {
-            ProcessHelper.resumeAllWineProcesses();
-        }
     }
 
     @Override
@@ -1697,9 +1698,15 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         boolean cleaningUp = exitRequested.get() || sessionCleanupStarted.get() || activityDestroyed.get();
 
         if (!cleaningUp && !isInPictureInPictureMode()) {
-            // Only pause environment and xServerView if not in PiP mode
+            // Pause GL rendering only — do NOT SIGSTOP wine on backgrounding.
+            // Auto-stopping wine across long screen-locked windows let the OS
+            // reap the suspended children (OOM killer prefers stopped procs,
+            // and the freezer can target them), which manifested as the
+            // container closing on unlock. Leaving wine running and trusting
+            // the keep-alive foreground service keeps the container intact.
+            // The drawer "Pause all Wine processes" toggle is still available
+            // for the user to manually suspend the session for battery.
             if (environment != null) {
-                environment.onPause();
                 xServerView.onPause();
             }
         }
@@ -1713,9 +1720,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         savePlaytimeData();
         handler.removeCallbacks(savePlaytimeRunnable);
-        if (!cleaningUp) {
-            ProcessHelper.pauseAllWineProcesses();
-        }
     }
 
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -529,6 +529,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         super.onCreate(savedInstanceState);
         AppUtils.hideSystemUI(this);
         AppUtils.keepScreenOn(this);
+        // Promote the app to a foreground service so the OS does not reap our
+        // process while the screen is locked or the activity is backgrounded.
+        // Without this, locking the phone while wine processes are paused can
+        // tear down the whole container. The service stops on session exit.
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.startGameSession(this);
         // Clean up any shared debug logs and prepare for fresh session logging
         DebugFragment.Companion.cleanupSharedLogs();
         com.winlator.cmod.runtime.system.LogManager.prepareForNewSession(this);
@@ -2063,6 +2068,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
         Log.d("XServerLeakCheck", "Forced cleanup final process snapshot: "
                 + ProcessHelper.listRunningWineProcessDetails());
+        com.winlator.cmod.runtime.system.SessionKeepAliveService.stopGameSession(getApplicationContext());
     }
 
     private void exit() {
@@ -2118,6 +2124,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     xServer = null;
                     xServerView = null;
                     if (preloaderDialog != null && preloaderDialog.isShowing()) preloaderDialog.closeOnUiThread();
+                    com.winlator.cmod.runtime.system.SessionKeepAliveService.stopGameSession(getApplicationContext());
                     closeAfterSessionExit();
                 }
             }, 1000);

--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -93,6 +93,25 @@ public abstract class ProcessHelper {
     if (PRINT_DEBUG) Log.d("ProcessHelper", "Process resumed with pid: " + pid);
   }
 
+  /**
+   * Best-effort write of /proc/[pid]/oom_score_adj for one of our own
+   * children. SIGSTOP'd processes are otherwise prime OOM-kill targets during
+   * long screen-locked windows; this lowers their kill priority so the OS
+   * leaves a manually-paused wine session alone over multi-minute windows.
+   * Silently ignored if the file is not writable on this device.
+   */
+  public static void setOomScoreAdj(int pid, int score) {
+    if (pid <= 0) return;
+    java.io.File f = new java.io.File("/proc/" + pid + "/oom_score_adj");
+    try (java.io.FileWriter w = new java.io.FileWriter(f, false)) {
+      w.write(Integer.toString(score));
+    } catch (Throwable t) {
+      // Some Android versions deny writes even for our own children. Don't
+      // spam logs — fall back silently and rely on the foreground service.
+      if (PRINT_DEBUG) Log.d(TAG, "oom_score_adj write skipped for pid " + pid + ": " + t);
+    }
+  }
+
   public static void terminateProcess(int pid) {
     Process.sendSignal(pid, SIGTERM);
     if (PRINT_DEBUG) Log.d("ProcessHelper", "Process terminated with pid: " + pid);
@@ -165,11 +184,23 @@ public abstract class ProcessHelper {
     return finalRemaining;
   }
 
+  // Aggressive OOM protection for paused wine processes. -1000 marks the
+  // process as oom_score_adj OOM_SCORE_ADJ_MIN, telling the kernel never to
+  // kill it on memory pressure. We restore to 0 (default) on resume so a
+  // running wine process is back to normal priority.
+  private static final int OOM_SCORE_ADJ_PROTECT = -1000;
+  private static final int OOM_SCORE_ADJ_DEFAULT = 0;
+
   public static void pauseAllWineProcesses() {
     ArrayList<String> processes = listRunningWineProcesses();
     if (!processes.isEmpty()) Log.d(TAG, "Pausing session processes: " + processes);
     for (String process : processes) {
-      suspendProcess(Integer.parseInt(process));
+      int pid = Integer.parseInt(process);
+      // Make the OS never OOM-kill the paused process. Without this, the
+      // kernel happily reaps SIGSTOP'd processes during long screen-locked
+      // windows because they look idle and unreclaimable.
+      setOomScoreAdj(pid, OOM_SCORE_ADJ_PROTECT);
+      suspendProcess(pid);
     }
   }
 
@@ -177,7 +208,9 @@ public abstract class ProcessHelper {
     ArrayList<String> processes = listRunningWineProcesses();
     if (!processes.isEmpty()) Log.d(TAG, "Resuming session processes: " + processes);
     for (String process : processes) {
-      resumeProcess(Integer.parseInt(process));
+      int pid = Integer.parseInt(process);
+      resumeProcess(pid);
+      setOomScoreAdj(pid, OOM_SCORE_ADJ_DEFAULT);
     }
   }
 

--- a/app/src/main/runtime/system/SessionKeepAliveService.java
+++ b/app/src/main/runtime/system/SessionKeepAliveService.java
@@ -1,0 +1,262 @@
+package com.winlator.cmod.runtime.system;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import com.winlator.cmod.R;
+import com.winlator.cmod.app.shell.UnifiedActivity;
+
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Foreground service that keeps the WinNative process alive while a wine
+ * session is in the background or while a component download/install is
+ * running. Without it, Android can reap the app process when the screen is
+ * locked, taking the wine container (and any in-flight download) with it.
+ *
+ * Reasons are reference-counted via static helpers. The service stops itself
+ * once no reasons remain. On task removal (user swipe-away) it does a
+ * defensive wine cleanup and lets the process exit, matching the previous
+ * "swipe = close" behaviour.
+ */
+public class SessionKeepAliveService extends Service {
+    private static final String TAG = "SessionKeepAlive";
+
+    private static final String CHANNEL_ID = "winnative_session_keepalive";
+    private static final int NOTIFICATION_ID = 0xC0DE;
+
+    private static final String ACTION_GAME_START = "com.winlator.cmod.action.SESSION_GAME_START";
+    private static final String ACTION_GAME_STOP = "com.winlator.cmod.action.SESSION_GAME_STOP";
+    private static final String ACTION_DL_START = "com.winlator.cmod.action.SESSION_DL_START";
+    private static final String ACTION_DL_STOP = "com.winlator.cmod.action.SESSION_DL_STOP";
+    private static final String ACTION_REFRESH = "com.winlator.cmod.action.SESSION_REFRESH";
+
+    private static final String EXTRA_TAG = "tag";
+
+    private static final AtomicBoolean gameActive = new AtomicBoolean(false);
+    private static final HashSet<String> activeDownloads = new HashSet<>();
+    private static final AtomicBoolean serviceRunning = new AtomicBoolean(false);
+
+    public static void startGameSession(Context ctx) {
+        if (ctx == null) return;
+        if (gameActive.compareAndSet(false, true)) {
+            sendCommand(ctx, ACTION_GAME_START, null);
+        }
+    }
+
+    public static void stopGameSession(Context ctx) {
+        if (ctx == null) return;
+        if (gameActive.compareAndSet(true, false)) {
+            sendCommand(ctx, ACTION_GAME_STOP, null);
+        }
+    }
+
+    public static void startDownload(Context ctx, String tag) {
+        if (ctx == null) return;
+        String key = tag == null ? "default" : tag;
+        boolean added;
+        synchronized (activeDownloads) {
+            added = activeDownloads.add(key);
+        }
+        if (added) {
+            sendCommand(ctx, ACTION_DL_START, key);
+        }
+    }
+
+    public static void stopDownload(Context ctx, String tag) {
+        if (ctx == null) return;
+        String key = tag == null ? "default" : tag;
+        boolean removed;
+        synchronized (activeDownloads) {
+            removed = activeDownloads.remove(key);
+        }
+        if (removed) {
+            sendCommand(ctx, ACTION_DL_STOP, key);
+        }
+    }
+
+    public static boolean isGameSessionActive() {
+        return gameActive.get();
+    }
+
+    private static boolean hasReason() {
+        if (gameActive.get()) return true;
+        synchronized (activeDownloads) {
+            return !activeDownloads.isEmpty();
+        }
+    }
+
+    private static void sendCommand(Context ctx, String action, @Nullable String tag) {
+        Context app = ctx.getApplicationContext();
+        Intent intent = new Intent(app, SessionKeepAliveService.class);
+        intent.setAction(action);
+        if (tag != null) intent.putExtra(EXTRA_TAG, tag);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                app.startForegroundService(intent);
+            } else {
+                app.startService(intent);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to send command " + action, e);
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        ensureChannel();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // Always promote to foreground first so Android does not consider
+        // the start a violation (and so the notification reflects current
+        // reasons), even if the command immediately tells us to stop.
+        ensureForeground();
+        serviceRunning.set(true);
+
+        if (!hasReason()) {
+            Log.d(TAG, "No active reason; stopping keep-alive service");
+            stopForegroundCompat();
+            stopSelf();
+            serviceRunning.set(false);
+        }
+        return START_NOT_STICKY;
+    }
+
+    private void ensureForeground() {
+        Notification n = buildNotification();
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(NOTIFICATION_ID, n, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+            } else {
+                startForeground(NOTIFICATION_ID, n);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to startForeground", e);
+        }
+    }
+
+    private void stopForegroundCompat() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE);
+            } else {
+                stopForeground(true);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to stopForeground", e);
+        }
+    }
+
+    private void ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm == null) return;
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return;
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                "WinNative session keep-alive",
+                NotificationManager.IMPORTANCE_LOW);
+        channel.setDescription(
+                "Keeps WinNative running in the background so a paused game session or "
+                        + "an active component download is not interrupted by screen lock.");
+        channel.setShowBadge(false);
+        nm.createNotificationChannel(channel);
+    }
+
+    private Notification buildNotification() {
+        boolean game = gameActive.get();
+        boolean dl;
+        synchronized (activeDownloads) {
+            dl = !activeDownloads.isEmpty();
+        }
+        String content;
+        if (game && dl) {
+            content = "Session paused — downloads continuing in background";
+        } else if (game) {
+            content = "Game session is paused in the background";
+        } else if (dl) {
+            content = "Downloading components in the background";
+        } else {
+            content = "WinNative is running in the background";
+        }
+
+        Intent openIntent = new Intent(this, UnifiedActivity.class);
+        openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent contentIntent = PendingIntent.getActivity(
+                this,
+                0,
+                openIntent,
+                PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(getString(R.string.common_ui_app_name))
+                .setContentText(content)
+                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setOngoing(true)
+                .setShowWhen(false)
+                .setContentIntent(contentIntent)
+                .build();
+    }
+
+    @Override
+    public void onTaskRemoved(Intent rootIntent) {
+        super.onTaskRemoved(rootIntent);
+        Log.i(TAG, "Task removed (user swipe). Tearing down session and exiting process.");
+
+        // Clear reasons so any subsequent re-entry will not keep us alive.
+        gameActive.set(false);
+        synchronized (activeDownloads) {
+            activeDownloads.clear();
+        }
+
+        // Give the activity's own onDestroy → performForcedSessionCleanup a
+        // chance to run first; then defensively clean any wine processes that
+        // might still be alive, and exit the process so swipe behaves like the
+        // pre-existing "swipe-away closes everything" flow.
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.postDelayed(() -> {
+            try {
+                ProcessHelper.terminateSessionProcessesAndWait(1500, true);
+                ProcessHelper.drainDeadChildren("session keep-alive task removed");
+            } catch (Throwable t) {
+                Log.w(TAG, "Defensive wine cleanup on task removal failed", t);
+            }
+            stopForegroundCompat();
+            stopSelf();
+            serviceRunning.set(false);
+            // Match the previous swipe behaviour: actually exit the process.
+            android.os.Process.killProcess(android.os.Process.myPid());
+        }, 1500L);
+    }
+
+    @Override
+    public void onDestroy() {
+        serviceRunning.set(false);
+        super.onDestroy();
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}


### PR DESCRIPTION
Add a foreground SessionKeepAliveService (dataSync, stopWithTask=false) that holds the app process alive while a wine session is in the background or while the setup wizard is downloading/installing components. Without it, locking the phone could let the OS reap the process and tear down a paused container, or interrupt an in-flight component install.

XServerDisplayActivity starts the service in onCreate and stops it from exit() and performForcedSessionCleanup, so existing session teardown paths are unchanged. The service's onTaskRemoved runs the same terminateSessionProcessesAndWait + drainDeadChildren cleanup the exit path uses, so user swipe-away still closes the app cleanly with no zombie wine processes.

SetupWizardActivity acquires a keep-alive tag around installImageFs, installAllRecommended, and installAdvancedComponent (released in finally) so screen lock cannot interrupt those operations.