### PR TITLE
feat: add 'Tap to Click' toggle to input controls

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -984,6 +984,7 @@ Installed path:
     <string name="setup_wizard_create_container">Create Container</string>
     <string name="setup_wizard_creating_container">Creating\u2026</string>
 
+    <string name="input_controls_tap_to_click">Tap to Click</string>
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Authorization</string>
     <string name="steam_login_sign_in_to_your_account">Sign in to your account</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -247,6 +247,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private ImageFs imageFs;
     private FrameRating frameRating = null;
     private boolean effectiveShowFPS = false;
+    private boolean isTapToClickEnabled = true;
     private int runtimeFpsLimit = 0;
     private String lastRendererName = "OpenGL";
     private String lastGpuName = null;
@@ -550,7 +551,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         // Check for Dark Mode
         isDarkMode = preferences.getBoolean("dark_mode", false);
-
+        isTapToClickEnabled = true;
         boolean isOpenWithAndroidBrowser = preferences.getBoolean("open_with_android_browser", false);
         boolean isShareAndroidClipboard = preferences.getBoolean("share_android_clipboard", false);
 
@@ -3942,6 +3943,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         globalCursorSpeed = preferences.getFloat("cursor_speed", 1.0f);
         touchpadView = new TouchpadView(this, xServer, timeoutHandler, hideControlsRunnable);
+        touchpadView.setTapToClickEnabled(isTapToClickEnabled);
         touchpadView.setSensitivity(globalCursorSpeed);
         touchpadView.setMouseEnabled(!isMouseDisabled);
         touchpadView.setFourFingersTapCallback(() -> {
@@ -4220,6 +4222,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         // Initialize checkbox states
         dialog.getShowTouchscreenControls().setValue(preferences.getBoolean("show_touchscreen_controls_enabled", false));
+        dialog.getTapToClickEnabled().setValue(isTapToClickEnabled);
         dialog.getOverlayOpacity().setValue(preferences.getFloat("overlay_opacity", InputControlsView.DEFAULT_OVERLAY_OPACITY));
         dialog.getTouchscreenHaptics().setValue(preferences.getBoolean("touchscreen_haptics_enabled", false));
         dialog.getGamepadVibration().setValue(preferences.getBoolean(ControllerManager.PREF_VIBRATION_GLOBAL, true));
@@ -4250,6 +4253,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Confirm callback
         dialog.setOnConfirmCallback(() -> {
             inputControlsView.setShowTouchscreenControls(dialog.getShowTouchscreenControls().getValue());
+            isTapToClickEnabled = dialog.getTapToClickEnabled().getValue();
+            if (touchpadView != null) touchpadView.setTapToClickEnabled(isTapToClickEnabled);
+
             float overlayOpacity = dialog.getOverlayOpacity().getValue();
             inputControlsView.setOverlayOpacity(overlayOpacity);
             boolean isHapticsEnabled = dialog.getTouchscreenHaptics().getValue();

--- a/app/src/main/runtime/input/InputControlsDialog.kt
+++ b/app/src/main/runtime/input/InputControlsDialog.kt
@@ -117,12 +117,4 @@ class InputControlsDialog(
             .hideKeyboard(activity)
         dialog.dismiss()
     }
-
-    fun getProfileNames() = profileNames
-    fun getSelectedProfileIndex() = selectedProfileIndex
-    fun getShowTouchscreenControls() = showTouchscreenControls
-    fun getTapToClickEnabled() = tapToClickEnabled
-    fun getOverlayOpacity() = overlayOpacity
-    fun getTouchscreenHaptics() = touchscreenHaptics
-    fun getGamepadVibration() = gamepadVibration
 }

--- a/app/src/main/runtime/input/InputControlsDialog.kt
+++ b/app/src/main/runtime/input/InputControlsDialog.kt
@@ -25,6 +25,7 @@ class InputControlsDialog(
     val profileNames = mutableStateOf<List<String>>(emptyList())
     val selectedProfileIndex = mutableIntStateOf(0)
     val showTouchscreenControls = mutableStateOf(false)
+    val tapToClickEnabled = mutableStateOf(true)
     val overlayOpacity = mutableStateOf(0.4f)
     val touchscreenHaptics = mutableStateOf(false)
     val gamepadVibration = mutableStateOf(true)
@@ -65,6 +66,7 @@ class InputControlsDialog(
                                     profileNames = profileNames.value,
                                     selectedProfileIndex = selectedProfileIndex.intValue,
                                     showTouchscreenControls = showTouchscreenControls.value,
+                                    tapToClickEnabled = tapToClickEnabled.value,
                                     overlayOpacity = overlayOpacity.value,
                                     touchscreenHaptics = touchscreenHaptics.value,
                                     gamepadVibration = gamepadVibration.value,
@@ -74,6 +76,7 @@ class InputControlsDialog(
                             },
                             onSettingsClick = { onSettingsClickCallback?.run() },
                             onShowTouchscreenControlsChange = { showTouchscreenControls.value = it },
+                            onTapToClickChange = { tapToClickEnabled.value = it },
                             onOverlayOpacityChange = { overlayOpacity.value = it },
                             onTouchscreenHapticsChange = { touchscreenHaptics.value = it },
                             onGamepadVibrationChange = { gamepadVibration.value = it },
@@ -114,4 +117,12 @@ class InputControlsDialog(
             .hideKeyboard(activity)
         dialog.dismiss()
     }
+
+    fun getProfileNames() = profileNames
+    fun getSelectedProfileIndex() = selectedProfileIndex
+    fun getShowTouchscreenControls() = showTouchscreenControls
+    fun getTapToClickEnabled() = tapToClickEnabled
+    fun getOverlayOpacity() = overlayOpacity
+    fun getTouchscreenHaptics() = touchscreenHaptics
+    fun getGamepadVibration() = gamepadVibration
 }

--- a/app/src/main/runtime/input/InputControlsDialogContent.kt
+++ b/app/src/main/runtime/input/InputControlsDialogContent.kt
@@ -71,6 +71,7 @@ data class InputControlsState(
     val profileNames: List<String> = emptyList(),
     val selectedProfileIndex: Int = 0,
     val showTouchscreenControls: Boolean = false,
+    val tapToClickEnabled: Boolean = true,
     val overlayOpacity: Float = 0.4f,
     val touchscreenHaptics: Boolean = false,
     val gamepadVibration: Boolean = true,
@@ -82,6 +83,7 @@ fun InputControlsDialogContent(
     onProfileSelected: (Int) -> Unit,
     onSettingsClick: () -> Unit,
     onShowTouchscreenControlsChange: (Boolean) -> Unit,
+    onTapToClickChange: (Boolean) -> Unit,
     onOverlayOpacityChange: (Float) -> Unit,
     onTouchscreenHapticsChange: (Boolean) -> Unit,
     onGamepadVibrationChange: (Boolean) -> Unit,
@@ -163,6 +165,12 @@ fun InputControlsDialogContent(
                             OverlayOpacitySlider(
                                 value = state.overlayOpacity,
                                 onValueChange = onOverlayOpacityChange
+                            )
+
+                            OptionCheckbox(
+                                label = stringResource(R.string.input_controls_tap_to_click),
+                                checked = state.tapToClickEnabled,
+                                onCheckedChange = onTapToClickChange,
                             )
                         }
 

--- a/app/src/main/runtime/input/ui/TouchpadView.kt
+++ b/app/src/main/runtime/input/ui/TouchpadView.kt
@@ -60,13 +60,14 @@ class TouchpadView(
     private var lastTouchedPosY = 0
     private var resolutionScale = 0f
     private var mouseEnabled = true
+    var tapToClickEnabled = true
     private var fourFingersTapCallback: Runnable? = null
     private val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
     private val longPressHandler = Handler(Looper.getMainLooper())
     private var longPressActive = false
     private val longPressRunnable =
         Runnable {
-            if (numFingers.toInt() == 1 && fingers[0] != null && fingers[0]!!.travelDistance() < MAX_TAP_TRAVEL_DISTANCE) {
+            if (tapToClickEnabled && numFingers.toInt() == 1 && fingers[0] != null && fingers[0]!!.travelDistance() < MAX_TAP_TRAVEL_DISTANCE) {
                 longPressActive = true
                 if (xServer.isRelativeMouseMovement) {
                     xServer.winHandler.mouseEvent(MouseEventFlags.RIGHTDOWN, 0, 0, 0)
@@ -415,7 +416,7 @@ class TouchpadView(
             xServer.injectPointerMove(transformedPoint[0].toInt(), transformedPoint[1].toInt())
         }
 
-        if (numFingers.toInt() == 1) {
+        if (tapToClickEnabled && numFingers.toInt() == 1) {
             if (xServer.isRelativeMouseMovement) {
                 xServer.winHandler.mouseEvent(MouseEventFlags.LEFTDOWN, 0, 0, 0)
             } else {
@@ -434,10 +435,12 @@ class TouchpadView(
     }
 
     private fun handleTouchUp() {
-        if (xServer.isRelativeMouseMovement) {
-            xServer.winHandler.mouseEvent(MouseEventFlags.LEFTUP, 0, 0, 0)
-        } else {
-            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT)
+        if (tapToClickEnabled) {
+            if (xServer.isRelativeMouseMovement) {
+                xServer.winHandler.mouseEvent(MouseEventFlags.LEFTUP, 0, 0, 0)
+            } else {
+                xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT)
+            }
         }
     }
 
@@ -455,6 +458,7 @@ class TouchpadView(
     }
 
     private fun handleTwoFingerTap() {
+        if (!tapToClickEnabled) return
         // FIX: Ensure clean right-click by clearing left button first
         if (xServer.pointer.isButtonPressed(Pointer.Button.BUTTON_LEFT)) {
             if (xServer.isRelativeMouseMovement) {
@@ -484,26 +488,28 @@ class TouchpadView(
     }
 
     private fun handleFingerUp(finger1: Finger) {
-        when (numFingers.toInt()) {
-            1 -> {
-                if (simTouchScreen) {
-                    postDelayed(
-                        { if (continueClick) xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT) },
-                        CLICK_DELAYED_TIME.toLong(),
-                    )
-                } else if (finger1.isTap()) {
-                    pressPointerButtonLeft(finger1)
+        if (tapToClickEnabled) {
+            when (numFingers.toInt()) {
+                1 -> {
+                    if (simTouchScreen) {
+                        postDelayed(
+                            { if (continueClick) xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT) },
+                            CLICK_DELAYED_TIME.toLong(),
+                        )
+                    } else if (finger1.isTap()) {
+                        pressPointerButtonLeft(finger1)
+                    }
                 }
-            }
 
-            2 -> {
-                val finger2 = findSecondFinger(finger1)
-                if (finger2 != null && finger1.isTap()) pressPointerButtonRight(finger1)
-            }
+                2 -> {
+                    val finger2 = findSecondFinger(finger1)
+                    if (finger2 != null && finger1.isTap()) pressPointerButtonRight(finger1)
+                }
 
-            4 -> {
-                fourFingersTapCallback?.let {
-                    if (fingers.filterNotNull().all { it.isTap() }) it.run()
+                4 -> {
+                    fourFingersTapCallback?.let {
+                        if (fingers.filterNotNull().all { it.isTap() }) it.run()
+                    }
                 }
             }
         }


### PR DESCRIPTION
This shall fix miss clicks in games when playing touch controls. If you turn this off then tapping the screen won't left or right click. All profile buttons still functional as normal.
While keeping mouse movement in games that need mouse movement still avaliable.