### PR TITLE
fix(i18n): remove orphan fexcore_env_var_help__smc_checks translations

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Aktiverer multiblok-kodekompilering. Kan forårsage længere JIT-kompilering og hakken.</string>
     <string name="fexcore_env_var_help__hostfeatures">Styrer tvungen CPU-funktioner.</string>
     <string name="fexcore_env_var_help__smalltscscale">Skalerer TSC på lavfrekvens-systemer.</string>
-    <string name="fexcore_env_var_help__smc_checks">Kontrol af selvmodificerende kode.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Bruger volatil metadata fra PE-filer til TSO når det er tilgængeligt.</string>
     <string name="fexcore_env_var_help__monohacks">Specielle SMC + JIT-blokhacks til Mono-registrering.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Skjuler CPUID hypervisor-bit (nyttigt for apps der crasher med det).</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Aktiviert Multiblock-Code-Kompilierung. Kann längere JIT-Kompilierung und Ruckler verursachen.</string>
     <string name="fexcore_env_var_help__hostfeatures">Steuert das Erzwingen von CPU-Features.</string>
     <string name="fexcore_env_var_help__smalltscscale">Skaliert TSC auf Systemen mit niedriger Frequenz.</string>
-    <string name="fexcore_env_var_help__smc_checks">Prüfungen für selbstmodifizierenden Code.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Verwendet volatile Metadaten aus PE-Dateien für TSO, wenn verfügbar.</string>
     <string name="fexcore_env_var_help__monohacks">Spezielle SMC- und JIT-Block-Hacks für Mono-Erkennung.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Verbirgt das CPUID-Hypervisor-Bit (nützlich für Apps, die damit abstürzen).</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Activa la compilación de código multibloque. Puede causar compilación JIT más larga y tirones.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controla el forzado de características de CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Escala TSC en sistemas de baja frecuencia.</string>
-    <string name="fexcore_env_var_help__smc_checks">Verificaciones de código automodificable.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Usa metadatos volátiles de archivos PE para TSO cuando estén disponibles.</string>
     <string name="fexcore_env_var_help__monohacks">Hacks especiales de SMC + bloque JIT para detección de Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Oculta el bit de hipervisor en CPUID (útil para apps que fallan con él).</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Active la compilation de code multibloc. Peut causer une compilation JIT plus longue et des saccades.</string>
     <string name="fexcore_env_var_help__hostfeatures">Contrôle le forçage des fonctionnalités du processeur.</string>
     <string name="fexcore_env_var_help__smalltscscale">Met à l\'échelle le TSC sur les systèmes à basse fréquence.</string>
-    <string name="fexcore_env_var_help__smc_checks">Vérifications de code auto-modifiant.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Utilise les métadonnées volatiles des fichiers PE pour TSO lorsque disponibles.</string>
     <string name="fexcore_env_var_help__monohacks">Hacks spéciaux SMC + bloc JIT pour la détection Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Masque le bit hyperviseur CPUID (utile pour les applications qui plantent avec).</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Abilita la compilazione di codice multiblock. Può causare compilazioni JIT più lunghe e scatti.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controlla il forzamento delle funzionalità della CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Scala il TSC sui sistemi a bassa frequenza.</string>
-    <string name="fexcore_env_var_help__smc_checks">Controlli del codice auto-modificante.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Usa i metadati volatili dai file PE per TSO quando disponibili.</string>
     <string name="fexcore_env_var_help__monohacks">Hack speciali SMC + blocco JIT per il rilevamento di Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Nasconde il bit hypervisor CPUID (utile per le app che vanno in crash con esso).</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">멀티블록 코드 컴파일을 활성화합니다. JIT 컴파일 시간이 길어지고 끊김이 발생할 수 있습니다.</string>
     <string name="fexcore_env_var_help__hostfeatures">CPU 기능 강제를 제어합니다.</string>
     <string name="fexcore_env_var_help__smalltscscale">저주파 시스템에서 TSC를 스케일링합니다.</string>
-    <string name="fexcore_env_var_help__smc_checks">자기 수정 코드 검사.</string>
     <string name="fexcore_env_var_help__volatilemetadata">사용 가능한 경우 PE 파일의 휘발성 메타데이터를 TSO에 사용합니다.</string>
     <string name="fexcore_env_var_help__monohacks">Mono 감지를 위한 특수 SMC + JIT 블록 핵.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">CPUID 하이퍼바이저 비트를 숨깁니다 (이로 인해 충돌하는 앱에 유용).</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -469,7 +469,6 @@
     <string name="fexcore_env_var_help__multiblock">Włącza kompilację kodu wieloblokowego. Może powodować dłuższą kompilację JIT i zacinanie.</string>
     <string name="fexcore_env_var_help__hostfeatures">Kontroluje wymuszanie funkcji CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Skaluje TSC na systemach o niskiej częstotliwości.</string>
-    <string name="fexcore_env_var_help__smc_checks">Sprawdzanie samomodyfikującego się kodu.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Używa ulotnych metadanych z plików PE dla TSO, gdy są dostępne.</string>
     <string name="fexcore_env_var_help__monohacks">Specjalne hacki SMC + blokowania JIT do wykrywania Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Ukrywa bit hypervisora w CPUID (przydatne dla aplikacji, które się z nim zawieszają).</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Ativa compilacao de codigo multibloco. Pode causar compilacao JIT mais longa e engasgos.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controla o forcamento de recursos da CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Ajusta escala TSC em sistemas de baixa frequencia.</string>
-    <string name="fexcore_env_var_help__smc_checks">Verificacoes de Codigo Auto-Modificante.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Usa metadados volateis de arquivos PE para TSO quando disponivel.</string>
     <string name="fexcore_env_var_help__monohacks">Hacks especiais de SMC + blocos JIT para deteccao do Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Oculta o bit de hypervisor do CPUID (util para apps que travam com ele).</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">Activeaza compilarea codului multibloc. Poate cauza compilare JIT mai lunga si sacadari.</string>
     <string name="fexcore_env_var_help__hostfeatures">Controleaza fortarea caracteristicilor CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Scaleaza TSC pe sisteme cu frecventa joasa.</string>
-    <string name="fexcore_env_var_help__smc_checks">Verificari cod auto-modificabil.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Foloseste metadate volatile din fisierele PE pentru TSO cand sunt disponibile.</string>
     <string name="fexcore_env_var_help__monohacks">Trucuri speciale SMC + bloc JIT pentru detectia Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Ascunde bitul hypervisor CPUID (util pentru aplicatii care se blocheaza cu acesta).</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -469,7 +469,6 @@
     <string name="fexcore_env_var_help__multiblock">Вмикає компіляцію коду кількома блоками. Може спричинити тривалішу JIT-компіляцію та мікрозатримки.</string>
     <string name="fexcore_env_var_help__hostfeatures">Контролює примусове увімкнення функцій CPU.</string>
     <string name="fexcore_env_var_help__smalltscscale">Масштабує TSC на системах з низькою частотою.</string>
-    <string name="fexcore_env_var_help__smc_checks">Перевірки самомодифікуючогося коду.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Використовує волатильні метадані з PE-файлів для TSO, коли доступні.</string>
     <string name="fexcore_env_var_help__monohacks">Спеціальні хаки SMC + JIT-блоків для виявлення Mono.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Приховує біт гіпервізора CPUID (корисно для додатків, що аварійно завершуються з ним).</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">启用多块代码编译。可能导致更长的 JIT 编译时间和卡顿。</string>
     <string name="fexcore_env_var_help__hostfeatures">控制 CPU 功能强制选项。</string>
     <string name="fexcore_env_var_help__smalltscscale">在低频系统上缩放 TSC。</string>
-    <string name="fexcore_env_var_help__smc_checks">自修改代码检查。</string>
     <string name="fexcore_env_var_help__volatilemetadata">在可用时使用 PE 文件中的易失性元数据进行 TSO。</string>
     <string name="fexcore_env_var_help__monohacks">用于 Mono 检测的特殊 SMC + JIT 块技巧。</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">隐藏 CPUID 虚拟化位（对因此崩溃的应用有用）。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -465,7 +465,6 @@
     <string name="fexcore_env_var_help__multiblock">啟用多區塊程式碼編譯。可能導致較長的 JIT 編譯時間和卡頓。</string>
     <string name="fexcore_env_var_help__hostfeatures">控制 CPU 功能強制啟用。</string>
     <string name="fexcore_env_var_help__smalltscscale">在低頻系統上縮放 TSC。</string>
-    <string name="fexcore_env_var_help__smc_checks">自修改程式碼檢查。</string>
     <string name="fexcore_env_var_help__volatilemetadata">可用時使用 PE 檔案中的易失性中繼資料進行 TSO。</string>
     <string name="fexcore_env_var_help__monohacks">用於 Mono 偵測的特殊 SMC + JIT 區塊技巧。</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">隱藏 CPUID 虛擬機監控位元（適用於因此當機的應用程式）。</string>


### PR DESCRIPTION
The default strings.xml renamed fexcore_env_var_help__smc_checks to fexcore_env_var_help__smcchecks (no underscore) to match the dynamic lookup in PresetsFragment, which derives the resource id from the asset env var name FEX_SMCCHECKS as "smcchecks". The new key was added to every locale, but the old __smc_checks line was left behind in 12 non-default locales — making it an ExtraTranslation orphan that fails assembleRelease lint.

No code path ever resolves __smc_checks; the SMC Checks help text in FEX Presets reads __smcchecks, which is unchanged in every locale.

Removes 12 dead lines, eliminates the lint failure, no UI impact.