### PR TITLE
Fix FEX SMC checks env var

### DIFF
--- a/app/src/main/assets/metadata/box64_env_vars.json
+++ b/app/src/main/assets/metadata/box64_env_vars.json
@@ -18,7 +18,7 @@
     {"name" : "BOX64_DYNAREC_PAUSE", "values" : ["0", "1", "2", "3"], "toggleSwitch" : false, "defaultValue" : "0"},
     {"name" : "BOX64_DYNAREC_NOARCH", "values" : ["0", "1", "2"], "defaultValue" : "0"},
     {"name" : "BOX64_DYNAREC_VOLATILE_METADATA", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
-    {"name" : "BOX64_AVX", "values" : ["0", "1", "2"], "defaultValue" : "2"},
+    {"name" : "BOX64_AVX", "values" : ["0", "1", "2"], "defaultValue" : "0"},
     {"name" : "BOX64_AES", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "BOX64_PCLMULQDQ", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "BOX64_SHAEXT", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},

--- a/app/src/main/assets/metadata/fexcore_env_vars.json
+++ b/app/src/main/assets/metadata/fexcore_env_vars.json
@@ -15,8 +15,8 @@
     {"name" : "FEX_VOLATILEMETADATA", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_MONOHACKS", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_HIDEHYPERVISORBIT", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "0"},
-    {"name" : "FEX_DISABLEL2CACHE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
-    {"name" : "FEX_DYNAMICL1CACHE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
+    {"name" : "FEX_DISABLEL2CACHE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "0"},
+    {"name" : "FEX_DYNAMICL1CACHE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "0"},
     {"name" : "FEX_DYNAMICL1CACHEINCREASECOUNTHEURISTIC", "values" : ["250"], "editText" : true, "defaultValue" : "250"},
     {"name" : "FEX_DYNAMICL1CACHEDECREASECOUNTHEURISTIC", "values" : ["50"], "editText" : true, "defaultValue" : "50"}
 ]

--- a/app/src/main/assets/metadata/fexcore_env_vars.json
+++ b/app/src/main/assets/metadata/fexcore_env_vars.json
@@ -11,7 +11,7 @@
     {"name" : "FEX_HOSTFEATURES", "values" : ["off", "enablesve", "disablesve", "enableavx", "disableavx", "enableafp", "disableafp", "enablelrcpc", "disablelrcpc", "enablelrcpc2", "disablelrcpc2", "enablecssc", "disablecssc", "enablepmull128", "disablepmull128", "enablerng", "disablerng", "enableclzero", "disableclzero", "enableatomics", "disableatomics", "enablefcma", "disablefcma", "enableflagm", "disableflagm", "enableflagm2", "disableflagm2", "enablefrintts", "disablefrintts", "enablecrypto", "disablecrypto", "enablerpres", "disablerpres", "enablesvebitperm", "disablesvebitperm", "enablepreserveallabi", "disablepreserveallabi", "enablewfxt", "disablewfxt", "enable3dnow", "disable3dnow", "enablesse4a", "disablesse4a", "enablemops", "disablemops"], "defaultValue" : "off"},
     {"name" : "FEX_SMALLTSCSCALE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_HIDEHYBRID", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
-    {"name" : "FEX_SMC_CHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
+    {"name" : "FEX_SMCCHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
     {"name" : "FEX_VOLATILEMETADATA", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_MONOHACKS", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_HIDEHYPERVISORBIT", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "0"},

--- a/app/src/main/assets/metadata/fexcore_env_vars.json
+++ b/app/src/main/assets/metadata/fexcore_env_vars.json
@@ -11,7 +11,7 @@
     {"name" : "FEX_HOSTFEATURES", "values" : ["off", "enablesve", "disablesve", "enableavx", "disableavx", "enableafp", "disableafp", "enablelrcpc", "disablelrcpc", "enablelrcpc2", "disablelrcpc2", "enablecssc", "disablecssc", "enablepmull128", "disablepmull128", "enablerng", "disablerng", "enableclzero", "disableclzero", "enableatomics", "disableatomics", "enablefcma", "disablefcma", "enableflagm", "disableflagm", "enableflagm2", "disableflagm2", "enablefrintts", "disablefrintts", "enablecrypto", "disablecrypto", "enablerpres", "disablerpres", "enablesvebitperm", "disablesvebitperm", "enablepreserveallabi", "disablepreserveallabi", "enablewfxt", "disablewfxt", "enable3dnow", "disable3dnow", "enablesse4a", "disablesse4a", "enablemops", "disablemops"], "defaultValue" : "off"},
     {"name" : "FEX_SMALLTSCSCALE", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_HIDEHYBRID", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
-    {"name" : "FEX_SMCCHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
+    {"name" : "FEX_SMC_CHECKS", "values" : ["none", "mtrack", "full"], "defaultValue" : "mtrack"},
     {"name" : "FEX_VOLATILEMETADATA", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_MONOHACKS", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "1"},
     {"name" : "FEX_HIDEHYPERVISORBIT", "values" : ["0", "1"], "toggleSwitch" : true, "defaultValue" : "0"},

--- a/app/src/main/feature/settings/presets/PresetsFragment.kt
+++ b/app/src/main/feature/settings/presets/PresetsFragment.kt
@@ -412,7 +412,11 @@ class PresetsFragment : Fragment() {
         val suffix =
             when (engine) {
                 PresetEngine.BOX64 -> envVarName.removePrefix("BOX64_").lowercase(Locale.ENGLISH)
-                PresetEngine.FEXCORE -> envVarName.removePrefix("FEX_").lowercase(Locale.ENGLISH)
+                PresetEngine.FEXCORE ->
+                    when (envVarName) {
+                        "FEX_SMCCHECKS" -> "smc_checks"
+                        else -> envVarName.removePrefix("FEX_").lowercase(Locale.ENGLISH)
+                    }
             }
         return StringUtils.getString(requireContext(), "${engine.helpKeyPrefix}$suffix").orEmpty()
     }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1040,6 +1040,5 @@ Installeret sti:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Kontrol af selvmodificerende kode.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1040,6 +1040,5 @@ Installierter Pfad:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Prüfungen für selbstmodifizierenden Code.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1040,6 +1040,5 @@ Ruta instalada:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Verificaciones de código automodificable.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1040,6 +1040,5 @@ Chemin installé :
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Vérifications de code auto-modifiant.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1040,6 +1040,5 @@ Percorso installato:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Controlli del codice auto-modificante.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1040,6 +1040,5 @@
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">자기 수정 코드 검사.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1044,6 +1044,5 @@ Zainstalowana ścieżka:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Sprawdzanie samomodyfikującego się kodu.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1040,6 +1040,5 @@ Caminho instalado:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Verificacoes de Codigo Auto-Modificante.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1040,6 +1040,5 @@ Cale instalata:
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Verificari cod auto-modificabil.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1044,6 +1044,5 @@
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">Перевірки самомодифікуючогося коду.</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1040,6 +1040,5 @@
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">自修改代码检查。</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1040,6 +1040,5 @@
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
     <string name="fexcore_env_var_help__kernelunalignedatomicbackpatching">Backpatches kernel-handled unaligned atomics to reduce kernel context switches.</string>
     <string name="fexcore_env_var_help__maxinst">Maximum number of instructions stored in a compiled block.</string>
-    <string name="fexcore_env_var_help__smcchecks">自修改程式碼檢查。</string>
     <string name="fexcore_env_var_help__strictinprocesssplitlocks">Uses a strict process-wide lock for split unaligned atomic accesses.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -528,7 +528,7 @@
     <string name="fexcore_env_var_help__hostfeatures">Controls CPU feature forcing.</string>
     <string name="fexcore_env_var_help__smalltscscale">Scales TSC on low-frequency systems.</string>
     <string name="fexcore_env_var_help__hidehybrid">Hides hybrid CPU core layout from the guest.</string>
-    <string name="fexcore_env_var_help__smcchecks">Checks code for modification before execution.</string>
+    <string name="fexcore_env_var_help__smc_checks">Checks code for modification before execution.</string>
     <string name="fexcore_env_var_help__volatilemetadata">Uses volatile metadata from PE files for TSO when available.</string>
     <string name="fexcore_env_var_help__monohacks">Special SMC + JIT block hacks for Mono detection.</string>
     <string name="fexcore_env_var_help__hidehypervisorbit">Hides CPUID hypervisor bit (useful for apps that crash with it).</string>

--- a/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
+++ b/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
@@ -65,8 +65,34 @@ public class FEXCorePresetManager {
       }
     }
 
+    normalizeSmcChecksEnvVars(envVars);
     Log.d(TAG, "getEnvVars resolved presetId='" + id + "' -> envVars='" + envVars.toString() + "'");
     return envVars;
+  }
+
+  public static void normalizeSmcChecksEnvVars(EnvVars envVars) {
+    normalizeSmcChecksEnvVars(envVars, null);
+  }
+
+  public static void normalizeSmcChecksEnvVars(EnvVars envVars, EnvVars preferredEnvVars) {
+    String smcChecks = envVars.get("FEX_SMCCHECKS");
+    String legacySmcChecks = envVars.get("FEX_SMC_CHECKS");
+    if (preferredEnvVars != null) {
+      String preferredSmcChecks = preferredEnvVars.get("FEX_SMCCHECKS");
+      String preferredLegacySmcChecks = preferredEnvVars.get("FEX_SMC_CHECKS");
+      if (!preferredSmcChecks.isEmpty()) {
+        smcChecks = preferredSmcChecks;
+      } else if (!preferredLegacySmcChecks.isEmpty()) {
+        smcChecks = preferredLegacySmcChecks;
+      }
+    }
+    if (smcChecks.isEmpty()) {
+      smcChecks = legacySmcChecks;
+    }
+    if (!smcChecks.isEmpty()) {
+      envVars.put("FEX_SMCCHECKS", smcChecks);
+      envVars.put("FEX_SMC_CHECKS", smcChecks);
+    }
   }
 
   public static ArrayList<FEXCorePreset> getPresets(Context context) {

--- a/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
+++ b/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
@@ -65,21 +65,8 @@ public class FEXCorePresetManager {
       }
     }
 
-    normalizeLegacyEnvVars(envVars);
     Log.d(TAG, "getEnvVars resolved presetId='" + id + "' -> envVars='" + envVars.toString() + "'");
     return envVars;
-  }
-
-  private static void normalizeLegacyEnvVars(EnvVars envVars) {
-    String smcChecks = envVars.get("FEX_SMC_CHECKS");
-    String legacySmcChecks = envVars.get("FEX_SMCCHECKS");
-    if (smcChecks.isEmpty()) {
-      smcChecks = legacySmcChecks;
-    }
-    if (!smcChecks.isEmpty()) {
-      envVars.put("FEX_SMC_CHECKS", smcChecks);
-      envVars.put("FEX_SMCCHECKS", smcChecks);
-    }
   }
 
   public static ArrayList<FEXCorePreset> getPresets(Context context) {

--- a/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
+++ b/app/src/main/runtime/compat/fexcore/FEXCorePresetManager.java
@@ -65,8 +65,21 @@ public class FEXCorePresetManager {
       }
     }
 
+    normalizeLegacyEnvVars(envVars);
     Log.d(TAG, "getEnvVars resolved presetId='" + id + "' -> envVars='" + envVars.toString() + "'");
     return envVars;
+  }
+
+  private static void normalizeLegacyEnvVars(EnvVars envVars) {
+    String smcChecks = envVars.get("FEX_SMC_CHECKS");
+    String legacySmcChecks = envVars.get("FEX_SMCCHECKS");
+    if (smcChecks.isEmpty()) {
+      smcChecks = legacySmcChecks;
+    }
+    if (!smcChecks.isEmpty()) {
+      envVars.put("FEX_SMC_CHECKS", smcChecks);
+      envVars.put("FEX_SMCCHECKS", smcChecks);
+    }
   }
 
   public static ArrayList<FEXCorePreset> getPresets(Context context) {

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -237,6 +237,7 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     }
     envVars.put("WINEESYNC_WINLATOR", "1");
     mergeExternalEnvVars(envVars, envVars.get("LD_PRELOAD"), envVars.get("FAKE_EVDEV_DIR"));
+    FEXCorePresetManager.normalizeSmcChecksEnvVars(envVars, this.envVars);
 
     // For arm64ec Wine builds the wine binary is native ARM64 — call it directly
     // with a fully-qualified path. Wrapping with box64 causes it to fail ELF
@@ -822,6 +823,7 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     // Preserve the launcher-owned preload/input paths while restoring the
     // full env built upstream in XServerDisplayActivity (driver, DXVK, Vulkan, etc).
     mergeExternalEnvVars(envVars, envVars.get("LD_PRELOAD"), envVars.get("FAKE_EVDEV_DIR"));
+    FEXCorePresetManager.normalizeSmcChecksEnvVars(envVars, this.envVars);
 
     String emulator = container.getEmulator();
     String emulator64 = container.getEmulator64();


### PR DESCRIPTION
## Summary
- Restore the FEX SMC checks preset metadata key to the canonical `FEX_SMCCHECKS` name used by FEX.
- Remove the `FEX_SMC_CHECKS` alias/normalization path so launches emit only the canonical variable.
- Keep the preset UI help text working by mapping `FEX_SMCCHECKS` to the existing `fexcore_env_var_help__smc_checks` strings.

## Root cause
The prior change renamed the preset metadata to `FEX_SMC_CHECKS`, but current upstream FEX still exposes the option as `SMCCHECKS`, which maps to the environment variable `FEX_SMCCHECKS`. If `none` is saved under the wrong env var name, FEX can ignore it and fall back to the default `mtrack` behavior.

## Validation
- Confirmed upstream FEX `main` still uses `FEX_CONFIG_OPT(SMCChecks, SMCCHECKS)` and accepts `none`, `mtrack`, and `full` through `SMCCheckHandler`.
- Ran `git diff --check` successfully.
- Attempted Gradle compile, but this machine has no Java available (`JAVA_HOME` is unset and `java` is not on `PATH`).