### PR TITLE
Fix controller services in startup modes

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3658,8 +3658,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         else
             startupSelection = String.valueOf(container.getStartupSelection());
 
+        WineUtils.changeServicesStatus(container, startupSelection);
         if (!startupSelection.equals(container.getExtra("startupSelection"))) {
-            WineUtils.changeServicesStatus(container, startupSelection);
             container.putExtra("startupSelection", startupSelection);
             containerDataChanged = true;
         }
@@ -3703,9 +3703,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         // Additional container checks and environment configuration
         if (container != null) {
-                if (Byte.parseByte(startupSelection) == Container.STARTUP_SELECTION_AGGRESSIVE) {
-                    winHandler.killProcess("services.exe");
-                }
                 guestProgramLauncherComponent.setContainer(this.container);
                 guestProgramLauncherComponent.setWineInfo(this.wineInfo);
 


### PR DESCRIPTION
## Summary
- Reapply Wine service startup settings on every launch so existing containers are repaired without toggling startup mode.
- Stop killing `services.exe` in aggressive mode so `winebus`, `winehid`, and `PlugPlay` can remain active for controller detection.

## Why
Aggressive and essential startup modes preserve the controller-related services in the registry, but stale containers could keep old disabled values because service status updates only ran when the saved startup mode changed. Aggressive mode also killed the Wine service manager immediately before launch, which prevented the preserved services from helping controller detection.

## Validation
- `./gradlew.bat :app:compileStandardDebugJavaWithJavac`