### PR TITLE
Polish settings UI layout

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -1100,6 +1100,8 @@ class UnifiedActivity :
     // Main scaffold
     @Composable
     fun UnifiedHub() {
+        val horizontalNavigationInsets =
+            WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
         val initialLibraryLayoutMode = startupLibraryLayoutMode
         val initialStoreVisible = startupStoreVisible ?: mapOf("steam" to true, "epic" to true, "gog" to true)
         val initialContentFilters = startupContentFilters ?: mapOf("games" to true, "dlc" to false, "applications" to false, "tools" to false)
@@ -1108,7 +1110,8 @@ class UnifiedActivity :
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .background(BgDark),
+                        .background(BgDark)
+                        .windowInsetsPadding(horizontalNavigationInsets),
                 contentAlignment = Alignment.Center,
             ) {
                 Column(
@@ -1444,7 +1447,12 @@ class UnifiedActivity :
             scrimColor = Color.Black.copy(alpha = 0.5f),
             gesturesEnabled = true,
         ) {
-            Box(Modifier.fillMaxSize().background(BgDark)) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(BgDark)
+                    .windowInsetsPadding(horizontalNavigationInsets),
+            ) {
                 Scaffold(
                     containerColor = BgDark,
                     contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -1573,9 +1581,7 @@ class UnifiedActivity :
                                     Modifier
                                         .align(Alignment.BottomEnd)
                                         .windowInsetsPadding(
-                                            WindowInsets.navigationBars.only(
-                                                WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
-                                            ),
+                                            WindowInsets.navigationBars.only(WindowInsetsSides.Bottom),
                                         )
                                         .padding(end = addGameFabMargin, bottom = addGameFabMargin)
                                         .size(addGameFabSize)
@@ -1735,7 +1741,6 @@ class UnifiedActivity :
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
                         .padding(
                             start = UnifiedTopBarHorizontalPadding,
                             end = UnifiedTopBarHorizontalPadding,
@@ -1757,6 +1762,8 @@ class UnifiedActivity :
                         androidx.compose.material3.LocalRippleConfiguration provides null,
                     ) {
                         val tabWidth = 100.dp
+                        val tabSideGutter = 12.dp
+                        val tabBarShape = RoundedCornerShape(18.dp)
                         val visibleCount = minOf(3, tabs.size)
                         val tabListState = rememberLazyListState()
                         val snapFlingBehavior = rememberSnapFlingBehavior(lazyListState = tabListState)
@@ -1769,19 +1776,21 @@ class UnifiedActivity :
                         Box(
                             modifier =
                                 Modifier
-                                    .width(tabWidth * visibleCount)
+                                    .width(tabWidth * visibleCount + tabSideGutter * 2)
                                     .height(44.dp)
-                                    .shadow(8.dp, RoundedCornerShape(24.dp), spotColor = Color.Black.copy(alpha = 0.5f))
-                                    .clip(RoundedCornerShape(24.dp))
+                                    .shadow(8.dp, tabBarShape, spotColor = Color.Black.copy(alpha = 0.5f))
+                                    .clip(tabBarShape)
                                     .background(CardDark)
-                                    .border(1.dp, CardBorder, RoundedCornerShape(24.dp)),
+                                    .border(1.dp, CardBorder, tabBarShape),
                         ) {
                             LazyRow(
                                 state = tabListState,
                                 flingBehavior = snapFlingBehavior,
                                 modifier =
                                     Modifier
-                                        .fillMaxSize()
+                                        .align(Alignment.Center)
+                                        .width(tabWidth * visibleCount)
+                                        .fillMaxHeight()
                                         .focusProperties { canFocus = !isLibraryTab },
                                 userScrollEnabled = tabs.size > visibleCount,
                             ) {

--- a/app/src/main/feature/settings/containers/ContainersScreen.kt
+++ b/app/src/main/feature/settings/containers/ContainersScreen.kt
@@ -158,20 +158,7 @@ fun ContainersScreen(
                 ),
     ) {
         SectionLabel(text = stringResource(R.string.common_ui_containers))
-        if (state.containers.isEmpty()) {
-            Text(
-                text = stringResource(R.string.common_ui_no_items_to_display),
-                color = ContainersTextSecondary,
-                fontSize = 14.sp,
-                textAlign = TextAlign.Center,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = 6.dp, bottom = 14.dp),
-            )
-        } else {
-            Spacer(Modifier.height(6.dp))
-        }
+        Spacer(Modifier.height(6.dp))
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),

--- a/app/src/main/feature/settings/contents/ComponentsScreen.kt
+++ b/app/src/main/feature/settings/contents/ComponentsScreen.kt
@@ -222,7 +222,7 @@ fun ComponentsScreen(
             item(key = "available_section_${state.currentType.name}") {
                 SectionLabel(
                     text = stringResource(R.string.common_ui_available),
-                    modifier = Modifier.padding(top = 8.dp),
+                    modifier = Modifier.padding(top = 6.dp),
                 )
             }
             items(
@@ -389,14 +389,6 @@ private fun TypeTabsContent(
     onTypeSelected: (ContentProfile.ContentType) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.settings_content_type).uppercase(),
-            color = TextSecondary,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 1.4.sp,
-            modifier = Modifier.padding(start = 2.dp, bottom = 8.dp),
-        )
         Row(
             modifier =
                 Modifier

--- a/app/src/main/feature/settings/drivers/DriversScreen.kt
+++ b/app/src/main/feature/settings/drivers/DriversScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.DeveloperBoard
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Hub
@@ -266,7 +265,6 @@ fun DriversScreen(
             HeroHeader(
                 installedCount = state.installedDrivers.size,
                 repoCount = state.sources.size,
-                isBusy = state.loadingSourceApiUrl != null,
                 onInstall = onInstallFromFile,
                 onAddRepo = { showAddRepoDialog = true },
             )
@@ -302,7 +300,7 @@ fun DriversScreen(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(top = 8.dp),
+                        .padding(top = 6.dp),
                 verticalAlignment = Alignment.Bottom,
             ) {
                 SectionLabel(
@@ -363,88 +361,54 @@ fun DriversScreen(
 private fun HeroHeader(
     installedCount: Int,
     repoCount: Int,
-    isBusy: Boolean,
     onInstall: () -> Unit,
     onAddRepo: () -> Unit,
 ) {
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
-                .background(CardDark)
-                .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
-                .padding(horizontal = 14.dp, vertical = 12.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SectionLabel(text = stringResource(R.string.settings_drivers_manager_header))
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(CardDark)
+                    .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
         ) {
-            Row(
-                modifier = Modifier.weight(1f),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(34.dp)
-                            .clip(RoundedCornerShape(9.dp))
-                            .background(IconBoxBg),
-                    contentAlignment = Alignment.Center,
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        imageVector = Icons.Outlined.DeveloperBoard,
-                        contentDescription = null,
-                        tint = Accent,
-                        modifier = Modifier.size(17.dp),
-                    )
-                }
-
-                Spacer(Modifier.width(12.dp))
-
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.settings_drivers_manager_header),
-                        color = TextPrimary,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         CountPill(label = "Installed", count = installedCount)
                         Spacer(Modifier.width(6.dp))
                         CountPill(label = "Repos", count = repoCount)
                     }
-                    if (isBusy) {
-                        Spacer(Modifier.height(3.dp))
-                        Text(
-                            text = stringResource(R.string.settings_drivers_repo_loading_releases),
-                            color = Accent,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium,
+
+                    Spacer(Modifier.width(12.dp))
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        HeroButton(
+                            label = "Add Repo",
+                            icon = Icons.Outlined.Add,
+                            onClick = onAddRepo,
+                            modifier = Modifier.widthIn(min = 112.dp, max = 132.dp),
+                        )
+                        HeroButton(
+                            label = stringResource(R.string.settings_drivers_install),
+                            icon = Icons.Outlined.Upload,
+                            onClick = onInstall,
+                            modifier = Modifier.widthIn(min = 112.dp, max = 132.dp),
                         )
                     }
                 }
-            }
-
-            Spacer(Modifier.width(12.dp))
-
-            Column(
-                modifier = Modifier.widthIn(min = 112.dp, max = 132.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                HeroButton(
-                    label = "Add Repo",
-                    icon = Icons.Outlined.Add,
-                    onClick = onAddRepo,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                HeroButton(
-                    label = stringResource(R.string.settings_drivers_install),
-                    icon = Icons.Outlined.Upload,
-                    onClick = onInstall,
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
         }
     }

--- a/app/src/main/feature/settings/drivers/DriversScreen.kt
+++ b/app/src/main/feature/settings/drivers/DriversScreen.kt
@@ -376,9 +376,12 @@ private fun HeroHeader(
                 .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
                 .padding(horizontal = 14.dp, vertical = 12.dp),
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.weight(1f),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(
@@ -424,23 +427,23 @@ private fun HeroHeader(
                 }
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.width(12.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            Column(
+                modifier = Modifier.widthIn(min = 112.dp, max = 132.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                HeroButton(
-                    label = stringResource(R.string.settings_drivers_install),
-                    icon = Icons.Outlined.Upload,
-                    onClick = onInstall,
-                    modifier = Modifier.weight(1f),
-                )
                 HeroButton(
                     label = "Add Repo",
                     icon = Icons.Outlined.Add,
                     onClick = onAddRepo,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                HeroButton(
+                    label = stringResource(R.string.settings_drivers_install),
+                    icon = Icons.Outlined.Upload,
+                    onClick = onInstall,
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
@@ -491,7 +494,8 @@ private fun HeroButton(
                 .background(Accent.copy(alpha = 0.12f))
                 .border(1.dp, Accent.copy(alpha = 0.32f), RoundedCornerShape(9.dp))
                 .noRippleClickable(onClick = onClick)
-                .padding(vertical = 7.dp),
+                .height(30.dp)
+                .padding(horizontal = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -499,14 +503,16 @@ private fun HeroButton(
                 imageVector = icon,
                 contentDescription = null,
                 tint = Accent,
-                modifier = Modifier.size(13.dp),
+                modifier = Modifier.size(12.dp),
             )
-            Spacer(Modifier.width(6.dp))
+            Spacer(Modifier.width(5.dp))
             Text(
                 text = label,
                 color = Accent,
-                fontSize = 12.sp,
+                fontSize = 11.sp,
                 fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }

--- a/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
+++ b/app/src/main/feature/settings/nav/SettingsNavSidebar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -52,6 +53,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -121,12 +123,16 @@ fun SettingsNavSidebar(
     onBackPressed: () -> Unit,
     bordersPaused: Boolean = false,
 ) {
-    val navBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val layoutDirection = LocalLayoutDirection.current
+    val navBarPadding = WindowInsets.navigationBars.asPaddingValues()
+    val navStartInset = navBarPadding.calculateStartPadding(layoutDirection)
+    val navBottomInset = navBarPadding.calculateBottomPadding()
 
     Row(
         modifier =
             Modifier
-                .fillMaxHeight(),
+                .fillMaxHeight()
+                .padding(start = navStartInset),
     ) {
         Column(
             modifier =

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -115,15 +115,6 @@ class OtherSettingsFragment : Fragment() {
                                 // AppCompatDelegate recreates attached activities automatically.
                             }
                         },
-                        onRefreshRateSelected = { index ->
-                            val hz =
-                                RefreshRateUtils.parseRefreshRateLabel(
-                                    uiState.refreshRateLabels.getOrNull(index),
-                                )
-                            preferences.edit { putInt("refresh_rate_override", hz) }
-                            if (isAdded) RefreshRateUtils.applyPreferredRefreshRate(requireActivity())
-                            refresh()
-                        },
                         onSoundFontSelected = { index ->
                             // Selection is display-only; no persistence in legacy code.
                             uiState = uiState.copy(soundFontIndex = index)
@@ -200,21 +191,6 @@ class OtherSettingsFragment : Fragment() {
             }
         val languageIndex = LocaleHelper.indexForTag(LocaleHelper.getAppliedLanguageTag())
 
-        // Refresh rate entries + saved selection
-        val refreshRateLabels =
-            RefreshRateUtils.buildRefreshRateEntryLabels(
-                requireActivity(),
-                getString(R.string.settings_general_refresh_rate_auto_max),
-            )
-        val savedRate = preferences.getInt("refresh_rate_override", 0)
-        val refreshRateIndex =
-            if (savedRate == 0) {
-                0
-            } else {
-                val target = "$savedRate Hz"
-                refreshRateLabels.indexOfFirst { it == target }.coerceAtLeast(0)
-            }
-
         // Sound font files
         val soundFontFiles = loadSoundFontFiles(ctx)
         val soundFontIndex = uiState.soundFontIndex.coerceIn(0, (soundFontFiles.size - 1).coerceAtLeast(0))
@@ -238,8 +214,6 @@ class OtherSettingsFragment : Fragment() {
                 checkForUpdates = preferences.getBoolean("check_for_updates", false),
                 languageLabels = languageLabels,
                 languageIndex = languageIndex,
-                refreshRateLabels = refreshRateLabels,
-                refreshRateIndex = refreshRateIndex,
                 soundFontFiles = soundFontFiles,
                 soundFontIndex = soundFontIndex,
                 winlatorPath = winlatorPath,

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -41,10 +41,8 @@ import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LibraryMusic
-import androidx.compose.material.icons.outlined.Monitor
 import androidx.compose.material.icons.outlined.Mouse
 import androidx.compose.material.icons.outlined.OpenInBrowser
-import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.SportsEsports
@@ -98,8 +96,6 @@ data class OtherSettingsState(
     val checkForUpdates: Boolean = true,
     val languageLabels: List<String> = emptyList(),
     val languageIndex: Int = 0,
-    val refreshRateLabels: List<String> = emptyList(),
-    val refreshRateIndex: Int = 0,
     val soundFontFiles: List<String> = emptyList(),
     val soundFontIndex: Int = 0,
     val winlatorPath: String = "",
@@ -121,7 +117,6 @@ fun OtherSettingsScreen(
     onCheckForUpdatesChanged: (Boolean) -> Unit,
     onCheckForUpdatesNow: () -> Unit,
     onLanguageSelected: (Int) -> Unit,
-    onRefreshRateSelected: (Int) -> Unit,
     onSoundFontSelected: (Int) -> Unit,
     onInstallSoundFont: () -> Unit,
     onRemoveSoundFont: () -> Unit,
@@ -192,21 +187,6 @@ fun OtherSettingsScreen(
                 options = state.languageLabels,
                 selectedIndex = state.languageIndex,
                 onOptionSelected = onLanguageSelected,
-            )
-        }
-
-        item(key = "display_section") {
-            SectionLabel(stringResource(R.string.session_display_title), modifier = Modifier.padding(top = 8.dp))
-        }
-
-        item(key = "refresh_rate_card") {
-            SettingsDropdownCard(
-                title = stringResource(R.string.settings_general_refresh_rate),
-                subtitle = stringResource(R.string.settings_general_refresh_rate_summary),
-                icon = Icons.Outlined.Monitor,
-                options = state.refreshRateLabels,
-                selectedIndex = state.refreshRateIndex,
-                onOptionSelected = onRefreshRateSelected,
             )
         }
 

--- a/app/src/main/feature/settings/presets/PresetsScreen.kt
+++ b/app/src/main/feature/settings/presets/PresetsScreen.kt
@@ -584,7 +584,6 @@ private fun PresetSelectorCard(
                     onRename = onRename,
                     onDuplicate = onDuplicate,
                     onExport = onExport,
-                    onImport = onImport,
                     onRemove = onRemove,
                 )
             }
@@ -607,20 +606,11 @@ private fun PresetSelectorRowContent(
     onRename: () -> Unit,
     onDuplicate: () -> Unit,
     onExport: () -> Unit,
-    onImport: () -> Unit,
     onRemove: () -> Unit,
 ) {
     var dropdownOpen by remember { mutableStateOf(false) }
     var menuOpen by remember { mutableStateOf(false) }
     val selected = data.presets.firstOrNull { it.id == data.selectedPresetId }
-    val hintText =
-        stringResource(
-            if (data.editable) {
-                R.string.container_presets_changes_auto_saved
-            } else {
-                R.string.container_presets_builtin_readonly_hint
-            },
-        )
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -745,17 +735,6 @@ private fun PresetSelectorRowContent(
                         },
                     )
                     MenuRow(
-                        icon = Icons.Outlined.FileDownload,
-                        iconTint = Accent,
-                        label = stringResource(R.string.common_ui_import),
-                        textColor = TextPrimary,
-                        enabled = true,
-                        onClick = {
-                            menuOpen = false
-                            onImport()
-                        },
-                    )
-                    MenuRow(
                         icon = Icons.Outlined.Delete,
                         iconTint = DangerRed,
                         label = stringResource(R.string.common_ui_remove),
@@ -770,16 +749,18 @@ private fun PresetSelectorRowContent(
             }
         }
 
-        Spacer(Modifier.height(6.dp))
-        Text(
-            text = hintText,
-            color = TextSecondary,
-            fontSize = 11.sp,
-            lineHeight = 14.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(start = 11.dp),
-        )
+        if (data.editable) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.container_presets_changes_auto_saved),
+                color = TextSecondary,
+                fontSize = 11.sp,
+                lineHeight = 14.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(start = 11.dp),
+            )
+        }
     }
 }
 

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -133,7 +133,7 @@ fun GoogleScreen() {
                 start = 16.dp + navBarStartPadding,
                 top = 16.dp,
                 end = 16.dp + navBarEndPadding,
-                bottom = 4.dp + navBarBottomPadding,
+                bottom = 16.dp + navBarBottomPadding,
             ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Omdøb forudindstilling</string>
     <string name="container_presets_import">Importer forudindstilling</string>
     <string name="container_presets_custom">Brugerdefineret</string>
-    <string name="container_presets_built_in">Indbygget</string>
+    <string name="container_presets_built_in">Standard</string>
     <string name="container_presets_changes_auto_saved">Ændringer gemmes automatisk mens du redigerer denne brugerdefinerede forudindstilling.</string>
-    <string name="container_presets_builtin_readonly_hint">Indbyggede forudindstillinger er skrivebeskyttede. Opret eller dupliker en forudindstilling for at tilpasse disse variabler.</string>
     <string name="container_presets_cannot_rename">Indbyggede forudindstillinger kan ikke omdøbes</string>
     <string name="container_presets_unable_to_import">Kan ikke importere forudindstilling</string>
     <string name="container_presets_no_description">Ingen beskrivelse tilgængelig</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Voreinstellung umbenennen</string>
     <string name="container_presets_import">Voreinstellung importieren</string>
     <string name="container_presets_custom">Benutzerdefiniert</string>
-    <string name="container_presets_built_in">Integriert</string>
+    <string name="container_presets_built_in">Standard</string>
     <string name="container_presets_changes_auto_saved">Änderungen werden beim Bearbeiten dieser benutzerdefinierten Voreinstellung automatisch gespeichert.</string>
-    <string name="container_presets_builtin_readonly_hint">Integrierte Voreinstellungen sind schreibgeschützt. Erstelle oder dupliziere eine Voreinstellung, um diese Variablen anzupassen.</string>
     <string name="container_presets_cannot_rename">Integrierte Voreinstellungen können nicht umbenannt werden</string>
     <string name="container_presets_unable_to_import">Voreinstellung kann nicht importiert werden</string>
     <string name="container_presets_no_description">Keine Beschreibung verfügbar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Renombrar preset</string>
     <string name="container_presets_import">Importar preset</string>
     <string name="container_presets_custom">Personalizado</string>
-    <string name="container_presets_built_in">Integrado</string>
+    <string name="container_presets_built_in">Predeterminado</string>
     <string name="container_presets_changes_auto_saved">Los cambios se guardan automáticamente al editar este preset personalizado.</string>
-    <string name="container_presets_builtin_readonly_hint">Los presets integrados son de solo lectura. Crea o duplica un preset para personalizar estas variables.</string>
     <string name="container_presets_cannot_rename">Los presets integrados no se pueden renombrar</string>
     <string name="container_presets_unable_to_import">No se pudo importar el preset</string>
     <string name="container_presets_no_description">No hay descripción disponible</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Renommer le préréglage</string>
     <string name="container_presets_import">Importer un préréglage</string>
     <string name="container_presets_custom">Personnalisé</string>
-    <string name="container_presets_built_in">Intégré</string>
+    <string name="container_presets_built_in">Par défaut</string>
     <string name="container_presets_changes_auto_saved">Les modifications sont enregistrées automatiquement lors de l\'édition de ce préréglage personnalisé.</string>
-    <string name="container_presets_builtin_readonly_hint">Les préréglages intégrés sont en lecture seule. Créez ou dupliquez un préréglage pour personnaliser ces variables.</string>
     <string name="container_presets_cannot_rename">Les préréglages intégrés ne peuvent pas être renommés</string>
     <string name="container_presets_unable_to_import">Impossible d\'importer le préréglage</string>
     <string name="container_presets_no_description">Aucune description disponible</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Rinomina preset</string>
     <string name="container_presets_import">Importa preset</string>
     <string name="container_presets_custom">Personalizzato</string>
-    <string name="container_presets_built_in">Integrato</string>
+    <string name="container_presets_built_in">Predefinito</string>
     <string name="container_presets_changes_auto_saved">Le modifiche vengono salvate automaticamente durante la modifica di questo preset personalizzato.</string>
-    <string name="container_presets_builtin_readonly_hint">I preset integrati sono di sola lettura. Crea o duplica un preset per personalizzare queste variabili.</string>
     <string name="container_presets_cannot_rename">I preset integrati non possono essere rinominati</string>
     <string name="container_presets_unable_to_import">Impossibile importare il preset</string>
     <string name="container_presets_no_description">Nessuna descrizione disponibile</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">프리셋 이름 변경</string>
     <string name="container_presets_import">프리셋 가져오기</string>
     <string name="container_presets_custom">사용자 지정</string>
-    <string name="container_presets_built_in">기본 제공</string>
+    <string name="container_presets_built_in">기본값</string>
     <string name="container_presets_changes_auto_saved">이 사용자 지정 프리셋을 편집하는 동안 변경 사항이 자동으로 저장됩니다.</string>
-    <string name="container_presets_builtin_readonly_hint">기본 제공 프리셋은 읽기 전용입니다. 이 변수를 사용자 지정하려면 프리셋을 만들거나 복제하세요.</string>
     <string name="container_presets_cannot_rename">기본 제공 프리셋은 이름을 변경할 수 없습니다</string>
     <string name="container_presets_unable_to_import">프리셋을 가져올 수 없습니다</string>
     <string name="container_presets_no_description">사용 가능한 설명이 없습니다</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -504,9 +504,8 @@
     <string name="container_presets_rename">Zmień nazwę presetu</string>
     <string name="container_presets_import">Importuj preset</string>
     <string name="container_presets_custom">Własne</string>
-    <string name="container_presets_built_in">Wbudowane</string>
+    <string name="container_presets_built_in">Domyślne</string>
     <string name="container_presets_changes_auto_saved">Zmiany zapisują się automatycznie podczas edycji tego własnego presetu.</string>
-    <string name="container_presets_builtin_readonly_hint">Wbudowane presety są tylko do odczytu. Utwórz lub zduplikuj preset, aby dostosować te zmienne.</string>
     <string name="container_presets_cannot_rename">Nie można zmienić nazwy wbudowanych presetów</string>
     <string name="container_presets_unable_to_import">Nie można zaimportować presetu</string>
     <string name="container_presets_no_description">Brak dostępnego opisu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Renomear Predefinicao</string>
     <string name="container_presets_import">Importar Predefinicao</string>
     <string name="container_presets_custom">Personalizado</string>
-    <string name="container_presets_built_in">Integrado</string>
+    <string name="container_presets_built_in">Padrão</string>
     <string name="container_presets_changes_auto_saved">As alteracoes sao salvas automaticamente ao editar esta predefinicao personalizada.</string>
-    <string name="container_presets_builtin_readonly_hint">Predefinicoes integradas sao somente leitura. Crie ou duplique uma predefinicao para personalizar estas variaveis.</string>
     <string name="container_presets_cannot_rename">Predefinicoes integradas nao podem ser renomeadas</string>
     <string name="container_presets_unable_to_import">Nao foi possivel importar a predefinicao</string>
     <string name="container_presets_no_description">Nenhuma descricao disponivel</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">Redenumeste preset</string>
     <string name="container_presets_import">Importa preset</string>
     <string name="container_presets_custom">Personalizat</string>
-    <string name="container_presets_built_in">Incorporat</string>
+    <string name="container_presets_built_in">Implicit</string>
     <string name="container_presets_changes_auto_saved">Modificarile se salveaza automat in timpul editarii acestui preset personalizat.</string>
-    <string name="container_presets_builtin_readonly_hint">Preseturile incorporate sunt doar pentru citire. Creeaza sau duplica un preset pentru a personaliza aceste variabile.</string>
     <string name="container_presets_cannot_rename">Preseturile incorporate nu pot fi redenumite</string>
     <string name="container_presets_unable_to_import">Nu s-a putut importa presetul</string>
     <string name="container_presets_no_description">Nicio descriere disponibila</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -504,9 +504,8 @@
     <string name="container_presets_rename">Перейменувати пресет</string>
     <string name="container_presets_import">Імпортувати пресет</string>
     <string name="container_presets_custom">Користувацький</string>
-    <string name="container_presets_built_in">Вбудований</string>
+    <string name="container_presets_built_in">За замовчуванням</string>
     <string name="container_presets_changes_auto_saved">Зміни зберігаються автоматично під час редагування цього користувацького пресету.</string>
-    <string name="container_presets_builtin_readonly_hint">Вбудовані пресети доступні лише для читання. Створіть або дублюйте пресет для налаштування цих змінних.</string>
     <string name="container_presets_cannot_rename">Вбудовані пресети неможливо перейменувати</string>
     <string name="container_presets_unable_to_import">Неможливо імпортувати пресет</string>
     <string name="container_presets_no_description">Опис недоступний</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">重命名预设</string>
     <string name="container_presets_import">导入预设</string>
     <string name="container_presets_custom">自定义</string>
-    <string name="container_presets_built_in">内置</string>
+    <string name="container_presets_built_in">默认</string>
     <string name="container_presets_changes_auto_saved">编辑此自定义预设时更改会自动保存。</string>
-    <string name="container_presets_builtin_readonly_hint">内置预设为只读。创建或复制预设以自定义这些变量。</string>
     <string name="container_presets_cannot_rename">内置预设无法重命名</string>
     <string name="container_presets_unable_to_import">无法导入预设</string>
     <string name="container_presets_no_description">暂无描述</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -500,9 +500,8 @@
     <string name="container_presets_rename">重新命名預設</string>
     <string name="container_presets_import">匯入預設</string>
     <string name="container_presets_custom">自訂</string>
-    <string name="container_presets_built_in">內建</string>
+    <string name="container_presets_built_in">預設</string>
     <string name="container_presets_changes_auto_saved">編輯此自訂預設時，變更會自動儲存。</string>
-    <string name="container_presets_builtin_readonly_hint">內建預設為唯讀。建立或複製預設以自訂這些變數。</string>
     <string name="container_presets_cannot_rename">無法重新命名內建預設</string>
     <string name="container_presets_unable_to_import">無法匯入預設</string>
     <string name="container_presets_no_description">沒有可用的說明</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,9 +565,8 @@
     <string name="container_presets_rename">Rename Preset</string>
     <string name="container_presets_import">Import Preset</string>
     <string name="container_presets_custom">Custom</string>
-    <string name="container_presets_built_in">Built-In</string>
+    <string name="container_presets_built_in">Default</string>
     <string name="container_presets_changes_auto_saved">Changes save automatically while editing this custom preset.</string>
-    <string name="container_presets_builtin_readonly_hint">Built-in presets are read-only. Create or duplicate a preset to customize these variables.</string>
     <string name="container_presets_cannot_rename">Built-in presets cannot be renamed</string>
     <string name="container_presets_unable_to_import">Unable to import preset</string>
     <string name="container_presets_no_description">No description available</string>


### PR DESCRIPTION
- Adjusts settings-side navigation, hub chrome, and section spacing across the affected Compose screens.
- Simplifies Drivers, Components, Containers, and Presets settings copy by removing redundant labels, hints, and duplicate menu actions.
- Updates the Presets default badge string across base and localized resources.
- Keeps the visible Presets import action in the header while removing the duplicate overflow menu entry.
- Validated with `./gradlew.bat :app:compileStandardDebugKotlin`.