### PR TITLE
Fix setup container dialog scaling

### DIFF
--- a/.github/workflows/pr-release-publish.yml
+++ b/.github/workflows/pr-release-publish.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
     env:
       SOURCE_REPO: ${{ github.repository }}
-      TARGET_REPO: MaxsTechReview/WinNative-CI
+      TARGET_REPO: WinNative-Emu/WinNative-CI
       RUN_ID: ${{ github.event.workflow_run.id }}
       HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -148,7 +148,7 @@ jobs:
         if: ${{ steps.scope.outputs.allowed == 'true' }}
         id: release
         env:
-          # Use a fine-grained PAT scoped only to MaxsTechReview/WinNative-CI
+          # Use a fine-grained PAT scoped only to WinNative-Emu/WinNative-CI
           # with "Contents" repository permission set to write.
           GH_TOKEN: ${{ secrets.WINNATIVE_CI_TOKEN }}
           PR_NUMBER: ${{ steps.scope.outputs.pr_number }}

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -2753,9 +2753,19 @@ class UnifiedActivity :
     ) {
         Dialog(
             onDismissRequest = onDismissRequest,
-            properties = DialogProperties(usePlatformDefaultWidth = false),
+            properties =
+                DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
         ) {
-            BoxWithConstraints(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            BoxWithConstraints(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(WindowInsets.navigationBars),
+                contentAlignment = Alignment.Center,
+            ) {
                 val widthModifier =
                     if (wide) {
                         Modifier.widthIn(min = 320.dp, max = (maxWidth - 32.dp).coerceAtMost(560.dp))
@@ -5920,9 +5930,20 @@ class UnifiedActivity :
         infoContent: @Composable ColumnScope.() -> Unit = {},
         actionsContent: @Composable ColumnScope.() -> Unit,
     ) {
-        Dialog(onDismissRequest = onDismissRequest, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties =
+                DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
+        ) {
             Surface(
-                modifier = Modifier.fillMaxWidth(0.864f).fillMaxHeight(0.92f),
+                modifier =
+                    Modifier
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .fillMaxWidth(0.864f)
+                        .fillMaxHeight(0.92f),
                 shape = RoundedCornerShape(20.dp),
                 color = CardDark,
             ) {

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -7651,18 +7651,38 @@ class UnifiedActivity :
                                 stringResource(R.string.downloads_queue_phase_unknown)
                             }
                         }
+                    val statusColor =
+                        when (status) {
+                            DownloadPhase.COMPLETE -> StatusOnline
+                            DownloadPhase.FAILED,
+                            DownloadPhase.CANCELLED,
+                            -> DangerRed
+                            DownloadPhase.PAUSED,
+                            DownloadPhase.QUEUED,
+                            -> StatusAway
+                            DownloadPhase.DOWNLOADING,
+                            DownloadPhase.PREPARING,
+                            DownloadPhase.VERIFYING,
+                            DownloadPhase.PATCHING,
+                            DownloadPhase.APPLYING_DATA,
+                            DownloadPhase.FINALIZING,
+                            DownloadPhase.UNPACKING,
+                            -> Accent
+                            else -> TextSecondary
+                        }
 
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                         Text(
                             stringResource(R.string.downloads_queue_status_label),
                             style = MaterialTheme.typography.bodySmall,
-                            color = TextPrimary,
+                            color = TextSecondary,
                             maxLines = 1,
                         )
+                        Spacer(Modifier.width(4.dp))
                         Text(
                             statusText,
                             style = MaterialTheme.typography.bodySmall,
-                            color = if (status == DownloadPhase.COMPLETE) StatusOnline else TextPrimary,
+                            color = statusColor,
                             modifier = Modifier.weight(1f),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -2812,6 +2812,7 @@ private fun EnvVarValueEditor(
             )
         }
         "NUMBER" -> EnvValueTextField(value, onValueChange, numeric = true)
+        "DECIMAL" -> EnvValueTextField(value, onValueChange, decimal = true)
         else -> EnvValueTextField(value, onValueChange, numeric = false)
     }
 }
@@ -2952,7 +2953,8 @@ private fun EnvValueMultiDropdown(
 private fun EnvValueTextField(
     value: String,
     onValueChange: (String) -> Unit,
-    numeric: Boolean
+    numeric: Boolean = false,
+    decimal: Boolean = false
 ) {
     BasicTextField(
         value = value,
@@ -2960,9 +2962,11 @@ private fun EnvValueTextField(
         textStyle = TextStyle(color = TextPrimary, fontSize = 13.sp),
         cursorBrush = SolidColor(AccentBlue),
         singleLine = true,
-        keyboardOptions = if (numeric)
-            KeyboardOptions(keyboardType = KeyboardType.Number)
-        else KeyboardOptions.Default,
+        keyboardOptions = when {
+            numeric -> KeyboardOptions(keyboardType = KeyboardType.Number)
+            decimal -> KeyboardOptions(keyboardType = KeyboardType.Decimal)
+            else -> KeyboardOptions.Default
+        },
         modifier = Modifier.fillMaxWidth(),
         decorationBox = { innerTextField ->
             Box(

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -122,6 +122,7 @@ private val SettingGroupPadding = 12.dp
 private val SettingFieldCorner = 8.dp
 private val SettingFieldHorizontalPadding = 12.dp
 private val SettingFieldVerticalPadding = 8.dp
+private val EnvVarControlHeight = 36.dp
 private val SettingItemGap = 10.dp
 private val SettingSectionGap = 12.dp
 private val SettingTightGap = 4.dp
@@ -2510,6 +2511,7 @@ private fun EnvVarRow(
                     singleLine = true,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .heightIn(min = EnvVarControlHeight)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
@@ -2529,6 +2531,7 @@ private fun EnvVarRow(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .heightIn(min = EnvVarControlHeight)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
@@ -2695,6 +2698,7 @@ private fun EnvValueDropdown(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .heightIn(min = EnvVarControlHeight)
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
@@ -2755,6 +2759,7 @@ private fun EnvValueMultiDropdown(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .heightIn(min = EnvVarControlHeight)
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
@@ -2836,6 +2841,7 @@ private fun EnvValueTextField(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .heightIn(min = EnvVarControlHeight)
                     .clip(RoundedCornerShape(8.dp))
                     .background(InputSurface)
                     .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -2511,32 +2511,34 @@ private fun EnvVarRow(
                     singleLine = true,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = EnvVarControlHeight)
+                        .height(EnvVarControlHeight)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                        .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
+                        .padding(horizontal = SettingFieldHorizontalPadding),
                     decorationBox = { innerTextField ->
-                        if (customText.isEmpty()) {
-                            Text(
-                                stringResource(R.string.container_config_new_env_var),
-                                color = TextDim,
-                                fontSize = SettingValueSize
-                            )
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.CenterStart) {
+                            if (customText.isEmpty()) {
+                                Text(
+                                    stringResource(R.string.container_config_new_env_var),
+                                    color = TextDim,
+                                    fontSize = SettingValueSize
+                                )
+                            }
+                            innerTextField()
                         }
-                        innerTextField()
                     }
                 )
             } else {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = EnvVarControlHeight)
+                        .height(EnvVarControlHeight)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                         .clickable { nameMenuExpanded = true }
-                        .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
+                        .padding(horizontal = SettingFieldHorizontalPadding),
                     contentAlignment = Alignment.CenterStart
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -2698,12 +2700,12 @@ private fun EnvValueDropdown(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = EnvVarControlHeight)
+                .height(EnvVarControlHeight)
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                 .clickable { expanded = true }
-                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
+                .padding(horizontal = SettingFieldHorizontalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -2759,12 +2761,12 @@ private fun EnvValueMultiDropdown(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = EnvVarControlHeight)
+                .height(EnvVarControlHeight)
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                 .clickable { expanded = true }
-                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
+                .padding(horizontal = SettingFieldHorizontalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -2836,16 +2838,18 @@ private fun EnvValueTextField(
         keyboardOptions = if (numeric)
             KeyboardOptions(keyboardType = KeyboardType.Number)
         else KeyboardOptions.Default,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(EnvVarControlHeight),
         decorationBox = { innerTextField ->
             Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = EnvVarControlHeight)
+                    .fillMaxSize()
                     .clip(RoundedCornerShape(8.dp))
                     .background(InputSurface)
                     .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                    .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
+                    .padding(horizontal = SettingFieldHorizontalPadding),
+                contentAlignment = Alignment.CenterStart
             ) {
                 if (value.isEmpty()) {
                     Text(stringResource(R.string.common_ui_value), color = TextDim, fontSize = SettingValueSize)

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.animation.AnimatedVisibility
@@ -63,6 +64,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -77,6 +79,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -86,6 +90,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -131,6 +136,26 @@ private val SettingControlIconSize = 16.dp
 private val SettingLabelSize = 11.sp
 private val SettingValueSize = 13.sp
 private val SettingSectionLabelSize = 12.sp
+
+@Composable
+private fun rememberSmartDropdownOffset(): MutableState<DpOffset> =
+    remember { mutableStateOf(DpOffset.Zero) }
+
+@Composable
+private fun Modifier.smartDropdownAnchor(
+    enabled: Boolean = true,
+    offset: MutableState<DpOffset>,
+    onOpen: () -> Unit,
+): Modifier {
+    if (!enabled) return this
+    val density = LocalDensity.current
+    return pointerInput(enabled, density, onOpen) {
+        detectTapGestures { tapOffset ->
+            offset.value = with(density) { DpOffset(tapOffset.x.toDp(), 0.dp) }
+            onOpen()
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Data classes
@@ -1927,6 +1952,7 @@ private fun WineSection(
             }
             Spacer(Modifier.width(8.dp))
             var showLocalePicker by remember { mutableStateOf(false) }
+            val localeMenuOffset = rememberSmartDropdownOffset()
             Box(
                 modifier = Modifier.padding(top = 22.dp)
             ) {
@@ -1936,7 +1962,7 @@ private fun WineSection(
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
-                        .clickable { showLocalePicker = true },
+                        .smartDropdownAnchor(offset = localeMenuOffset) { showLocalePicker = true },
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
@@ -1949,6 +1975,7 @@ private fun WineSection(
                 DropdownMenu(
                     expanded = showLocalePicker,
                     onDismissRequest = { showLocalePicker = false },
+                    offset = localeMenuOffset.value,
                     shape = RoundedCornerShape(8.dp),
                     containerColor = CardSurface,
                     modifier = Modifier.height(300.dp)
@@ -2395,6 +2422,7 @@ private fun DriveLetterSelector(
     onSelected: (String) -> Unit,
 ) {
     var expanded by remember(selectedLetter, availableLetters) { mutableStateOf(false) }
+    val menuOffset = rememberSmartDropdownOffset()
     val showDropdown = canChangeLetter && availableLetters.size > 1
 
     Box {
@@ -2406,11 +2434,7 @@ private fun DriveLetterSelector(
                     .clip(RoundedCornerShape(6.dp))
                     .background(AccentBlue.copy(alpha = 0.1f))
                     .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
-                    .clickable(
-                        enabled = showDropdown,
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                    ) { expanded = true }
+                    .smartDropdownAnchor(enabled = showDropdown, offset = menuOffset) { expanded = true }
                     .padding(horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
@@ -2435,6 +2459,7 @@ private fun DriveLetterSelector(
         DropdownMenu(
             expanded = showDropdown && expanded,
             onDismissRequest = { expanded = false },
+            offset = menuOffset.value,
             shape = RoundedCornerShape(8.dp),
             containerColor = CardSurface,
             modifier = Modifier.widthIn(min = 88.dp),
@@ -2482,6 +2507,7 @@ private fun EnvVarRow(
     trailing: (@Composable () -> Unit)? = null
 ) {
     var nameMenuExpanded by remember { mutableStateOf(false) }
+    val nameMenuOffset = rememberSmartDropdownOffset()
     var isCustomMode by remember(name) {
         mutableStateOf(name.isNotEmpty() && findKnownEnvVar(name) == null)
     }
@@ -2537,7 +2563,7 @@ private fun EnvVarRow(
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                        .clickable { nameMenuExpanded = true }
+                        .smartDropdownAnchor(offset = nameMenuOffset) { nameMenuExpanded = true }
                         .padding(horizontal = SettingFieldHorizontalPadding),
                     contentAlignment = Alignment.CenterStart
                 ) {
@@ -2562,6 +2588,7 @@ private fun EnvVarRow(
             DropdownMenu(
                 expanded = nameMenuExpanded,
                 onDismissRequest = { nameMenuExpanded = false },
+                offset = nameMenuOffset.value,
                 shape = RoundedCornerShape(8.dp),
                 containerColor = CardSurface,
                 modifier = Modifier
@@ -2696,6 +2723,7 @@ private fun EnvValueDropdown(
     onSelected: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val menuOffset = rememberSmartDropdownOffset()
     Box {
         Box(
             modifier = Modifier
@@ -2704,7 +2732,7 @@ private fun EnvValueDropdown(
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                .clickable { expanded = true }
+                .smartDropdownAnchor(offset = menuOffset) { expanded = true }
                 .padding(horizontal = SettingFieldHorizontalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
@@ -2728,6 +2756,7 @@ private fun EnvValueDropdown(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
+            offset = menuOffset.value,
             shape = RoundedCornerShape(8.dp),
             containerColor = CardSurface,
             modifier = Modifier.width(220.dp)
@@ -2754,6 +2783,7 @@ private fun EnvValueMultiDropdown(
     onChanged: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val menuOffset = rememberSmartDropdownOffset()
     val selectedSet = remember(current) {
         current.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toMutableSet()
     }
@@ -2765,7 +2795,7 @@ private fun EnvValueMultiDropdown(
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                .clickable { expanded = true }
+                .smartDropdownAnchor(offset = menuOffset) { expanded = true }
                 .padding(horizontal = SettingFieldHorizontalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
@@ -2789,6 +2819,7 @@ private fun EnvValueMultiDropdown(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
+            offset = menuOffset.value,
             shape = RoundedCornerShape(8.dp),
             containerColor = CardSurface,
             modifier = Modifier
@@ -2963,6 +2994,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 )
             }
             var showXInputHelp by remember { mutableStateOf(false) }
+            val xInputHelpOffset = rememberSmartDropdownOffset()
             Box {
                 Box(
                     modifier = Modifier
@@ -2970,7 +3002,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                         .clip(RoundedCornerShape(6.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(6.dp))
-                        .clickable { showXInputHelp = !showXInputHelp },
+                        .smartDropdownAnchor(offset = xInputHelpOffset) { showXInputHelp = !showXInputHelp },
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
@@ -2983,6 +3015,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 DropdownMenu(
                     expanded = showXInputHelp,
                     onDismissRequest = { showXInputHelp = false },
+                    offset = xInputHelpOffset.value,
                     shape = RoundedCornerShape(8.dp),
                     containerColor = CardSurface,
                     modifier = Modifier
@@ -3015,6 +3048,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 )
             }
             var showDInputHelp by remember { mutableStateOf(false) }
+            val dInputHelpOffset = rememberSmartDropdownOffset()
             Box {
                 Box(
                     modifier = Modifier
@@ -3022,7 +3056,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                         .clip(RoundedCornerShape(6.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(6.dp))
-                        .clickable { showDInputHelp = !showDInputHelp },
+                        .smartDropdownAnchor(offset = dInputHelpOffset) { showDInputHelp = !showDInputHelp },
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
@@ -3035,6 +3069,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 DropdownMenu(
                     expanded = showDInputHelp,
                     onDismissRequest = { showDInputHelp = false },
+                    offset = dInputHelpOffset.value,
                     shape = RoundedCornerShape(8.dp),
                     containerColor = CardSurface,
                     modifier = Modifier
@@ -3302,6 +3337,7 @@ private fun AdvancedSection(
 @Composable
 private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
+    val menuOffset = rememberSmartDropdownOffset()
 
     Box(modifier = Modifier.padding(top = 22.dp)) {
         Box(
@@ -3310,7 +3346,7 @@ private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
-                .clickable { expanded = true },
+                .smartDropdownAnchor(offset = menuOffset) { expanded = true },
             contentAlignment = Alignment.Center
         ) {
             Icon(
@@ -3324,6 +3360,7 @@ private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
+            offset = menuOffset.value,
             shape = RoundedCornerShape(8.dp),
             containerColor = CardSurface,
             modifier = Modifier
@@ -3531,6 +3568,7 @@ private fun SettingDropdown(
     enabled: Boolean = true
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val menuOffset = rememberSmartDropdownOffset()
     val selectedText = entries.getOrElse(selectedIndex) { "" }
     val alpha = if (enabled) 1f else 0.4f
 
@@ -3550,7 +3588,7 @@ private fun SettingDropdown(
                     .clip(RoundedCornerShape(SettingFieldCorner))
                     .background(InputSurface)
                     .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
-                    .then(if (enabled) Modifier.clickable { expanded = true } else Modifier)
+                    .smartDropdownAnchor(enabled = enabled, offset = menuOffset) { expanded = true }
                     .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -3571,6 +3609,7 @@ private fun SettingDropdown(
             DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
+                offset = menuOffset.value,
                 shape = RoundedCornerShape(8.dp),
                 containerColor = CardSurface,
             ) {

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -118,6 +118,20 @@ private val DangerRed = Color(0xFFFF6B6B)
 private val WarningAmber = Color(0xFFFFB74D)
 private val SelectableDriveLetters = ('D'..'Y').filter { it != 'E' }.map { "$it" }
 
+private val SettingGroupCorner = 12.dp
+private val SettingGroupPadding = 12.dp
+private val SettingFieldCorner = 8.dp
+private val SettingFieldHorizontalPadding = 12.dp
+private val SettingFieldVerticalPadding = 8.dp
+private val SettingItemGap = 10.dp
+private val SettingSectionGap = 12.dp
+private val SettingTightGap = 4.dp
+private val SettingIconSize = 18.dp
+private val SettingControlIconSize = 16.dp
+private val SettingLabelSize = 11.sp
+private val SettingValueSize = 13.sp
+private val SettingSectionLabelSize = 12.sp
+
 // ---------------------------------------------------------------------------
 // Data classes
 // ---------------------------------------------------------------------------
@@ -489,7 +503,7 @@ fun GameSettingsContent(
                     onSave = { callbacks.onConfirm() },
                     onCancel = { callbacks.onDismiss() },
                     modifier = Modifier
-                        .width(220.dp)
+                        .width(200.dp)
                         .fillMaxHeight()
                 )
 
@@ -536,12 +550,12 @@ private fun SectionContent(
         label = "SectionTransition"
     ) { id ->
         val scrollState = rememberScrollState()
-        val hPad = if (isCompact) 16.dp else 28.dp
+        val hPad = if (isCompact) 12.dp else 20.dp
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(horizontal = hPad, vertical = 20.dp)
+                .padding(horizontal = hPad, vertical = 14.dp)
         ) {
             when (id) {
                 SEC_GENERAL -> GeneralSection(state, callbacks)
@@ -553,7 +567,7 @@ private fun SectionContent(
                 SEC_INPUT -> InputSection(state)
                 SEC_ADVANCED -> AdvancedSection(state, callbacks)
             }
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(SettingSectionGap))
         }
     }
 }
@@ -573,8 +587,8 @@ private fun CompactTopBar(
             .fillMaxWidth()
             .background(SidebarBg)
             .horizontalScroll(scrollState)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         sections.forEachIndexed { index, (_, section) ->
             val isSelected = currentIndex == index
@@ -588,20 +602,20 @@ private fun CompactTopBar(
                         indication = null,
                         onClick = { onSectionSelected(index) }
                     )
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         section.icon,
                         contentDescription = null,
                         tint = if (isSelected) AccentBlue else TextDim,
-                        modifier = Modifier.size(16.dp)
+                        modifier = Modifier.size(SettingControlIconSize)
                     )
-                    Spacer(Modifier.width(6.dp))
+                    Spacer(Modifier.width(5.dp))
                     Text(
                         stringResource(section.labelResId),
                         color = if (isSelected) TextPrimary else TextSecondary,
-                        fontSize = 12.sp,
+                        fontSize = SettingLabelSize,
                         fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
                         maxLines = 1
                     )
@@ -622,7 +636,7 @@ private fun CompactBottomBar(
         modifier = Modifier
             .fillMaxWidth()
             .background(SidebarBg)
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -631,7 +645,7 @@ private fun CompactBottomBar(
             Text(
                 text = title,
                 color = TextPrimary,
-                fontSize = 12.sp,
+                fontSize = SettingLabelSize,
                 fontWeight = FontWeight.SemiBold,
                 letterSpacing = 0.2.sp,
                 lineHeight = 15.sp,
@@ -646,17 +660,17 @@ private fun CompactBottomBar(
         // Smaller right-aligned Cancel / Save buttons
         Box(
             modifier = Modifier
-                .height(28.dp)
+                .height(26.dp)
                 .clip(RoundedCornerShape(7.dp))
                 .border(1.dp, CardBorder, RoundedCornerShape(7.dp))
                 .background(CardSurface)
                 .clickable { onCancel() }
-                .padding(horizontal = 14.dp),
+                .padding(horizontal = 12.dp),
             contentAlignment = Alignment.Center
         ) {
-            Text(stringResource(R.string.common_ui_cancel), color = TextSecondary, fontSize = 11.sp, fontWeight = FontWeight.Medium)
+            Text(stringResource(R.string.common_ui_cancel), color = TextSecondary, fontSize = SettingLabelSize, fontWeight = FontWeight.Medium)
         }
-        SaveButton(enabled = saveEnabled, onClick = onSave, height = 28.dp, corner = 7.dp, fontSize = 11.sp)
+        SaveButton(enabled = saveEnabled, onClick = onSave, height = 26.dp, corner = 7.dp, fontSize = SettingLabelSize)
     }
 }
 
@@ -677,14 +691,14 @@ private fun Sidebar(
     Column(
         modifier = modifier
             .background(SidebarBg)
-            .padding(top = 18.dp, bottom = 16.dp)
+            .padding(top = 14.dp, bottom = 12.dp)
     ) {
         // Header: shortcut/game title being edited
         if (title.isNotBlank()) {
             Text(
                 text = title,
                 color = TextPrimary,
-                fontSize = 12.sp,
+                fontSize = SettingLabelSize,
                 fontWeight = FontWeight.SemiBold,
                 letterSpacing = 0.2.sp,
                 lineHeight = 15.sp,
@@ -692,17 +706,17 @@ private fun Sidebar(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 12.dp)
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 10.dp)
             )
             Box(
                 modifier = Modifier
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = 12.dp)
                     .fillMaxWidth()
                     .height(1.dp)
                     .background(DividerColor)
             )
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(8.dp))
         }
 
         // Sidebar items
@@ -710,8 +724,8 @@ private fun Sidebar(
             modifier = Modifier
                 .weight(1f)
                 .verticalScroll(rememberScrollState())
-                .padding(bottom = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
+                .padding(bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(1.dp)
         ) {
             sections.forEachIndexed { index, section ->
                 SidebarItem(
@@ -726,24 +740,24 @@ private fun Sidebar(
         // Divider above the action buttons (matches the one under the title)
         Box(
             modifier = Modifier
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 12.dp)
                 .fillMaxWidth()
                 .height(1.dp)
                 .background(DividerColor)
         )
-        Spacer(Modifier.height(10.dp))
+        Spacer(Modifier.height(8.dp))
 
         // Cancel + Save buttons
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .height(32.dp)
+                    .height(30.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .border(1.dp, CardBorder, RoundedCornerShape(8.dp))
                     .background(CardSurface)
@@ -753,16 +767,16 @@ private fun Sidebar(
                 Text(
                     stringResource(R.string.common_ui_cancel),
                     color = TextSecondary,
-                    fontSize = 12.sp,
+                    fontSize = SettingLabelSize,
                     fontWeight = FontWeight.Medium
                 )
             }
             SaveButton(
                 enabled = saveEnabled,
                 onClick = onSave,
-                height = 32.dp,
+                height = 30.dp,
                 corner = 8.dp,
-                fontSize = 12.sp,
+                fontSize = SettingLabelSize,
                 modifier = Modifier.weight(1f)
             )
         }
@@ -813,28 +827,28 @@ private fun SidebarItem(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 10.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .chasingBorder(isFocused = isSelected, cornerRadius = 10.dp, borderWidth = 2.dp)
+            .padding(horizontal = 8.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .chasingBorder(isFocused = isSelected, cornerRadius = 8.dp, borderWidth = 2.dp)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
                 onClick = onClick
             )
-            .padding(horizontal = 14.dp, vertical = 11.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 icon,
                 contentDescription = null,
                 tint = if (isSelected) AccentBlue else TextDim,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
-            Spacer(Modifier.width(12.dp))
+            Spacer(Modifier.width(10.dp))
             Text(
                 label,
                 color = if (isSelected) TextPrimary else TextSecondary,
-                fontSize = 13.sp,
+                fontSize = SettingValueSize,
                 fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 1
             )
@@ -872,12 +886,12 @@ private fun GeneralSection(
                     .background(tint.copy(alpha = 0.08f))
                     .border(1.dp, tint.copy(alpha = 0.2f), RoundedCornerShape(9.dp))
                     .clickable { onClick() }
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
             ) {
                 Text(
                     text = text,
                     color = tint,
-                    fontSize = 12.sp,
+                    fontSize = SettingLabelSize,
                     fontWeight = FontWeight.Medium
                 )
             }
@@ -886,15 +900,15 @@ private fun GeneralSection(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(SettingGroupCorner))
                 .background(InputSurface)
-                .border(1.dp, InputBorder, RoundedCornerShape(12.dp))
-                .padding(horizontal = 12.dp, vertical = 10.dp)
+                .border(1.dp, InputBorder, RoundedCornerShape(SettingGroupCorner))
+                .padding(horizontal = 10.dp, vertical = 8.dp)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 Column(
                     modifier = Modifier.weight(1f)
@@ -902,17 +916,17 @@ private fun GeneralSection(
                     Text(
                         text = title,
                         color = TextPrimary,
-                        fontSize = 13.sp,
+                        fontSize = SettingValueSize,
                         fontWeight = FontWeight.SemiBold
                     )
 
                     if (summary.isNotBlank()) {
-                        Spacer(Modifier.height(3.dp))
+                        Spacer(Modifier.height(2.dp))
 
                         Text(
                             text = summary,
                             color = TextSecondary,
-                            fontSize = 11.sp,
+                            fontSize = SettingLabelSize,
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -920,7 +934,7 @@ private fun GeneralSection(
                 }
 
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     ActionButton(
@@ -957,34 +971,34 @@ private fun GeneralSection(
         )
 
         if (!isContainer) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             Text(
                 stringResource(R.string.common_ui_select_exe),
                 color = TextSecondary,
-                fontSize = 12.sp,
+                fontSize = SettingLabelSize,
                 fontWeight = FontWeight.Medium
             )
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(SettingTightGap))
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(10.dp))
-                    .border(1.dp, InputBorder, RoundedCornerShape(10.dp))
+                    .clip(RoundedCornerShape(SettingFieldCorner))
+                    .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
                     .background(InputSurface)
                     .clickable { callbacks.onSelectExe() }
-                    .padding(horizontal = 14.dp, vertical = 12.dp)
+                    .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
             ) {
                 Text(
                     text = state.launchExePath.value.ifEmpty { stringResource(R.string.common_ui_select_exe) },
                     color = if (state.launchExePath.value.isEmpty()) TextDim else TextPrimary,
-                    fontSize = 13.sp,
+                    fontSize = SettingValueSize,
                     maxLines = 1
                 )
             }
         }
 
         if (!isContainer && state.containerEntries.value.isNotEmpty()) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             SettingDropdown(
                 label = stringResource(R.string.shortcuts_list_select_a_container),
                 entries = state.containerEntries.value,
@@ -997,7 +1011,7 @@ private fun GeneralSection(
         }
 
         if (isContainer && state.wineVersionEntries.value.isNotEmpty()) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             SettingDropdown(
                 label = stringResource(R.string.container_wine_version),
                 entries = state.wineVersionEntries.value,
@@ -1011,27 +1025,27 @@ private fun GeneralSection(
         }
 
         if (!isContainer) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             Box(
                 modifier = Modifier
                     .clip(RoundedCornerShape(10.dp))
                     .background(AccentBlue.copy(alpha = 0.08f))
                     .border(1.dp, AccentBlue.copy(alpha = 0.2f), RoundedCornerShape(10.dp))
                     .clickable { callbacks.onAddToHomeScreen() }
-                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         Icons.Outlined.Home,
                         contentDescription = null,
                         tint = AccentBlue,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(SettingIconSize)
                     )
-                    Spacer(Modifier.width(10.dp))
+                    Spacer(Modifier.width(8.dp))
                     Text(
                         stringResource(R.string.shortcuts_list_add_to_home_screen),
                         color = AccentBlue,
-                        fontSize = 13.sp,
+                        fontSize = SettingValueSize,
                         fontWeight = FontWeight.Medium
                     )
                 }
@@ -1040,7 +1054,7 @@ private fun GeneralSection(
     }
 
     if (!isContainer) {
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
 
         SettingGroup {
             Row(
@@ -1051,7 +1065,7 @@ private fun GeneralSection(
                 Text(
                     text = stringResource(R.string.shortcuts_library_artwork_title),
                     color = TextSecondary,
-                    fontSize = 13.sp,
+                    fontSize = SettingSectionLabelSize,
                     fontWeight = FontWeight.SemiBold,
                     letterSpacing = 0.8.sp
                 )
@@ -1062,27 +1076,27 @@ private fun GeneralSection(
                         .background(AccentBlue.copy(alpha = 0.08f))
                         .border(1.dp, AccentBlue.copy(alpha = 0.2f), RoundedCornerShape(10.dp))
                         .clickable { callbacks.onOpenArtworkSource() }
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .padding(horizontal = 10.dp, vertical = 6.dp)
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             Icons.AutoMirrored.Outlined.OpenInNew,
                             contentDescription = null,
                             tint = AccentBlue,
-                            modifier = Modifier.size(18.dp)
+                            modifier = Modifier.size(SettingIconSize)
                         )
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(6.dp))
                         Text(
                             text = stringResource(R.string.shortcuts_library_artwork_open_source),
                             color = AccentBlue,
-                            fontSize = 13.sp,
+                            fontSize = SettingValueSize,
                             fontWeight = FontWeight.Medium
                         )
                     }
                 }
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             ArtworkPickerRow(
                 title = stringResource(R.string.shortcuts_library_artwork_game_card_title),
@@ -1092,7 +1106,7 @@ private fun GeneralSection(
                 onRemove = callbacks::onRemoveGameCardArtwork
             )
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             ArtworkPickerRow(
                 title = stringResource(R.string.shortcuts_library_artwork_grid_title),
@@ -1102,7 +1116,7 @@ private fun GeneralSection(
                 onRemove = callbacks::onRemoveGridArtwork
             )
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             ArtworkPickerRow(
                 title = stringResource(R.string.shortcuts_library_artwork_carousel_title),
@@ -1112,7 +1126,7 @@ private fun GeneralSection(
                 onRemove = callbacks::onRemoveCarouselArtwork
             )
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             ArtworkPickerRow(
                 title = stringResource(R.string.shortcuts_library_artwork_list_title),
@@ -1124,7 +1138,7 @@ private fun GeneralSection(
         }
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     SettingGroup {
         // Screen Size
@@ -1137,10 +1151,10 @@ private fun GeneralSection(
 
         // Custom resolution fields when "Custom" is selected (index 0)
         if (state.selectedScreenSize.intValue == 0) {
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(SettingItemGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Box(Modifier.weight(1f)) {
                     SettingTextField(
@@ -1162,7 +1176,7 @@ private fun GeneralSection(
         }
 
         if (!isContainer) {
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             SettingDropdown(
                 label = stringResource(R.string.settings_general_refresh_rate),
                 entries = state.refreshRateEntries.value,
@@ -1172,7 +1186,7 @@ private fun GeneralSection(
         }
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     // Sound
     SettingGroup {
@@ -1183,7 +1197,7 @@ private fun GeneralSection(
             onSelected = { state.selectedAudioDriver.intValue = it }
         )
 
-        Spacer(Modifier.height(14.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingDropdown(
             label = stringResource(R.string.settings_audio_midi_sound_font),
@@ -1194,13 +1208,13 @@ private fun GeneralSection(
     }
 
     if (!isContainer) {
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
         SettingGroup {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Text(
                     text = "FPS Limiter",
                     color = TextPrimary,
-                    fontSize = 13.sp,
+                    fontSize = SettingValueSize,
                     fontWeight = FontWeight.SemiBold
                 )
                 val limits = listOf(0, 30, 45, 60, 90, 120)
@@ -1208,7 +1222,7 @@ private fun GeneralSection(
                     modifier = Modifier
                         .fillMaxWidth()
                         .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     limits.forEach { limit ->
                         val isChecked = state.fpsLimit.intValue == limit
@@ -1222,13 +1236,13 @@ private fun GeneralSection(
                                 .background(bgColor)
                                 .border(1.dp, borderColor, RoundedCornerShape(8.dp))
                                 .clickable { state.fpsLimit.intValue = limit }
-                                .padding(horizontal = 14.dp, vertical = 8.dp),
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
                             contentAlignment = Alignment.Center
                         ) {
                             Text(
                                 if (limit == 0) "None" else "$limit",
                                 color = textColor,
-                                fontSize = 12.sp,
+                                fontSize = SettingLabelSize,
                                 fontWeight = if (isChecked) FontWeight.SemiBold else FontWeight.Normal
                             )
                         }
@@ -1256,7 +1270,7 @@ private fun DisplaySection(
             onSelected = { state.selectedGraphicsDriver.intValue = it }
         )
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
 
         SettingDropdown(
             label = stringResource(R.string.container_wine_dxwrapper),
@@ -1266,12 +1280,12 @@ private fun DisplaySection(
         )
     }
 
-    Spacer(Modifier.height(12.dp))
+    Spacer(Modifier.height(SettingItemGap))
 
     // Graphics Driver Configuration - expandable inline card
     GraphicsDriverConfigCard(state, callbacks)
 
-    Spacer(Modifier.height(12.dp))
+    Spacer(Modifier.height(SettingItemGap))
 
     // Show DXVK or WineD3D config card based on selected DX wrapper
     val dxWrapperEntries = state.dxWrapperEntries.value
@@ -1301,29 +1315,29 @@ private fun GraphicsDriverConfigCard(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(SettingGroupCorner))
             .background(CardSurface)
-            .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
+            .border(1.dp, CardBorder, RoundedCornerShape(SettingGroupCorner))
     ) {
         // Header row - always visible, acts as expand/collapse toggle
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { state.gfxConfigExpanded.value = !expanded }
-                .padding(16.dp),
+                .padding(SettingGroupPadding),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 Icons.Outlined.Settings,
                 contentDescription = null,
                 tint = AccentBlue,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(8.dp))
             Text(
                 stringResource(R.string.container_graphics_configuration),
                 color = TextPrimary,
-                fontSize = 14.sp,
+                fontSize = SettingValueSize,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.weight(1f)
             )
@@ -1333,22 +1347,22 @@ private fun GraphicsDriverConfigCard(
                     modifier = Modifier
                         .clip(RoundedCornerShape(6.dp))
                         .background(AccentBlue.copy(alpha = 0.1f))
-                        .padding(horizontal = 8.dp, vertical = 3.dp)
+                        .padding(horizontal = 7.dp, vertical = 2.dp)
                 ) {
                     Text(
                         state.graphicsDriverVersion.value,
                         color = AccentBlue,
-                        fontSize = 11.sp,
+                        fontSize = SettingLabelSize,
                         fontWeight = FontWeight.Medium
                     )
                 }
-                Spacer(Modifier.width(8.dp))
+                Spacer(Modifier.width(6.dp))
             }
             Icon(
                 if (expanded) Icons.Outlined.KeyboardArrowUp else Icons.Outlined.KeyboardArrowDown,
                 contentDescription = null,
                 tint = TextDim,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
         }
 
@@ -1361,10 +1375,10 @@ private fun GraphicsDriverConfigCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .padding(start = 12.dp, end = 12.dp, bottom = 12.dp)
             ) {
                 Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                Spacer(Modifier.height(14.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_vulkan_version),
@@ -1373,7 +1387,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedVulkanVersion.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_version),
@@ -1385,12 +1399,12 @@ private fun GraphicsDriverConfigCard(
                     }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 // Available Extensions (multi-select)
                 ExtensionsMultiSelect(state)
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_gpu_name),
@@ -1399,7 +1413,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedGpuName.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_max_device_memory),
@@ -1408,7 +1422,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedMaxDeviceMemory.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_present_modes),
@@ -1417,7 +1431,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedPresentMode.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_resource_type),
@@ -1426,7 +1440,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedResourceType.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_bcn_emulation),
@@ -1435,7 +1449,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedBcnEmulation.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_bcn_emulation_type),
@@ -1444,7 +1458,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedBcnEmulationType.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_graphics_bcn_emulation_cache),
@@ -1453,7 +1467,7 @@ private fun GraphicsDriverConfigCard(
                     onSelected = { state.gfxSelectedBcnEmulationCache.intValue = it }
                 )
 
-                Spacer(Modifier.height(14.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 // Toggles
                 SettingCheckbox(
@@ -1462,7 +1476,7 @@ private fun GraphicsDriverConfigCard(
                     onCheckedChange = { state.gfxSyncFrame.value = it }
                 )
 
-                Spacer(Modifier.height(4.dp))
+                Spacer(Modifier.height(SettingTightGap))
 
                 SettingCheckbox(
                     label = stringResource(R.string.container_graphics_disable_present_wait),
@@ -1488,35 +1502,35 @@ private fun ExtensionsMultiSelect(state: GameSettingsStateHolder) {
         Text(
             stringResource(R.string.container_graphics_available_extensions),
             color = TextSecondary,
-            fontSize = 12.sp,
+            fontSize = SettingLabelSize,
             fontWeight = FontWeight.Medium,
             letterSpacing = 0.3.sp,
-            modifier = Modifier.padding(bottom = 6.dp)
+            modifier = Modifier.padding(bottom = SettingTightGap)
         )
 
         // Summary button — opens popup
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(SettingFieldCorner))
                 .background(InputSurface)
-                .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
+                .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
                 .clickable(enabled = extensions.isNotEmpty()) { showDialog = true }
-                .padding(horizontal = 14.dp, vertical = 11.dp),
+                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 if (extensions.isEmpty()) "—"
                 else stringResource(R.string.container_graphics_extensions_enabled_summary, enabledCount, extensions.size),
                 color = TextPrimary,
-                fontSize = 14.sp,
+                fontSize = SettingValueSize,
                 modifier = Modifier.weight(1f)
             )
             Icon(
                 Icons.Outlined.KeyboardArrowDown,
                 contentDescription = null,
                 tint = TextDim,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
         }
     }
@@ -1554,21 +1568,21 @@ private fun ExtensionsPickerDialog(
             modifier = Modifier
                 .widthIn(max = 360.dp)
                 .fillMaxHeight(0.70f)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(SettingGroupCorner))
                 .background(BgDeep)
-                .border(1.dp, CardBorder, RoundedCornerShape(16.dp))
+                .border(1.dp, CardBorder, RoundedCornerShape(SettingGroupCorner))
         ) {
             // Header
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     stringResource(R.string.container_graphics_available_extensions),
                     color = TextPrimary,
-                    fontSize = 16.sp,
+                    fontSize = SettingValueSize,
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.weight(1f)
                 )
@@ -1577,12 +1591,12 @@ private fun ExtensionsPickerDialog(
                     modifier = Modifier
                         .clip(RoundedCornerShape(6.dp))
                         .background(AccentBlue.copy(alpha = 0.1f))
-                        .padding(horizontal = 8.dp, vertical = 3.dp)
+                        .padding(horizontal = 7.dp, vertical = 2.dp)
                 ) {
                     Text(
                         stringResource(R.string.container_graphics_extensions_enabled_summary, enabledCount, extensions.size),
                         color = AccentBlue,
-                        fontSize = 12.sp,
+                        fontSize = SettingLabelSize,
                         fontWeight = FontWeight.Medium
                     )
                 }
@@ -1596,7 +1610,7 @@ private fun ExtensionsPickerDialog(
                     .fillMaxWidth()
                     .weight(1f)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .padding(horizontal = 10.dp, vertical = 6.dp)
             ) {
                 extensions.forEach { ext ->
                     val isEnabled = ext !in blacklisted
@@ -1605,24 +1619,24 @@ private fun ExtensionsPickerDialog(
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(8.dp))
                             .clickable { onToggle(ext, !isEnabled) }
-                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                            .padding(horizontal = 8.dp, vertical = 5.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
                             checked = isEnabled,
                             onCheckedChange = { onToggle(ext, it) },
-                            modifier = Modifier.size(22.dp),
+                            modifier = Modifier.size(20.dp),
                             colors = CheckboxDefaults.colors(
                                 checkedColor = AccentBlue,
                                 uncheckedColor = CheckBorder,
                                 checkmarkColor = Color.White
                             )
                         )
-                        Spacer(Modifier.width(12.dp))
+                        Spacer(Modifier.width(10.dp))
                         Text(
                             ext,
                             color = if (isEnabled) TextPrimary else TextDim,
-                            fontSize = 13.sp,
+                            fontSize = SettingValueSize,
                             maxLines = 1
                         )
                     }
@@ -1636,13 +1650,13 @@ private fun ExtensionsPickerDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onDismiss() }
-                    .padding(vertical = 14.dp),
+                    .padding(vertical = 10.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     stringResource(android.R.string.ok),
                     color = AccentBlue,
-                    fontSize = 14.sp,
+                    fontSize = SettingValueSize,
                     fontWeight = FontWeight.SemiBold
                 )
             }
@@ -1672,29 +1686,29 @@ private fun DXVKConfigCard(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(SettingGroupCorner))
             .background(CardSurface)
-            .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
+            .border(1.dp, CardBorder, RoundedCornerShape(SettingGroupCorner))
     ) {
         // Header row
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { state.dxvkConfigExpanded.value = !expanded }
-                .padding(16.dp),
+                .padding(SettingGroupPadding),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 Icons.Outlined.Tune,
                 contentDescription = null,
                 tint = AccentBlue,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(8.dp))
             Text(
                 stringResource(R.string.container_wine_dxvk_config_title),
                 color = TextPrimary,
-                fontSize = 14.sp,
+                fontSize = SettingValueSize,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.weight(1f)
             )
@@ -1702,7 +1716,7 @@ private fun DXVKConfigCard(
                 if (expanded) Icons.Outlined.KeyboardArrowUp else Icons.Outlined.KeyboardArrowDown,
                 contentDescription = null,
                 tint = TextDim,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
         }
 
@@ -1715,10 +1729,10 @@ private fun DXVKConfigCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .padding(start = 12.dp, end = 12.dp, bottom = 12.dp)
             ) {
                 Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                Spacer(Modifier.height(14.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_vkd3d_version),
@@ -1730,7 +1744,7 @@ private fun DXVKConfigCard(
                     }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_vkd3d_feature_level),
@@ -1739,7 +1753,7 @@ private fun DXVKConfigCard(
                     onSelected = { state.dxvkSelectedVkd3dFeatureLevel.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_dxvk_version),
@@ -1752,7 +1766,7 @@ private fun DXVKConfigCard(
                 )
 
                 // Async toggle - greyed out when version doesn't support it
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
                 Box(modifier = Modifier.alpha(if (asyncEnabled) 1f else 0.35f)) {
                     SettingCheckbox(
                         label = stringResource(R.string.container_wine_enabled_async),
@@ -1762,7 +1776,7 @@ private fun DXVKConfigCard(
                 }
 
                 // Async Cache toggle - greyed out when version doesn't support it
-                Spacer(Modifier.height(4.dp))
+                Spacer(Modifier.height(SettingTightGap))
                 Box(modifier = Modifier.alpha(if (asyncCacheEnabled) 1f else 0.35f)) {
                     SettingCheckbox(
                         label = stringResource(R.string.container_wine_enabled_async_cache),
@@ -1771,7 +1785,7 @@ private fun DXVKConfigCard(
                     )
                 }
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_ddraw_wrapper),
@@ -1794,29 +1808,29 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(SettingGroupCorner))
             .background(CardSurface)
-            .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
+            .border(1.dp, CardBorder, RoundedCornerShape(SettingGroupCorner))
     ) {
         // Header row
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { state.wined3dConfigExpanded.value = !expanded }
-                .padding(16.dp),
+                .padding(SettingGroupPadding),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 Icons.Outlined.Tune,
                 contentDescription = null,
                 tint = AccentBlue,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(8.dp))
             Text(
                 stringResource(R.string.container_wine_wined3d_config_title),
                 color = TextPrimary,
-                fontSize = 14.sp,
+                fontSize = SettingValueSize,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.weight(1f)
             )
@@ -1824,7 +1838,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                 if (expanded) Icons.Outlined.KeyboardArrowUp else Icons.Outlined.KeyboardArrowDown,
                 contentDescription = null,
                 tint = TextDim,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(SettingIconSize)
             )
         }
 
@@ -1837,10 +1851,10 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .padding(start = 12.dp, end = 12.dp, bottom = 12.dp)
             ) {
                 Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                Spacer(Modifier.height(14.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_csmt),
@@ -1849,7 +1863,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                     onSelected = { state.wined3dSelectedCsmt.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_gpu_name),
@@ -1858,7 +1872,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                     onSelected = { state.wined3dSelectedGpuName.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_video_memory_size),
@@ -1867,7 +1881,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                     onSelected = { state.wined3dSelectedVideoMemorySize.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_strict_shader_math),
@@ -1876,7 +1890,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                     onSelected = { state.wined3dSelectedStrictShaderMath.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_wine_offscreen_rendering_mode),
@@ -1885,7 +1899,7 @@ private fun WineD3DConfigCard(state: GameSettingsStateHolder) {
                     onSelected = { state.wined3dSelectedOffscreenRenderingMode.intValue = it }
                 )
 
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(SettingItemGap))
 
                 SettingDropdown(
                     label = stringResource(R.string.container_config_renderer),
@@ -1924,14 +1938,14 @@ private fun SteamSection(state: GameSettingsStateHolder) {
             fontSize = 11.sp,
             lineHeight = 16.sp
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.shortcuts_properties_use_steam_input),
             checked = state.useSteamInput.value,
             onCheckedChange = { state.useSteamInput.value = it }
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.shortcuts_properties_force_dlc),
@@ -1945,14 +1959,14 @@ private fun SteamSection(state: GameSettingsStateHolder) {
             fontSize = 11.sp,
             lineHeight = 16.sp
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.shortcuts_properties_steam_offline_mode),
             checked = state.steamOfflineMode.value,
             onCheckedChange = { state.steamOfflineMode.value = it }
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.shortcuts_properties_unpack_files),
@@ -1971,7 +1985,7 @@ private fun SteamSection(state: GameSettingsStateHolder) {
             fontSize = 11.sp,
             lineHeight = 16.sp
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.shortcuts_properties_runtime_patcher),
@@ -1993,7 +2007,7 @@ private fun SteamSection(state: GameSettingsStateHolder) {
         )
     }
 
-    Spacer(Modifier.height(12.dp))
+    Spacer(Modifier.height(SettingItemGap))
 
     SubsectionLabel(stringResource(R.string.steam_section_real_client))
     Spacer(Modifier.height(8.dp))
@@ -2020,7 +2034,7 @@ private fun SteamSection(state: GameSettingsStateHolder) {
             fontSize = 11.sp,
             lineHeight = 16.sp
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         if (state.steamTypeEntries.value.isNotEmpty()) {
             SettingDropdown(
@@ -2063,7 +2077,7 @@ private fun WineSection(
             ) {
                 Box(
                     modifier = Modifier
-                        .size(38.dp)
+                        .size(34.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
@@ -2087,7 +2101,7 @@ private fun WineSection(
                     state.localeOptions.value.forEach { locale ->
                         DropdownMenuItem(
                             text = {
-                                Text(locale, color = TextPrimary, fontSize = 13.sp)
+                                Text(locale, color = TextPrimary, fontSize = SettingValueSize)
                             },
                             onClick = {
                                 state.lcAll.value = locale
@@ -2102,7 +2116,7 @@ private fun WineSection(
 
     // Desktop Theme
     if (state.desktopThemeEntries.value.isNotEmpty()) {
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
         SettingGroup {
             SettingDropdown(
                 label = stringResource(R.string.settings_general_theme),
@@ -2112,7 +2126,7 @@ private fun WineSection(
             )
 
             if (isContainer && state.desktopBackgroundTypeEntries.value.isNotEmpty()) {
-                Spacer(Modifier.height(14.dp))
+                Spacer(Modifier.height(SettingItemGap))
                 SettingDropdown(
                     label = stringResource(R.string.settings_general_background),
                     entries = state.desktopBackgroundTypeEntries.value,
@@ -2125,7 +2139,7 @@ private fun WineSection(
                     ?.lowercase() ?: ""
                 when (selectedType) {
                     "color" -> {
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(SettingItemGap))
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.Bottom
@@ -2153,15 +2167,15 @@ private fun WineSection(
                         }
                     }
                     "image" -> {
-                        Spacer(Modifier.height(12.dp))
+                        Spacer(Modifier.height(SettingItemGap))
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(10.dp))
-                                .border(1.dp, InputBorder, RoundedCornerShape(10.dp))
+                                .clip(RoundedCornerShape(SettingFieldCorner))
+                                .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
                                 .background(InputSurface)
                                 .clickable { callbacks.onPickWallpaper() }
-                                .padding(horizontal = 14.dp, vertical = 12.dp),
+                                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
@@ -2171,7 +2185,7 @@ private fun WineSection(
                                     stringResource(R.string.settings_general_select_wallpaper)
                                 },
                                 color = if (state.desktopWallpaperSelected.value) TextPrimary else TextSecondary,
-                                fontSize = 12.sp,
+                                fontSize = SettingLabelSize,
                                 modifier = Modifier.weight(1f)
                             )
                             if (state.desktopWallpaperSelected.value) {
@@ -2190,7 +2204,7 @@ private fun WineSection(
     }
 
     if (isContainer && state.mouseWarpOverrideEntries.value.isNotEmpty()) {
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
         SettingGroup {
             SettingDropdown(
                 label = stringResource(R.string.container_wine_mouse_warp_override),
@@ -2217,7 +2231,7 @@ private fun ComponentsSection(
         Spacer(Modifier.height(8.dp))
         SettingGroup {
             state.directXComponents.value.forEachIndexed { index, component ->
-                if (index > 0) Spacer(Modifier.height(12.dp))
+                if (index > 0) Spacer(Modifier.height(SettingItemGap))
                 SettingDropdown(
                     label = component.label,
                     entries = state.winComponentEntries.value,
@@ -2228,7 +2242,7 @@ private fun ComponentsSection(
                 )
             }
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
     }
 
     // General components
@@ -2237,7 +2251,7 @@ private fun ComponentsSection(
         Spacer(Modifier.height(8.dp))
         SettingGroup {
             state.generalComponents.value.forEachIndexed { index, component ->
-                if (index > 0) Spacer(Modifier.height(12.dp))
+                if (index > 0) Spacer(Modifier.height(SettingItemGap))
                 SettingDropdown(
                     label = component.label,
                     entries = state.winComponentEntries.value,
@@ -2277,20 +2291,20 @@ private fun VariablesSection(
             Text(
                 stringResource(R.string.common_ui_none),
                 color = TextDim,
-                fontSize = 13.sp,
-                modifier = Modifier.padding(vertical = 8.dp)
+                fontSize = SettingValueSize,
+                modifier = Modifier.padding(vertical = 6.dp)
             )
         } else {
             state.envVars.value.forEachIndexed { index, envVar ->
                 if (index > 0) {
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(1.dp))
                     Box(
                         Modifier
                             .fillMaxWidth()
                             .height(1.dp)
                             .background(DividerColor)
                     )
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(1.dp))
                 }
                 EnvVarRow(
                     name = envVar.key,
@@ -2320,9 +2334,9 @@ private fun VariablesSection(
         // Inline add row
         if (isAdding) {
             if (state.envVars.value.isNotEmpty()) {
-                Spacer(Modifier.height(2.dp))
+                Spacer(Modifier.height(1.dp))
                 Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(6.dp))
             }
             EnvVarRow(
                 name = newName,
@@ -2332,10 +2346,10 @@ private fun VariablesSection(
                 onValueChange = { newValue = it },
                 onRemove = null,
                 trailing = {
-                    Spacer(Modifier.width(4.dp))
+                    Spacer(Modifier.width(3.dp))
                     Box(
                         modifier = Modifier
-                            .size(28.dp)
+                            .size(26.dp)
                             .clip(RoundedCornerShape(6.dp))
                             .background(AccentBlue.copy(alpha = 0.15f))
                             .clickable {
@@ -2352,12 +2366,12 @@ private fun VariablesSection(
                             },
                         contentAlignment = Alignment.Center
                     ) {
-                        Icon(Icons.Outlined.Check, contentDescription = null, tint = AccentBlue, modifier = Modifier.size(16.dp))
+                        Icon(Icons.Outlined.Check, contentDescription = null, tint = AccentBlue, modifier = Modifier.size(SettingControlIconSize))
                     }
-                    Spacer(Modifier.width(4.dp))
+                    Spacer(Modifier.width(3.dp))
                     Box(
                         modifier = Modifier
-                            .size(28.dp)
+                            .size(26.dp)
                             .clip(RoundedCornerShape(6.dp))
                             .background(DangerRed.copy(alpha = 0.1f))
                             .clickable {
@@ -2367,13 +2381,13 @@ private fun VariablesSection(
                             },
                         contentAlignment = Alignment.Center
                     ) {
-                        Icon(Icons.Outlined.Close, contentDescription = null, tint = DangerRed, modifier = Modifier.size(16.dp))
+                        Icon(Icons.Outlined.Close, contentDescription = null, tint = DangerRed, modifier = Modifier.size(SettingControlIconSize))
                     }
                 }
             )
         }
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         // Add button
         if (!isAdding) {
@@ -2387,20 +2401,20 @@ private fun VariablesSection(
                         newValue = ""
                         isAdding = true
                     }
-                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         Icons.Outlined.Add,
                         contentDescription = null,
                         tint = AccentBlue,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(SettingIconSize)
                     )
-                    Spacer(Modifier.width(8.dp))
+                    Spacer(Modifier.width(6.dp))
                     Text(
                         stringResource(R.string.common_ui_add),
                         color = AccentBlue,
-                        fontSize = 13.sp,
+                        fontSize = SettingValueSize,
                         fontWeight = FontWeight.Medium
                     )
                 }
@@ -2409,17 +2423,17 @@ private fun VariablesSection(
     }
 
     if (isContainer) {
-        Spacer(Modifier.height(20.dp))
+        Spacer(Modifier.height(SettingSectionGap))
         SubsectionLabel(stringResource(R.string.container_config_drives))
         Spacer(Modifier.height(8.dp))
         SettingGroup {
             val drives = state.drivesList.value
             if (drives.isEmpty()) {
                 Text(
-                    stringResource(R.string.common_ui_none),
-                    color = TextDim,
-                    fontSize = 13.sp,
-                    modifier = Modifier.padding(vertical = 8.dp)
+                stringResource(R.string.common_ui_none),
+                color = TextDim,
+                fontSize = SettingValueSize,
+                modifier = Modifier.padding(vertical = 6.dp)
                 )
             } else {
                 drives.forEachIndexed { index, drive ->
@@ -2434,14 +2448,14 @@ private fun VariablesSection(
                         }
 
                     if (index > 0) {
-                        Spacer(Modifier.height(2.dp))
+                        Spacer(Modifier.height(1.dp))
                         Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                        Spacer(Modifier.height(2.dp))
+                        Spacer(Modifier.height(1.dp))
                     }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 6.dp),
+                            .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         DriveLetterSelector(
@@ -2450,7 +2464,7 @@ private fun VariablesSection(
                             availableLetters = availableLetters,
                             onSelected = { callbacks.onDriveLetterChanged(index, it) },
                         )
-                        Spacer(Modifier.width(10.dp))
+                        Spacer(Modifier.width(8.dp))
                         Box(
                             modifier = Modifier
                                 .weight(1f)
@@ -2458,20 +2472,20 @@ private fun VariablesSection(
                                 .background(InputSurface)
                                 .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
                                 .clickable { callbacks.onPickDrivePath(index) }
-                                .padding(horizontal = 12.dp, vertical = 10.dp)
+                                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
                         ) {
                             Text(
                                 drive.path.ifEmpty { stringResource(R.string.common_ui_select_folder) },
                                 color = if (drive.path.isEmpty()) TextDim else TextPrimary,
-                                fontSize = 12.sp,
+                                fontSize = SettingLabelSize,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
                         }
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(6.dp))
                         Box(
                             modifier = Modifier
-                                .size(32.dp)
+                                .size(30.dp)
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(DangerRed.copy(alpha = 0.1f))
                                 .clickable { callbacks.onRemoveDrive(index) },
@@ -2481,14 +2495,14 @@ private fun VariablesSection(
                                 Icons.Outlined.Close,
                                 contentDescription = null,
                                 tint = DangerRed,
-                                modifier = Modifier.size(16.dp)
+                                modifier = Modifier.size(SettingControlIconSize)
                             )
                         }
                     }
                 }
             }
 
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             Box(
                 modifier = Modifier
@@ -2496,20 +2510,20 @@ private fun VariablesSection(
                     .background(AccentBlue.copy(alpha = 0.08f))
                     .border(1.dp, AccentBlue.copy(alpha = 0.2f), RoundedCornerShape(8.dp))
                     .clickable { callbacks.onAddDrive() }
-                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         Icons.Outlined.Add,
                         contentDescription = null,
                         tint = AccentBlue,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(SettingIconSize)
                     )
-                    Spacer(Modifier.width(8.dp))
+                    Spacer(Modifier.width(6.dp))
                     Text(
                         stringResource(R.string.common_ui_add),
                         color = AccentBlue,
-                        fontSize = 13.sp,
+                        fontSize = SettingValueSize,
                         fontWeight = FontWeight.Medium
                     )
                 }
@@ -2533,7 +2547,7 @@ private fun DriveLetterSelector(
             modifier =
                 Modifier
                     .widthIn(min = 64.dp)
-                    .height(32.dp)
+                    .height(30.dp)
                     .clip(RoundedCornerShape(6.dp))
                     .background(AccentBlue.copy(alpha = 0.1f))
                     .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
@@ -2542,23 +2556,23 @@ private fun DriveLetterSelector(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                     ) { expanded = true }
-                    .padding(horizontal = 10.dp),
+                    .padding(horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {
             Text(
                 "$selectedLetter:",
                 color = AccentBlue,
-                fontSize = 13.sp,
+                fontSize = SettingValueSize,
                 fontWeight = FontWeight.SemiBold,
             )
             if (showDropdown) {
-                Spacer(Modifier.width(4.dp))
+                Spacer(Modifier.width(3.dp))
                 Icon(
                     Icons.Outlined.KeyboardArrowDown,
                     contentDescription = null,
                     tint = AccentBlue,
-                    modifier = Modifier.size(14.dp),
+                    modifier = Modifier.size(13.dp),
                 )
             }
         }
@@ -2582,7 +2596,7 @@ private fun DriveLetterSelector(
                             Text(
                                 "$letter:",
                                 color = if (letter == selectedLetter) AccentBlue else TextPrimary,
-                                fontSize = 13.sp,
+                                fontSize = SettingValueSize,
                                 fontWeight =
                                     if (letter == selectedLetter) FontWeight.SemiBold
                                     else FontWeight.Normal,
@@ -2621,7 +2635,7 @@ private fun EnvVarRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp),
+            .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Name dropdown or custom text field
@@ -2636,7 +2650,7 @@ private fun EnvVarRow(
                     },
                     textStyle = TextStyle(
                         color = TextPrimary,
-                        fontSize = 13.sp
+                        fontSize = SettingValueSize
                     ),
                     cursorBrush = SolidColor(AccentBlue),
                     singleLine = true,
@@ -2645,13 +2659,13 @@ private fun EnvVarRow(
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                        .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
                     decorationBox = { innerTextField ->
                         if (customText.isEmpty()) {
                             Text(
                                 stringResource(R.string.container_config_new_env_var),
                                 color = TextDim,
-                                fontSize = 13.sp
+                                fontSize = SettingValueSize
                             )
                         }
                         innerTextField()
@@ -2665,14 +2679,14 @@ private fun EnvVarRow(
                         .background(InputSurface)
                         .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                         .clickable { nameMenuExpanded = true }
-                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                        .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
                     contentAlignment = Alignment.CenterStart
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             if (name.isEmpty()) stringResource(R.string.container_config_new_env_var) else name,
                             color = if (name.isEmpty()) TextDim else TextPrimary,
-                            fontSize = 13.sp,
+                            fontSize = SettingValueSize,
                             modifier = Modifier.weight(1f),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
@@ -2681,7 +2695,7 @@ private fun EnvVarRow(
                             Icons.Outlined.KeyboardArrowDown,
                             contentDescription = null,
                             tint = TextSecondary,
-                            modifier = Modifier.size(16.dp)
+                            modifier = Modifier.size(SettingControlIconSize)
                         )
                     }
                 }
@@ -2701,7 +2715,7 @@ private fun EnvVarRow(
                         Text(
                             stringResource(R.string.common_ui_custom),
                             color = AccentBlue,
-                            fontSize = 13.sp,
+                            fontSize = SettingValueSize,
                             fontWeight = FontWeight.Medium
                         )
                     },
@@ -2732,7 +2746,7 @@ private fun EnvVarRow(
                             Text(
                                 knownName,
                                 color = if (disabled) TextDim else TextPrimary,
-                                fontSize = 13.sp
+                                fontSize = SettingValueSize
                             )
                         },
                         onClick = {
@@ -2745,7 +2759,7 @@ private fun EnvVarRow(
                 }
             }
         }
-        Spacer(Modifier.width(8.dp))
+        Spacer(Modifier.width(6.dp))
         // Value editor (type-aware)
         Box(modifier = Modifier.weight(1f)) {
             EnvVarValueEditor(
@@ -2755,10 +2769,10 @@ private fun EnvVarRow(
             )
         }
         if (onRemove != null) {
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(6.dp))
             Box(
                 modifier = Modifier
-                    .size(28.dp)
+                    .size(26.dp)
                     .clip(RoundedCornerShape(6.dp))
                     .background(DangerRed.copy(alpha = 0.1f))
                     .clickable { onRemove() },
@@ -2768,7 +2782,7 @@ private fun EnvVarRow(
                     Icons.Outlined.Close,
                     contentDescription = null,
                     tint = DangerRed,
-                    modifier = Modifier.size(16.dp)
+                    modifier = Modifier.size(SettingControlIconSize)
                 )
             }
         }
@@ -2831,14 +2845,14 @@ private fun EnvValueDropdown(
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                 .clickable { expanded = true }
-                .padding(horizontal = 12.dp, vertical = 10.dp),
+                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     current,
                     color = TextPrimary,
-                    fontSize = 13.sp,
+                    fontSize = SettingValueSize,
                     modifier = Modifier.weight(1f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -2861,7 +2875,7 @@ private fun EnvValueDropdown(
             options.forEach { opt ->
                 DropdownMenuItem(
                     text = {
-                        Text(opt, color = TextPrimary, fontSize = 13.sp)
+                        Text(opt, color = TextPrimary, fontSize = SettingValueSize)
                     },
                     onClick = {
                         onSelected(opt)
@@ -2891,14 +2905,14 @@ private fun EnvValueMultiDropdown(
                 .background(InputSurface)
                 .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
                 .clickable { expanded = true }
-                .padding(horizontal = 12.dp, vertical = 10.dp),
+                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
             contentAlignment = Alignment.CenterStart
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     if (selectedSet.isEmpty()) "—" else selectedSet.joinToString(","),
                     color = if (selectedSet.isEmpty()) TextDim else TextPrimary,
-                    fontSize = 13.sp,
+                    fontSize = SettingValueSize,
                     modifier = Modifier.weight(1f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -2934,8 +2948,8 @@ private fun EnvValueMultiDropdown(
                                     checkmarkColor = Color.White
                                 )
                             )
-                            Spacer(Modifier.width(8.dp))
-                            Text(opt, color = TextPrimary, fontSize = 13.sp)
+                            Spacer(Modifier.width(6.dp))
+                            Text(opt, color = TextPrimary, fontSize = SettingValueSize)
                         }
                     },
                     onClick = {
@@ -2957,7 +2971,7 @@ private fun EnvValueTextField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        textStyle = TextStyle(color = TextPrimary, fontSize = 13.sp),
+        textStyle = TextStyle(color = TextPrimary, fontSize = SettingValueSize),
         cursorBrush = SolidColor(AccentBlue),
         singleLine = true,
         keyboardOptions = if (numeric)
@@ -2971,10 +2985,10 @@ private fun EnvValueTextField(
                     .clip(RoundedCornerShape(8.dp))
                     .background(InputSurface)
                     .border(1.dp, AccentBlue.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
-                    .padding(horizontal = 12.dp, vertical = 10.dp)
+                    .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
             ) {
                 if (value.isEmpty()) {
-                    Text(stringResource(R.string.common_ui_value), color = TextDim, fontSize = 13.sp)
+                    Text(stringResource(R.string.common_ui_value), color = TextDim, fontSize = SettingValueSize)
                 }
                 innerTextField()
             }
@@ -3001,7 +3015,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 onSelected = { state.selectedControlsProfile.intValue = it }
             )
 
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(SettingItemGap))
 
             SettingDropdown(
                 label = stringResource(R.string.num_controllers),
@@ -3010,7 +3024,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 onSelected = { state.selectedNumControllers.intValue = it }
             )
 
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(SettingItemGap))
         }
 
         // Exclusive Input — when off, XInput + DInput are both forced on and locked below.
@@ -3052,7 +3066,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
         }
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     // Game Controller group
     SubsectionLabel(stringResource(R.string.session_gamepad_game_controller))
@@ -3066,7 +3080,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
                 selectedIndex = state.selectedDInputMapperType.intValue,
                 onSelected = { state.selectedDInputMapperType.intValue = it }
             )
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(SettingItemGap))
         }
 
         // Enable XInput with help — only toggleable when Exclusive Input is on.
@@ -3088,7 +3102,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
             Box {
                 Box(
                     modifier = Modifier
-                        .size(32.dp)
+                        .size(30.dp)
                         .clip(RoundedCornerShape(6.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(6.dp))
@@ -3108,14 +3122,14 @@ private fun InputSection(state: GameSettingsStateHolder) {
                     shape = RoundedCornerShape(8.dp),
                     containerColor = CardSurface,
                     modifier = Modifier
-                        .padding(12.dp)
+                        .padding(10.dp)
                         .width(280.dp)
                 ) {
                     HtmlText(
                         stringResource(R.string.container_config_help_xinput),
                         color = TextPrimary,
-                        fontSize = 12.sp,
-                        lineHeight = 18.sp
+                        fontSize = SettingLabelSize,
+                        lineHeight = 16.sp
                     )
                 }
             }
@@ -3140,7 +3154,7 @@ private fun InputSection(state: GameSettingsStateHolder) {
             Box {
                 Box(
                     modifier = Modifier
-                        .size(32.dp)
+                        .size(30.dp)
                         .clip(RoundedCornerShape(6.dp))
                         .background(InputSurface)
                         .border(1.dp, InputBorder, RoundedCornerShape(6.dp))
@@ -3160,14 +3174,14 @@ private fun InputSection(state: GameSettingsStateHolder) {
                     shape = RoundedCornerShape(8.dp),
                     containerColor = CardSurface,
                     modifier = Modifier
-                        .padding(12.dp)
+                        .padding(10.dp)
                         .width(280.dp)
                 ) {
                     HtmlText(
                         stringResource(R.string.container_config_help_dinput),
                         color = TextPrimary,
-                        fontSize = 12.sp,
-                        lineHeight = 18.sp
+                        fontSize = SettingLabelSize,
+                        lineHeight = 16.sp
                     )
                 }
             }
@@ -3182,13 +3196,13 @@ private fun InputSection(state: GameSettingsStateHolder) {
                     .clip(RoundedCornerShape(8.dp))
                     .background(WarningAmber.copy(alpha = 0.08f))
                     .border(1.dp, WarningAmber.copy(alpha = 0.2f), RoundedCornerShape(8.dp))
-                    .padding(12.dp)
+                    .padding(10.dp)
             ) {
                 Text(
                     stringResource(R.string.container_config_xinput_dinput_warning),
                     color = WarningAmber,
-                    fontSize = 12.sp,
-                    lineHeight = 17.sp
+                    fontSize = SettingLabelSize,
+                    lineHeight = 16.sp
                 )
             }
         }
@@ -3216,11 +3230,11 @@ private fun AdvancedSection(
             Text(
                 text = wineVersionDisplay,
                 color = TextPrimary,
-                fontSize = 14.sp,
+                fontSize = SettingValueSize,
                 fontWeight = FontWeight.Medium
             )
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
     }
 
     // Emulator selection (mirrors the Wine tab dropdowns)
@@ -3237,7 +3251,7 @@ private fun AdvancedSection(
             },
             enabled = state.emulator64Entries.value.isNotEmpty()
         )
-        Spacer(Modifier.height(14.dp))
+        Spacer(Modifier.height(SettingItemGap))
         SettingDropdown(
             label = stringResource(R.string.container_config_dll_emulator),
             entries = state.emulator32Entries.value,
@@ -3249,7 +3263,7 @@ private fun AdvancedSection(
             enabled = state.emulator32Entries.value.isNotEmpty()
         )
     }
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     // FEXCore — hidden when FEXCore isn't explicitly in either slot.
     if (state.showFexcoreFrame.value) {
@@ -3263,7 +3277,7 @@ private fun AdvancedSection(
                 selectedIndex = state.selectedFexcoreVersion.intValue,
                 onSelected = { state.selectedFexcoreVersion.intValue = it }
             )
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             SettingDropdown(
                 label = stringResource(R.string.container_fexcore_preset),
                 entries = state.fexcorePresetEntries.value,
@@ -3271,7 +3285,7 @@ private fun AdvancedSection(
                 onSelected = { state.selectedFexcorePreset.intValue = it }
             )
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
     }
 
     // Box64 / Wowbox64 — title switches between Box64/Wowbox64/both based on selection.
@@ -3299,7 +3313,7 @@ private fun AdvancedSection(
                 selectedIndex = state.selectedBox64Version.intValue,
                 onSelected = { state.selectedBox64Version.intValue = it }
             )
-            Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(SettingItemGap))
             SettingDropdown(
                 label = stringResource(R.string.container_box64_preset),
                 entries = state.box64PresetEntries.value,
@@ -3307,7 +3321,7 @@ private fun AdvancedSection(
                 onSelected = { state.selectedBox64Preset.intValue = it }
             )
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(SettingSectionGap))
     }
 
     // System
@@ -3321,7 +3335,7 @@ private fun AdvancedSection(
             onSelected = { state.selectedStartupSelection.intValue = it }
         )
 
-        Spacer(Modifier.height(14.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         // Exec Arguments with helper dropdown
         Row(
@@ -3345,7 +3359,7 @@ private fun AdvancedSection(
             )
         }
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(SettingItemGap))
 
         SettingCheckbox(
             label = stringResource(R.string.session_display_fullscreen_stretched),
@@ -3354,7 +3368,7 @@ private fun AdvancedSection(
         )
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     // CPU Affinity
     SubsectionLabel(stringResource(R.string.container_config_processor_affinity))
@@ -3387,7 +3401,7 @@ private fun AdvancedSection(
         }
     }
 
-    Spacer(Modifier.height(16.dp))
+    Spacer(Modifier.height(SettingSectionGap))
 
     // CPU Affinity (32-bit apps)
     SubsectionLabel(stringResource(R.string.container_config_processor_affinity_32bit))
@@ -3428,7 +3442,7 @@ private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
     Box(modifier = Modifier.padding(top = 22.dp)) {
         Box(
             modifier = Modifier
-                .size(38.dp)
+                .size(34.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(InputSurface)
                 .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
@@ -3459,7 +3473,7 @@ private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
                         Text(
                             group.header,
                             color = AccentBlue,
-                            fontSize = 12.sp,
+                            fontSize = SettingLabelSize,
                             fontWeight = FontWeight.Bold,
                             letterSpacing = 0.8.sp
                         )
@@ -3473,7 +3487,7 @@ private fun ExecArgsHelper(onArgSelected: (String) -> Unit) {
                             Text(
                                 arg,
                                 color = TextPrimary,
-                                fontSize = 13.sp
+                                fontSize = SettingValueSize
                             )
                         },
                         onClick = {
@@ -3506,13 +3520,13 @@ private fun CpuChip(
             .background(bgColor)
             .border(1.dp, borderColor, RoundedCornerShape(8.dp))
             .clickable(onClick = onClick)
-            .padding(horizontal = 14.dp, vertical = 8.dp),
+            .padding(horizontal = 12.dp, vertical = 6.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
             "CPU $index",
             color = textColor,
-            fontSize = 12.sp,
+            fontSize = SettingLabelSize,
             fontWeight = if (isChecked) FontWeight.SemiBold else FontWeight.Normal
         )
     }
@@ -3568,7 +3582,7 @@ private fun SubsectionLabel(text: String) {
     Text(
         text = text,
         color = TextSecondary,
-        fontSize = 13.sp,
+        fontSize = SettingSectionLabelSize,
         fontWeight = FontWeight.SemiBold,
         letterSpacing = 0.8.sp
     )
@@ -3603,7 +3617,7 @@ private fun EmulatorSectionHeader(title: String, usage: String?) {
         Text(
             text = title,
             color = TextSecondary,
-            fontSize = 13.sp,
+            fontSize = SettingSectionLabelSize,
             fontWeight = FontWeight.SemiBold,
             letterSpacing = 0.8.sp
         )
@@ -3635,10 +3649,10 @@ private fun SettingGroup(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(SettingGroupCorner))
             .background(CardSurface)
-            .border(1.dp, CardBorder, RoundedCornerShape(14.dp))
-            .padding(16.dp)
+            .border(1.dp, CardBorder, RoundedCornerShape(SettingGroupCorner))
+            .padding(SettingGroupPadding)
     ) {
         content()
     }
@@ -3660,26 +3674,26 @@ private fun SettingDropdown(
         Text(
             label,
             color = TextSecondary,
-            fontSize = 12.sp,
+            fontSize = SettingLabelSize,
             fontWeight = FontWeight.Medium,
             letterSpacing = 0.3.sp,
-            modifier = Modifier.padding(bottom = 6.dp)
+            modifier = Modifier.padding(bottom = SettingTightGap)
         )
         Box {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(RoundedCornerShape(SettingFieldCorner))
                     .background(InputSurface)
-                    .border(1.dp, InputBorder, RoundedCornerShape(8.dp))
+                    .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
                     .then(if (enabled) Modifier.clickable { expanded = true } else Modifier)
-                    .padding(horizontal = 14.dp, vertical = 11.dp),
+                    .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     selectedText,
                     color = TextPrimary,
-                    fontSize = 14.sp,
+                    fontSize = SettingValueSize,
                     modifier = Modifier.weight(1f),
                     maxLines = 1
                 )
@@ -3687,7 +3701,7 @@ private fun SettingDropdown(
                     Icons.Outlined.KeyboardArrowDown,
                     contentDescription = null,
                     tint = TextDim,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(SettingIconSize)
                 )
             }
             DropdownMenu(
@@ -3702,7 +3716,7 @@ private fun SettingDropdown(
                             Text(
                                 entry,
                                 color = if (index == selectedIndex) AccentBlue else TextPrimary,
-                                fontSize = 14.sp,
+                                fontSize = SettingValueSize,
                                 fontWeight = if (index == selectedIndex) FontWeight.Medium else FontWeight.Normal
                             )
                         },
@@ -3733,27 +3747,27 @@ private fun SettingTextField(
         Text(
             label,
             color = TextSecondary,
-            fontSize = 12.sp,
+            fontSize = SettingLabelSize,
             fontWeight = FontWeight.Medium,
             letterSpacing = 0.3.sp,
-            modifier = Modifier.padding(bottom = 6.dp)
+            modifier = Modifier.padding(bottom = SettingTightGap)
         )
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
             textStyle = TextStyle(
                 color = TextPrimary,
-                fontSize = 14.sp
+                fontSize = SettingValueSize
             ),
             cursorBrush = SolidColor(AccentBlue),
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(SettingFieldCorner))
                 .background(InputSurface)
-                .border(1.dp, InputBorder, RoundedCornerShape(10.dp))
-                .padding(horizontal = 14.dp, vertical = 12.dp)
+                .border(1.dp, InputBorder, RoundedCornerShape(SettingFieldCorner))
+                .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
         )
     }
 }
@@ -3772,25 +3786,25 @@ private fun SettingCheckbox(
             .alpha(alpha)
             .clip(RoundedCornerShape(8.dp))
             .then(if (enabled) Modifier.clickable { onCheckedChange(!checked) } else Modifier)
-            .padding(vertical = 6.dp),
+            .padding(vertical = SettingTightGap),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
             checked = checked,
             onCheckedChange = if (enabled) onCheckedChange else null,
             enabled = enabled,
-            modifier = Modifier.size(22.dp),
+            modifier = Modifier.size(20.dp),
             colors = CheckboxDefaults.colors(
                 checkedColor = AccentBlue,
                 uncheckedColor = CheckBorder,
                 checkmarkColor = Color.White
             )
         )
-        Spacer(Modifier.width(12.dp))
+        Spacer(Modifier.width(10.dp))
         Text(
             label,
             color = TextPrimary,
-            fontSize = 14.sp
+            fontSize = SettingValueSize
         )
     }
 }
@@ -3807,7 +3821,7 @@ private fun SettingSlider(
             Text(
                 label,
                 color = TextSecondary,
-                fontSize = 12.sp,
+                fontSize = SettingLabelSize,
                 fontWeight = FontWeight.Medium,
                 letterSpacing = 0.3.sp
             )
@@ -3817,24 +3831,24 @@ private fun SettingSlider(
                 modifier = Modifier
                     .clip(RoundedCornerShape(6.dp))
                     .background(AccentBlue.copy(alpha = 0.1f))
-                    .padding(horizontal = 8.dp, vertical = 3.dp)
+                    .padding(horizontal = 7.dp, vertical = 2.dp)
             ) {
                 Text(
                     "$value%",
                     color = AccentBlue,
-                    fontSize = 12.sp,
+                    fontSize = SettingLabelSize,
                     fontWeight = FontWeight.SemiBold
                 )
             }
         }
-        Spacer(Modifier.height(6.dp))
+        Spacer(Modifier.height(SettingTightGap))
         Slider(
             value = value.toFloat(),
             onValueChange = { onValueChange(it.roundToInt()) },
             valueRange = range.first.toFloat()..range.last.toFloat(),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(28.dp),
+                .height(24.dp),
             colors = SliderDefaults.colors(
                 thumbColor = Color.White,
                 activeTrackColor = AccentBlue,

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -447,81 +446,40 @@ fun GameSettingsContent(
     val currentSectionId = sections.getOrNull(selectedIdx)?.first ?: SEC_GENERAL
     val saveEnabled by state.isLoaded
 
-    BoxWithConstraints(
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .clip(RoundedCornerShape(16.dp))
             .background(BgDeep)
     ) {
-        val isCompact = maxWidth < 720.dp
+        Row(modifier = Modifier.fillMaxSize()) {
+            Sidebar(
+                title = state.name.value,
+                sections = sections.map { it.second },
+                currentIndex = selectedIdx,
+                onSectionSelected = { state.currentSection.intValue = it },
+                saveEnabled = saveEnabled,
+                onSave = { callbacks.onConfirm() },
+                onCancel = { callbacks.onDismiss() },
+                modifier = Modifier
+                    .width(220.dp)
+                    .fillMaxHeight()
+            )
 
-        if (isCompact) {
-            // Compact layout: top title+action bar + content + bottom section picker
-            Column(modifier = Modifier.fillMaxSize()) {
-                // Top action bar: title on left, Cancel/Save on right
-                CompactBottomBar(
-                    title = state.name.value,
-                    saveEnabled = saveEnabled,
-                    onSave = { callbacks.onConfirm() },
-                    onCancel = { callbacks.onDismiss() }
-                )
+            Box(
+                modifier = Modifier
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .background(DividerColor)
+            )
 
-                Box(
-                    Modifier.fillMaxWidth().height(1.dp).background(DividerColor)
-                )
-
-                // Content area
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
-                        .background(ContentBg)
-                ) {
-                    SectionContent(currentSectionId, state, callbacks, isCompact)
-                }
-
-                Box(
-                    Modifier.fillMaxWidth().height(1.dp).background(DividerColor)
-                )
-
-                // Bottom section picker - scrollable row of chips
-                CompactTopBar(
-                    sections = sections,
-                    currentIndex = selectedIdx,
-                    onSectionSelected = { state.currentSection.intValue = it }
-                )
-            }
-        } else {
-            // Wide layout: sidebar + content
-            Row(modifier = Modifier.fillMaxSize()) {
-                Sidebar(
-                    title = state.name.value,
-                    sections = sections.map { it.second },
-                    currentIndex = selectedIdx,
-                    onSectionSelected = { state.currentSection.intValue = it },
-                    saveEnabled = saveEnabled,
-                    onSave = { callbacks.onConfirm() },
-                    onCancel = { callbacks.onDismiss() },
-                    modifier = Modifier
-                        .width(200.dp)
-                        .fillMaxHeight()
-                )
-
-                Box(
-                    modifier = Modifier
-                        .width(1.dp)
-                        .fillMaxHeight()
-                        .background(DividerColor)
-                )
-
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .background(ContentBg)
-                ) {
-                    SectionContent(currentSectionId, state, callbacks, false)
-                }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(ContentBg)
+            ) {
+                SectionContent(currentSectionId, state, callbacks)
             }
         }
     }
@@ -531,8 +489,7 @@ fun GameSettingsContent(
 private fun SectionContent(
     sectionId: Int,
     state: GameSettingsStateHolder,
-    callbacks: GameSettingsCallbacks,
-    isCompact: Boolean
+    callbacks: GameSettingsCallbacks
 ) {
     AnimatedContent(
         targetState = sectionId,
@@ -550,12 +507,11 @@ private fun SectionContent(
         label = "SectionTransition"
     ) { id ->
         val scrollState = rememberScrollState()
-        val hPad = if (isCompact) 12.dp else 20.dp
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(horizontal = hPad, vertical = 14.dp)
+                .padding(horizontal = 20.dp, vertical = 14.dp)
         ) {
             when (id) {
                 SEC_GENERAL -> GeneralSection(state, callbacks)
@@ -569,108 +525,6 @@ private fun SectionContent(
             }
             Spacer(Modifier.height(SettingSectionGap))
         }
-    }
-}
-
-// ===================================================================
-// Compact layout components (small screens)
-// ===================================================================
-@Composable
-private fun CompactTopBar(
-    sections: List<Pair<Int, SidebarSection>>,
-    currentIndex: Int,
-    onSectionSelected: (Int) -> Unit
-) {
-    val scrollState = rememberScrollState()
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SidebarBg)
-            .horizontalScroll(scrollState)
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        sections.forEachIndexed { index, (_, section) ->
-            val isSelected = currentIndex == index
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(8.dp))
-                    .chasingBorder(isFocused = isSelected, cornerRadius = 8.dp, borderWidth = 2.dp)
-                    .background(if (isSelected) AccentBlue.copy(alpha = 0.08f) else Color.Transparent)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = { onSectionSelected(index) }
-                    )
-                    .padding(horizontal = 10.dp, vertical = 6.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        section.icon,
-                        contentDescription = null,
-                        tint = if (isSelected) AccentBlue else TextDim,
-                        modifier = Modifier.size(SettingControlIconSize)
-                    )
-                    Spacer(Modifier.width(5.dp))
-                    Text(
-                        stringResource(section.labelResId),
-                        color = if (isSelected) TextPrimary else TextSecondary,
-                        fontSize = SettingLabelSize,
-                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                        maxLines = 1
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun CompactBottomBar(
-    title: String,
-    saveEnabled: Boolean,
-    onSave: () -> Unit,
-    onCancel: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(SidebarBg)
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        // Game title on the left — matches the Sidebar header text format
-        if (title.isNotBlank()) {
-            Text(
-                text = title,
-                color = TextPrimary,
-                fontSize = SettingLabelSize,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.2.sp,
-                lineHeight = 15.sp,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-        } else {
-            Spacer(Modifier.weight(1f))
-        }
-
-        // Smaller right-aligned Cancel / Save buttons
-        Box(
-            modifier = Modifier
-                .height(26.dp)
-                .clip(RoundedCornerShape(7.dp))
-                .border(1.dp, CardBorder, RoundedCornerShape(7.dp))
-                .background(CardSurface)
-                .clickable { onCancel() }
-                .padding(horizontal = 12.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(stringResource(R.string.common_ui_cancel), color = TextSecondary, fontSize = SettingLabelSize, fontWeight = FontWeight.Medium)
-        }
-        SaveButton(enabled = saveEnabled, onClick = onSave, height = 26.dp, corner = 7.dp, fontSize = SettingLabelSize)
     }
 }
 

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -136,6 +136,7 @@ private val SettingControlIconSize = 16.dp
 private val SettingLabelSize = 11.sp
 private val SettingValueSize = 13.sp
 private val SettingSectionLabelSize = 12.sp
+private val SmartDropdownPressStartInset = 28.dp
 
 @Composable
 private fun rememberSmartDropdownOffset(): MutableState<DpOffset> =
@@ -151,7 +152,14 @@ private fun Modifier.smartDropdownAnchor(
     val density = LocalDensity.current
     return pointerInput(enabled, density, onOpen) {
         detectTapGestures { tapOffset ->
-            offset.value = with(density) { DpOffset(tapOffset.x.toDp(), 0.dp) }
+            offset.value =
+                with(density) {
+                    val tapX = tapOffset.x.toDp()
+                    DpOffset(
+                        if (tapX > SmartDropdownPressStartInset) tapX - SmartDropdownPressStartInset else 0.dp,
+                        0.dp,
+                    )
+                }
             onOpen()
         }
     }
@@ -2159,9 +2167,7 @@ private fun VariablesSection(
     callbacks: GameSettingsCallbacks
 ) {
     val isContainer = state.isContainerEditMode.value
-    var isAdding by remember { mutableStateOf(false) }
-    var newName by remember { mutableStateOf("") }
-    var newValue by remember { mutableStateOf("") }
+    val hasDraftEnvVar = state.envVars.value.any { it.key.isBlank() }
 
     if (isContainer) {
         SubsectionLabel(stringResource(R.string.container_config_variables))
@@ -2169,7 +2175,7 @@ private fun VariablesSection(
     }
 
     SettingGroup {
-        if (state.envVars.value.isEmpty() && !isAdding) {
+        if (state.envVars.value.isEmpty()) {
             Text(
                 stringResource(R.string.common_ui_none),
                 color = TextDim,
@@ -2196,10 +2202,12 @@ private fun VariablesSection(
                         .map { it.key }
                         .toSet(),
                     onNameChange = { newKey ->
-                        if (newKey.isNotEmpty() &&
-                            state.envVars.value.none { it.key == newKey }) {
-                            val list = state.envVars.value.toMutableList()
-                            list[index] = EnvVarItem(newKey, "")
+                        val normalizedKey = newKey.trim()
+                        val list = state.envVars.value.toMutableList()
+                        val isUnique = normalizedKey.isEmpty() ||
+                            state.envVars.value.none { it.key == normalizedKey }
+                        if (index in list.indices && isUnique) {
+                            list[index] = EnvVarItem(normalizedKey, envVar.value)
                             state.envVars.value = list
                         }
                     },
@@ -2213,75 +2221,17 @@ private fun VariablesSection(
             }
         }
 
-        // Inline add row
-        if (isAdding) {
-            if (state.envVars.value.isNotEmpty()) {
-                Spacer(Modifier.height(1.dp))
-                Box(Modifier.fillMaxWidth().height(1.dp).background(DividerColor))
-                Spacer(Modifier.height(6.dp))
-            }
-            EnvVarRow(
-                name = newName,
-                value = newValue,
-                excludeOtherNames = state.envVars.value.map { it.key }.toSet(),
-                onNameChange = { newName = it; newValue = "" },
-                onValueChange = { newValue = it },
-                onRemove = null,
-                trailing = {
-                    Spacer(Modifier.width(3.dp))
-                    Box(
-                        modifier = Modifier
-                            .size(26.dp)
-                            .clip(RoundedCornerShape(6.dp))
-                            .background(AccentBlue.copy(alpha = 0.15f))
-                            .clickable {
-                                val key = newName.trim()
-                                if (key.isNotEmpty() &&
-                                    state.envVars.value.none { it.key == key }) {
-                                    val list = state.envVars.value.toMutableList()
-                                    list.add(EnvVarItem(key, newValue.trim()))
-                                    state.envVars.value = list
-                                }
-                                newName = ""
-                                newValue = ""
-                                isAdding = false
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Outlined.Check, contentDescription = null, tint = AccentBlue, modifier = Modifier.size(SettingControlIconSize))
-                    }
-                    Spacer(Modifier.width(3.dp))
-                    Box(
-                        modifier = Modifier
-                            .size(26.dp)
-                            .clip(RoundedCornerShape(6.dp))
-                            .background(DangerRed.copy(alpha = 0.1f))
-                            .clickable {
-                                newName = ""
-                                newValue = ""
-                                isAdding = false
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Outlined.Close, contentDescription = null, tint = DangerRed, modifier = Modifier.size(SettingControlIconSize))
-                    }
-                }
-            )
-        }
-
         Spacer(Modifier.height(SettingItemGap))
 
         // Add button
-        if (!isAdding) {
+        if (!hasDraftEnvVar) {
             Box(
                 modifier = Modifier
                     .clip(RoundedCornerShape(8.dp))
                     .background(AccentBlue.copy(alpha = 0.08f))
                     .border(1.dp, AccentBlue.copy(alpha = 0.2f), RoundedCornerShape(8.dp))
                     .clickable {
-                        newName = ""
-                        newValue = ""
-                        isAdding = true
+                        state.envVars.value = state.envVars.value + EnvVarItem("", "")
                     }
                     .padding(horizontal = 12.dp, vertical = 8.dp)
             ) {

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1453,17 +1453,30 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val needsNearFullWidth = screenWidthDp < 820f
         val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
         val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
-        val systemInsets =
+        val navInsets =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
-                    WindowInsets.Type.navigationBars() or WindowInsets.Type.displayCutout()
+                    WindowInsets.Type.navigationBars()
+                )
+            } else {
+                null
+            }
+        val cutoutInsets =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
+                    WindowInsets.Type.displayCutout()
                 )
             } else {
                 null
             }
         val edgePaddingPx = (12f * dm.density).toInt().coerceAtLeast(1)
-        val horizontalInsetPx = maxOf(systemInsets?.left ?: 0, systemInsets?.right ?: 0)
-        val verticalInsetPx = maxOf(systemInsets?.top ?: 0, systemInsets?.bottom ?: 0)
+        val cutoutPaddingCapPx = (8f * dm.density).toInt()
+        val leftInsetPx = maxOf(navInsets?.left ?: 0, (cutoutInsets?.left ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val rightInsetPx = maxOf(navInsets?.right ?: 0, (cutoutInsets?.right ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val topInsetPx = maxOf(navInsets?.top ?: 0, (cutoutInsets?.top ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val bottomInsetPx = maxOf(navInsets?.bottom ?: 0, (cutoutInsets?.bottom ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val horizontalInsetPx = maxOf(leftInsetPx, rightInsetPx)
+        val verticalInsetPx = maxOf(topInsetPx, bottomInsetPx)
         val maxDialogWidth = (bounds.first - ((horizontalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
         val maxDialogHeight = (bounds.second - ((verticalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
 

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
 import android.view.Window
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -1452,10 +1453,23 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val needsNearFullWidth = screenWidthDp < 820f
         val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
         val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
+        val systemInsets =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
+                    WindowInsets.Type.navigationBars() or WindowInsets.Type.displayCutout()
+                )
+            } else {
+                null
+            }
+        val edgePaddingPx = (12f * dm.density).toInt().coerceAtLeast(1)
+        val horizontalInsetPx = maxOf(systemInsets?.left ?: 0, systemInsets?.right ?: 0)
+        val verticalInsetPx = maxOf(systemInsets?.top ?: 0, systemInsets?.bottom ?: 0)
+        val maxDialogWidth = (bounds.first - ((horizontalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
+        val maxDialogHeight = (bounds.second - ((verticalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
 
         setLayout(
-            (bounds.first * widthFactor).toInt(),
-            (bounds.second * heightFactor).toInt(),
+            (bounds.first * widthFactor).toInt().coerceAtMost(maxDialogWidth),
+            (bounds.second * heightFactor).toInt().coerceAtMost(maxDialogHeight),
         )
     }
 

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1327,7 +1327,9 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
     }
 
     private fun buildEnvVarsString(): String {
-        val filtered = state.envVars.value.filterNot { it.key in SDL2_KEYS }
+        val filtered = state.envVars.value
+            .filter { it.key.isNotBlank() }
+            .filterNot { it.key in SDL2_KEYS }
         val merged = if (state.sdl2Compatibility.value) {
             filtered + SDL2_ENV_VARS.map { EnvVarItem(it.first, it.second) }
         } else filtered

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1449,17 +1449,9 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             }
 
         val screenWidthDp = bounds.first / dm.density
-        val dialogWidthDp = screenWidthDp * 0.88f
-        val isCompactLayout = dialogWidthDp < 720f
-        val widthFactor: Float
-        val heightFactor: Float
-        if (screenWidthDp < 600f) {
-            widthFactor = 0.96f
-            heightFactor = 0.90f
-        } else {
-            widthFactor = 0.88f
-            heightFactor = if (isCompactLayout) 0.90f else 0.88f
-        }
+        val needsNearFullWidth = screenWidthDp < 820f
+        val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
+        val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
 
         setLayout(
             (bounds.first * widthFactor).toInt(),

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -2,6 +2,7 @@ package com.winlator.cmod.feature.settings
 import android.app.Activity
 import android.app.Dialog
 import android.net.Uri
+import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
 import android.view.Window
@@ -10,7 +11,10 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
@@ -158,7 +162,12 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             setViewTreeSavedStateRegistryOwner(activity as SavedStateRegistryOwner)
             setContent {
                 WinNativeTheme {
-                    GameSettingsContent(state = state, callbacks = createCallbacks())
+                    val defaultDensity = LocalDensity.current
+                    CompositionLocalProvider(
+                        LocalDensity provides Density(defaultDensity.density, fontScale = 1f)
+                    ) {
+                        GameSettingsContent(state = state, callbacks = createCallbacks())
+                    }
                 }
             }
         }
@@ -1413,27 +1422,49 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
     fun show() {
         dialog.show()
         dialog.window?.apply {
-            val dm = activity.resources.displayMetrics
-            val screenWidthDp = dm.widthPixels / dm.density
-            val dialogWidthDp = screenWidthDp * 0.88f
-            val isCompactLayout = dialogWidthDp < 720f
-            if (screenWidthDp < 600f) {
-                val dialogWidth = (dm.widthPixels * 0.96f).toInt()
-                val dialogHeight = (dm.heightPixels * 0.90f).toInt()
-                setLayout(dialogWidth, dialogHeight)
-            } else {
-                val dialogWidth = (dm.widthPixels * 0.88f).toInt()
-                val heightFactor = if (isCompactLayout) 0.90f else 0.88f
-                val dialogHeight = (dm.heightPixels * heightFactor).toInt()
-                setLayout(dialogWidth, dialogHeight)
-            }
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            applyDialogLayout()
+            decorView.post { applyDialogLayout() }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 val params = attributes
                 params.flags = params.flags or WindowManager.LayoutParams.FLAG_BLUR_BEHIND
                 params.blurBehindRadius = 10
                 attributes = params
             }
         }
+    }
+
+    private fun Window.applyDialogLayout() {
+        val dm = activity.resources.displayMetrics
+        val hostView = activity.window?.decorView
+        val hostWidth = hostView?.width?.takeIf { it > 0 }
+        val hostHeight = hostView?.height?.takeIf { it > 0 }
+        val bounds =
+            if (hostWidth != null && hostHeight != null) {
+                hostWidth to hostHeight
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val windowBounds = activity.windowManager.currentWindowMetrics.bounds
+                windowBounds.width() to windowBounds.height()
+            } else {
+                dm.widthPixels to dm.heightPixels
+            }
+
+        val screenWidthDp = bounds.first / dm.density
+        val dialogWidthDp = screenWidthDp * 0.88f
+        val isCompactLayout = dialogWidthDp < 720f
+        val widthFactor: Float
+        val heightFactor: Float
+        if (screenWidthDp < 600f) {
+            widthFactor = 0.96f
+            heightFactor = 0.90f
+        } else {
+            widthFactor = 0.88f
+            heightFactor = if (isCompactLayout) 0.90f else 0.88f
+        }
+
+        setLayout(
+            (bounds.first * widthFactor).toInt(),
+            (bounds.second * heightFactor).toInt(),
+        )
     }
 
     fun dismiss() {

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -103,6 +103,19 @@ private val InputTextSecondary = Color(0xFF7A8FA8)
 private val InputDanger = Color(0xFFFF7A88)
 private val InputTickHidden = Color.Transparent
 
+private val InputCardCorner = 10.dp
+private val InputCardHorizontalPadding = 12.dp
+private val InputCardVerticalPadding = 10.dp
+private val InputFieldCorner = 8.dp
+private val InputCompactGap = 6.dp
+private val InputItemGap = 8.dp
+private val InputIconBoxSize = 38.dp
+private val InputActionSize = 30.dp
+private val InputSliderHeight = 24.dp
+private val InputPrimaryTextSize = 13.sp
+private val InputSecondaryTextSize = 11.sp
+private val InputSectionTextSize = 10.sp
+
 data class InputControlsScreenState(
     val selectedProfileName: String? = null,
     val selectedProfileElementCount: Int = 0,
@@ -241,12 +254,12 @@ fun InputControlsScreen(
             modifier = Modifier.fillMaxSize(),
             contentPadding =
                 PaddingValues(
-                    start = 16.dp + navBarStartPadding,
-                    top = 16.dp,
-                    end = 16.dp + navBarEndPadding,
-                    bottom = 20.dp + navBarBottomPadding,
+                    start = 12.dp + navBarStartPadding,
+                    top = 12.dp,
+                    end = 12.dp + navBarEndPadding,
+                    bottom = 16.dp + navBarBottomPadding,
                 ),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(InputCompactGap),
         ) {
             item("profile-card") { ProfileCard(state, actions) }
             item("overlay-label") { SectionLabel(stringResource(R.string.input_controls_editor_overlay_opacity)) }
@@ -344,9 +357,9 @@ private fun SectionLabel(text: String) {
     Text(
         text = text.uppercase(),
         color = InputTextSecondary,
-        fontSize = 11.sp,
+        fontSize = InputSectionTextSize,
         fontWeight = FontWeight.Bold,
-        letterSpacing = 1.2.sp,
+        letterSpacing = 1.sp,
         modifier = Modifier.padding(start = 4.dp),
     )
 }
@@ -371,11 +384,11 @@ private fun CardShell(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(InputCardCorner))
                 .background(InputCard)
-                .border(1.dp, InputOutline, RoundedCornerShape(12.dp))
+                .border(1.dp, InputOutline, RoundedCornerShape(InputCardCorner))
                 .then(clickableModifier)
-                .padding(horizontal = 14.dp, vertical = 12.dp),
+                .padding(horizontal = InputCardHorizontalPadding, vertical = InputCardVerticalPadding),
     ) {
         content()
     }
@@ -389,8 +402,8 @@ private fun IconBox(
     Box(
         modifier =
             Modifier
-                .size(44.dp)
-                .clip(RoundedCornerShape(10.dp))
+                .size(InputIconBoxSize)
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputIconBox),
         contentAlignment = Alignment.Center,
     ) {
@@ -398,7 +411,7 @@ private fun IconBox(
             imageVector = image,
             contentDescription = null,
             tint = tint,
-            modifier = Modifier.size(22.dp),
+            modifier = Modifier.size(18.dp),
         )
     }
 }
@@ -409,15 +422,15 @@ private fun IconActionButton(
     contentDescription: String,
     tint: Color = InputTextSecondary,
     onClick: () -> Unit,
-    size: Dp = 34.dp,
+    size: Dp = InputActionSize,
 ) {
     Box(
         modifier =
             Modifier
                 .size(size)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputSubcard)
-                .border(1.dp, InputOutline, RoundedCornerShape(8.dp))
+                .border(1.dp, InputOutline, RoundedCornerShape(InputFieldCorner))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -429,7 +442,7 @@ private fun IconActionButton(
             imageVector = image,
             contentDescription = contentDescription,
             tint = tint,
-            modifier = Modifier.size(if (size <= 28.dp) 14.dp else 18.dp),
+            modifier = Modifier.size(if (size <= 28.dp) 14.dp else 16.dp),
         )
     }
 }
@@ -457,7 +470,7 @@ private fun ChipRow(
     selectedIndex: Int,
     onSelected: (Int) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(InputCompactGap)) {
         options.forEachIndexed { index, label ->
             Chip(
                 text = label,
@@ -477,24 +490,24 @@ private fun Chip(
     Box(
         modifier =
             Modifier
-                .height(34.dp)
-                .clip(RoundedCornerShape(9.dp))
+                .height(30.dp)
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(if (selected) InputAccent.copy(alpha = 0.18f) else InputSubcard)
                 .border(
                     1.dp,
                     if (selected) InputAccent.copy(alpha = 0.35f) else InputOutline,
-                    RoundedCornerShape(9.dp),
+                    RoundedCornerShape(InputFieldCorner),
                 ).clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onClick,
-                ).padding(horizontal = 14.dp),
+                ).padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,
             color = if (selected) InputAccent else InputTextSecondary,
-            fontSize = 13.sp,
+            fontSize = InputSecondaryTextSize,
             fontWeight = FontWeight.Bold,
         )
     }
@@ -508,21 +521,21 @@ private fun SelectionPill(
     Row(
         modifier =
             Modifier
-                .heightIn(min = 34.dp)
-                .clip(RoundedCornerShape(9.dp))
+                .heightIn(min = 30.dp)
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputField)
-                .border(1.dp, InputOutline, RoundedCornerShape(9.dp))
+                .border(1.dp, InputOutline, RoundedCornerShape(InputFieldCorner))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onClick,
-                ).padding(start = 14.dp, end = 10.dp, top = 8.dp, bottom = 8.dp),
+                ).padding(start = 12.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
             color = InputTextPrimary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -543,16 +556,16 @@ private fun EmptyStateCard(text: String) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(InputCardCorner))
                 .background(InputCard)
-                .border(1.dp, InputOutline, RoundedCornerShape(12.dp))
-                .padding(horizontal = 18.dp, vertical = 24.dp),
+                .border(1.dp, InputOutline, RoundedCornerShape(InputCardCorner))
+                .padding(horizontal = 14.dp, vertical = 16.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,
             color = InputTextSecondary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
             textAlign = TextAlign.Center,
         )
     }
@@ -628,8 +641,8 @@ private fun ProfileSelectorIconBox(tint: Color) {
     Box(
         modifier =
             Modifier
-                .size(44.dp)
-                .clip(RoundedCornerShape(10.dp))
+                .size(InputIconBoxSize)
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputIconBox),
         contentAlignment = Alignment.Center,
     ) {
@@ -1215,7 +1228,7 @@ private fun ProfileCard(
                 onClick = actions.onSelectProfile,
                 modifier = Modifier.weight(1f),
             )
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(InputItemGap))
             ProfileActionRow(actions = actions)
         }
     }
@@ -1233,7 +1246,7 @@ private fun ProfileSelectorRow(
     Row(
         modifier =
             modifier
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(InputCardCorner))
                 .background(
                     Color(
                         red = InputField.red,
@@ -1249,30 +1262,30 @@ private fun ProfileSelectorRow(
                         blue = InputOutline.blue + ((InputAccent.blue - InputOutline.blue) * selectorTint * 0.45f),
                         alpha = 0.8f + (0.15f * selectorTint),
                     ),
-                    RoundedCornerShape(12.dp),
+                    RoundedCornerShape(InputCardCorner),
                 )
                 .clickable(
                     interactionSource = selectionInteraction,
                     indication = null,
                     onClick = onClick,
                 )
-                .padding(horizontal = 12.dp, vertical = 10.dp),
+                .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ProfileSelectorIconBox(if (selectorPressed) InputTextPrimary else InputAccent)
-        Spacer(Modifier.width(14.dp))
+        Spacer(Modifier.width(10.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text =
                     state.selectedProfileName
                         ?: stringResource(R.string.input_controls_editor_select_profile),
                 color = InputTextPrimary,
-                fontSize = 15.sp,
+                fontSize = InputPrimaryTextSize,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            Spacer(Modifier.height(2.dp))
+            Spacer(Modifier.height(1.dp))
             Text(
                 text =
                     if (state.selectedProfileName != null) {
@@ -1281,12 +1294,12 @@ private fun ProfileSelectorRow(
                         stringResource(R.string.input_controls_editor_no_profile_selected)
                     },
                 color = InputTextSecondary,
-                fontSize = 12.sp,
+                fontSize = InputSecondaryTextSize,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(InputItemGap))
         Icon(
             imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
             contentDescription = null,
@@ -1296,7 +1309,7 @@ private fun ProfileSelectorRow(
                 } else {
                     InputAccent.copy(alpha = 0.9f)
                 },
-            modifier = Modifier.size(18.dp),
+            modifier = Modifier.size(16.dp),
         )
     }
 }
@@ -1304,7 +1317,7 @@ private fun ProfileSelectorRow(
 @Composable
 private fun ProfileActionRow(actions: InputControlsScreenActions) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.End),
+        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconActionButton(
@@ -1348,23 +1361,23 @@ private fun OverlayOpacityCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconBox(Icons.Outlined.Visibility, InputTextSecondary)
-                Spacer(Modifier.width(14.dp))
+                Spacer(Modifier.width(10.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = stringResource(R.string.input_controls_editor_overlay_opacity),
                         color = InputTextPrimary,
-                        fontSize = 15.sp,
+                        fontSize = InputPrimaryTextSize,
                         fontWeight = FontWeight.Bold,
                     )
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(1.dp))
                     Text(
                         text = "${state.overlayOpacity}%",
                         color = InputTextSecondary,
-                        fontSize = 12.sp,
+                        fontSize = InputSecondaryTextSize,
                     )
                 }
             }
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(InputCompactGap))
             Slider(
                 value = state.overlayOpacity.toFloat(),
                 onValueChange = {
@@ -1372,6 +1385,7 @@ private fun OverlayOpacityCard(
                 },
                 valueRange = 10f..100f,
                 steps = 17,
+                modifier = Modifier.height(InputSliderHeight),
                 colors = sliderColors(),
             )
         }
@@ -1392,8 +1406,8 @@ private fun ActionCard(
             Box(
                 modifier =
                     Modifier
-                        .size(36.dp)
-                        .clip(RoundedCornerShape(9.dp))
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(InputFieldCorner))
                         .background(InputIconBox),
                 contentAlignment = Alignment.Center,
             ) {
@@ -1401,14 +1415,14 @@ private fun ActionCard(
                     imageVector = icon,
                     contentDescription = null,
                     tint = InputTextSecondary,
-                    modifier = Modifier.size(18.dp),
+                    modifier = Modifier.size(16.dp),
                 )
             }
-            Spacer(Modifier.width(12.dp))
+            Spacer(Modifier.width(10.dp))
             Text(
                 text = title,
                 color = InputTextPrimary,
-                fontSize = 14.sp,
+                fontSize = InputPrimaryTextSize,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(1f),
             )
@@ -1438,10 +1452,10 @@ private fun Subcard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(InputCardCorner))
                 .background(InputSubcard)
-                .border(1.dp, InputOutline, RoundedCornerShape(10.dp))
-                .padding(horizontal = 10.dp, vertical = 6.dp),
+                .border(1.dp, InputOutline, RoundedCornerShape(InputCardCorner))
+                .padding(horizontal = 8.dp, vertical = 5.dp),
     ) {
         Row(
             modifier =
@@ -1457,7 +1471,7 @@ private fun Subcard(
             Box(
                 modifier =
                     Modifier
-                        .size(30.dp)
+                        .size(28.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(InputIconBox),
                 contentAlignment = Alignment.Center,
@@ -1468,15 +1482,15 @@ private fun Subcard(
                     tint = InputTextSecondary,
                     modifier =
                         Modifier
-                            .size(14.dp)
+                            .size(13.dp)
                             .graphicsLayer { rotationZ = chevronRotation },
                 )
             }
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(InputItemGap))
             Text(
                 text = title,
                 color = InputTextSecondary,
-                fontSize = 13.sp,
+                fontSize = InputPrimaryTextSize,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -1500,13 +1514,14 @@ private fun SliderField(
         Text(
             text = label,
             color = InputTextSecondary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
         )
         Slider(
             value = value,
             onValueChange = onValueChange,
             valueRange = valueRange,
             steps = steps,
+            modifier = Modifier.height(InputSliderHeight),
             colors = sliderColors(),
         )
     }
@@ -1525,7 +1540,7 @@ private fun SwitchRow(
         Text(
             text = title,
             color = InputTextSecondary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
             modifier = Modifier.weight(1f),
         )
         AppSwitch(checked = checked, onCheckedChange = onCheckedChange)
@@ -1540,22 +1555,22 @@ private fun CenteredPillButton(
     Box(
         modifier =
             Modifier
-                .height(34.dp)
+                .height(30.dp)
                 .widthIn(min = 96.dp)
-                .clip(RoundedCornerShape(9.dp))
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputSubcard)
-                .border(1.dp, InputOutline, RoundedCornerShape(9.dp))
+                .border(1.dp, InputOutline, RoundedCornerShape(InputFieldCorner))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onClick,
-                ).padding(horizontal = 14.dp),
+                ).padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,
             color = InputTextPrimary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
         )
@@ -1574,11 +1589,11 @@ private fun GyroscopeCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconBox(Icons.Outlined.ScreenRotationAlt, InputTextSecondary)
-                Spacer(Modifier.width(14.dp))
+                Spacer(Modifier.width(10.dp))
                 Text(
                     text = stringResource(R.string.session_gyroscope_title),
                     color = InputTextPrimary,
-                    fontSize = 15.sp,
+                    fontSize = InputPrimaryTextSize,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.weight(1f),
                 )
@@ -1588,7 +1603,7 @@ private fun GyroscopeCard(
                 )
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(InputItemGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1596,9 +1611,9 @@ private fun GyroscopeCard(
                 Text(
                     text = stringResource(R.string.common_ui_mode),
                     color = InputTextSecondary,
-                    fontSize = 13.sp,
+                    fontSize = InputPrimaryTextSize,
                 )
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(InputItemGap))
                 ChipRow(
                     options =
                         listOf(
@@ -1610,7 +1625,7 @@ private fun GyroscopeCard(
                 )
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(InputItemGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1618,7 +1633,7 @@ private fun GyroscopeCard(
                 Text(
                     text = stringResource(R.string.session_gyroscope_activator_button),
                     color = InputTextSecondary,
-                    fontSize = 13.sp,
+                    fontSize = InputPrimaryTextSize,
                     modifier = Modifier.weight(1f),
                 )
                 SelectionPill(
@@ -1627,7 +1642,7 @@ private fun GyroscopeCard(
                 )
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(InputItemGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1635,13 +1650,13 @@ private fun GyroscopeCard(
                 Text(
                     text = stringResource(R.string.session_gyroscope_enable_right_stick),
                     color = InputTextSecondary,
-                    fontSize = 13.sp,
+                    fontSize = InputPrimaryTextSize,
                     modifier = Modifier.weight(1f),
                 )
                 Text(
                     text = stringResource(R.string.common_ui_experimental),
                     color = InputAccent,
-                    fontSize = 11.sp,
+                    fontSize = InputSecondaryTextSize,
                     fontWeight = FontWeight.Medium,
                 )
                 Spacer(Modifier.width(8.dp))
@@ -1651,7 +1666,7 @@ private fun GyroscopeCard(
                 )
             }
 
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(InputItemGap))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1659,13 +1674,13 @@ private fun GyroscopeCard(
                 Text(
                     text = stringResource(R.string.session_gyroscope_experimental_mouse_movement),
                     color = InputTextSecondary,
-                    fontSize = 13.sp,
+                    fontSize = InputPrimaryTextSize,
                     modifier = Modifier.weight(1f),
                 )
                 Text(
                     text = stringResource(R.string.common_ui_experimental),
                     color = InputAccent,
-                    fontSize = 11.sp,
+                    fontSize = InputSecondaryTextSize,
                     fontWeight = FontWeight.Medium,
                 )
                 Spacer(Modifier.width(8.dp))
@@ -1676,7 +1691,7 @@ private fun GyroscopeCard(
             }
 
             if (state.gyroMouseEnabled) {
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 SliderField(
                     label = stringResource(R.string.session_gyroscope_mouse_sensitivity_format, state.gyroMouseScale),
                     value = state.gyroMouseScale.toFloat(),
@@ -1686,7 +1701,7 @@ private fun GyroscopeCard(
                 )
             }
 
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(InputCompactGap))
             Subcard(
                 title = stringResource(R.string.session_gyroscope_calibrate),
                 expanded = state.gyroscopeExpanded,
@@ -1694,7 +1709,7 @@ private fun GyroscopeCard(
                     actions.onGyroscopeExpandedChanged(!state.gyroscopeExpanded)
                 },
             ) {
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(InputItemGap))
                 SliderField(
                     label = stringResource(R.string.session_gyroscope_x_sensitivity_format, state.gyroXSensitivity),
                     value = state.gyroXSensitivity.toFloat(),
@@ -1702,7 +1717,7 @@ private fun GyroscopeCard(
                     steps = 199,
                     onValueChange = { actions.onGyroXSensitivityChanged(it.roundToInt().coerceIn(0, 200)) },
                 )
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 SliderField(
                     label = stringResource(R.string.session_gyroscope_y_sensitivity_format, state.gyroYSensitivity),
                     value = state.gyroYSensitivity.toFloat(),
@@ -1710,7 +1725,7 @@ private fun GyroscopeCard(
                     steps = 199,
                     onValueChange = { actions.onGyroYSensitivityChanged(it.roundToInt().coerceIn(0, 200)) },
                 )
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 SliderField(
                     label = stringResource(R.string.session_gyroscope_smoothing_format, state.gyroSmoothing),
                     value = state.gyroSmoothing.toFloat(),
@@ -1718,7 +1733,7 @@ private fun GyroscopeCard(
                     steps = 99,
                     onValueChange = { actions.onGyroSmoothingChanged(it.roundToInt().coerceIn(0, 100)) },
                 )
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 SliderField(
                     label = stringResource(R.string.session_gyroscope_deadzone_format, state.gyroDeadzone),
                     value = state.gyroDeadzone.toFloat(),
@@ -1726,7 +1741,7 @@ private fun GyroscopeCard(
                     steps = 99,
                     onValueChange = { actions.onGyroDeadzoneChanged(it.roundToInt().coerceIn(0, 100)) },
                 )
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(InputItemGap))
                 SwitchRow(
                     title = stringResource(R.string.session_gamepad_invert_x),
                     checked = state.invertGyroX,
@@ -1738,12 +1753,12 @@ private fun GyroscopeCard(
                     checked = state.invertGyroY,
                     onCheckedChange = actions.onInvertGyroYChanged,
                 )
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(InputItemGap))
                 Box(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .height(160.dp)
+                            .height(136.dp)
                             .clip(RoundedCornerShape(10.dp))
                             .background(Color.Black),
                 ) {
@@ -1762,7 +1777,7 @@ private fun GyroscopeCard(
                         onDispose { actions.onDetachGyroPreview() }
                     }
                 }
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(InputItemGap))
                 CenteredPillButton(
                     text = stringResource(R.string.session_gyroscope_reset_stick),
                     onClick = actions.onResetGyroPreview,
@@ -1784,15 +1799,15 @@ private fun TriggerTypeCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconBox(Icons.Outlined.Tune, InputTextSecondary)
-                Spacer(Modifier.width(14.dp))
+                Spacer(Modifier.width(10.dp))
                 Text(
                     text = stringResource(R.string.session_gamepad_trigger_type),
                     color = InputTextPrimary,
-                    fontSize = 15.sp,
+                    fontSize = InputPrimaryTextSize,
                     fontWeight = FontWeight.Bold,
                 )
             }
-            Spacer(Modifier.height(10.dp))
+            Spacer(Modifier.height(InputItemGap))
             ChipRow(
                 options =
                     listOf(
@@ -1802,7 +1817,7 @@ private fun TriggerTypeCard(
                 selectedIndex = state.triggerTypeIndex,
                 onSelected = actions.onTriggerTypeSelected,
             )
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(InputCompactGap))
             Subcard(
                 title = stringResource(R.string.session_gamepad_trigger_type),
                 expanded = state.triggerCardExpanded,
@@ -1810,12 +1825,12 @@ private fun TriggerTypeCard(
                     actions.onTriggerCardExpandedChanged(!state.triggerCardExpanded)
                 },
             ) {
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 Text(
                     text = state.triggerDescription,
                     color = InputTextSecondary,
-                    fontSize = 12.sp,
-                    lineHeight = 18.sp,
+                    fontSize = InputSecondaryTextSize,
+                    lineHeight = 16.sp,
                 )
             }
         }
@@ -1837,21 +1852,21 @@ private fun ControllerCard(
                     image = Icons.Outlined.SportsEsports,
                     tint = if (state.connected) InputAccent else InputDanger,
                 )
-                Spacer(Modifier.width(14.dp))
+                Spacer(Modifier.width(10.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = state.name,
                         color = InputTextPrimary,
-                        fontSize = 15.sp,
+                        fontSize = InputPrimaryTextSize,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(1.dp))
                     Text(
                         text = "${state.bindingCount} ${stringResource(R.string.session_gamepad_bindings)}",
                         color = InputTextSecondary,
-                        fontSize = 12.sp,
+                        fontSize = InputSecondaryTextSize,
                     )
                 }
                 if (state.showBindings && state.bindingCount > 0) {
@@ -1865,7 +1880,7 @@ private fun ControllerCard(
             }
 
             if (state.showBindings) {
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(InputCompactGap))
                 Subcard(
                     title = stringResource(R.string.session_gamepad_control_bindings),
                     expanded = state.expanded,
@@ -1873,22 +1888,22 @@ private fun ControllerCard(
                         actions.onControllerExpandedToggle(state.controllerId)
                     },
                 ) {
-                    Spacer(Modifier.height(8.dp))
+                    Spacer(Modifier.height(InputCompactGap))
                     if (state.bindings.isEmpty()) {
                         Text(
                             text = stringResource(R.string.session_gamepad_press_any_button),
                             color = InputTextSecondary,
-                            fontSize = 13.sp,
+                            fontSize = InputPrimaryTextSize,
                             textAlign = TextAlign.Center,
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .padding(vertical = 8.dp),
+                                    .padding(vertical = 6.dp),
                         )
                     } else {
                         Column(
                             modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(3.dp),
                         ) {
                             state.bindings.forEach { binding ->
                                 BindingRow(
@@ -1915,21 +1930,21 @@ private fun BindingRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputSubcard)
-                .border(1.dp, InputOutline, RoundedCornerShape(10.dp))
-                .padding(horizontal = 10.dp, vertical = 6.dp),
+                .border(1.dp, InputOutline, RoundedCornerShape(InputFieldCorner))
+                .padding(horizontal = 8.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = state.label,
             color = InputTextPrimary,
-            fontSize = 13.sp,
+            fontSize = InputPrimaryTextSize,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
-        Spacer(Modifier.width(8.dp))
+        Spacer(Modifier.width(InputCompactGap))
         BindingSelectionButton(
             text = state.typeLabel,
             modifier = Modifier.weight(0.8f),
@@ -1941,7 +1956,7 @@ private fun BindingRow(
             modifier = Modifier.weight(1f),
             onClick = { actions.onBindingValueClick(controllerId, state.keyCode) },
         )
-        Spacer(Modifier.width(6.dp))
+        Spacer(Modifier.width(InputCompactGap))
         IconActionButton(
             image = Icons.Outlined.Delete,
             contentDescription = stringResource(R.string.common_ui_remove),
@@ -1961,21 +1976,21 @@ private fun BindingSelectionButton(
     Row(
         modifier =
             modifier
-                .heightIn(min = 32.dp)
-                .clip(RoundedCornerShape(8.dp))
+                .heightIn(min = 28.dp)
+                .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputField)
-                .border(1.dp, InputOutline, RoundedCornerShape(8.dp))
+                .border(1.dp, InputOutline, RoundedCornerShape(InputFieldCorner))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = onClick,
-                ).padding(horizontal = 8.dp, vertical = 7.dp),
+                ).padding(horizontal = 7.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
             color = InputTextPrimary,
-            fontSize = 12.sp,
+            fontSize = InputSecondaryTextSize,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -48,10 +48,13 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.ScreenRotationAlt
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -1331,48 +1334,90 @@ private fun ProfileActionRow(
     actions: InputControlsScreenActions,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+    var menuOpen by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
         IconActionButton(
-            image = Icons.Outlined.SportsEsports,
-            contentDescription = stringResource(R.string.input_controls_editor_title),
-            onClick = actions.onOpenEditor,
+            image = Icons.Outlined.MoreVert,
+            contentDescription = stringResource(R.string.common_ui_options),
+            onClick = { menuOpen = true },
             size = InputProfileActionSize,
             iconSize = InputProfileActionIconSize,
         )
-        IconActionButton(
-            image = Icons.Outlined.Add,
-            contentDescription = stringResource(R.string.common_ui_add),
-            onClick = actions.onAddProfile,
-            size = InputProfileActionSize,
-            iconSize = InputProfileActionIconSize,
-        )
-        IconActionButton(
-            image = Icons.Outlined.Edit,
-            contentDescription = stringResource(R.string.common_ui_edit),
-            onClick = actions.onEditProfile,
-            size = InputProfileActionSize,
-            iconSize = InputProfileActionIconSize,
-        )
-        IconActionButton(
-            image = Icons.Outlined.ContentCopy,
-            contentDescription = stringResource(R.string.common_ui_duplicate),
-            onClick = actions.onDuplicateProfile,
-            size = InputProfileActionSize,
-            iconSize = InputProfileActionIconSize,
-        )
-        IconActionButton(
-            image = Icons.Outlined.Delete,
-            contentDescription = stringResource(R.string.common_ui_remove),
-            tint = InputDanger,
-            onClick = actions.onRemoveProfile,
-            size = InputProfileActionSize,
-            iconSize = InputProfileActionIconSize,
-        )
+        DropdownMenu(
+            expanded = menuOpen,
+            onDismissRequest = { menuOpen = false },
+            containerColor = InputCard,
+        ) {
+            ProfileActionMenuItem(
+                icon = Icons.Outlined.SportsEsports,
+                label = stringResource(R.string.input_controls_editor_title),
+                onClick = {
+                    menuOpen = false
+                    actions.onOpenEditor()
+                },
+            )
+            ProfileActionMenuItem(
+                icon = Icons.Outlined.Add,
+                label = stringResource(R.string.common_ui_add),
+                onClick = {
+                    menuOpen = false
+                    actions.onAddProfile()
+                },
+            )
+            ProfileActionMenuItem(
+                icon = Icons.Outlined.Edit,
+                label = stringResource(R.string.common_ui_edit),
+                onClick = {
+                    menuOpen = false
+                    actions.onEditProfile()
+                },
+            )
+            ProfileActionMenuItem(
+                icon = Icons.Outlined.ContentCopy,
+                label = stringResource(R.string.common_ui_duplicate),
+                onClick = {
+                    menuOpen = false
+                    actions.onDuplicateProfile()
+                },
+            )
+            ProfileActionMenuItem(
+                icon = Icons.Outlined.Delete,
+                label = stringResource(R.string.common_ui_remove),
+                iconTint = InputDanger,
+                textColor = InputDanger,
+                onClick = {
+                    menuOpen = false
+                    actions.onRemoveProfile()
+                },
+            )
+        }
     }
+}
+
+@Composable
+private fun ProfileActionMenuItem(
+    icon: ImageVector,
+    label: String,
+    iconTint: Color = InputAccent,
+    textColor: Color = InputTextPrimary,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(15.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(label, color = textColor, fontSize = InputPrimaryTextSize)
+            }
+        },
+        onClick = onClick,
+    )
 }
 
 @Composable

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -116,9 +116,9 @@ private val InputIconBoxSize = 38.dp
 private val InputActionSize = 30.dp
 private val InputSliderHeight = 24.dp
 private val InputProfileIconBoxSize = 42.dp
-private val InputProfileActionSize = 36.dp
-private val InputProfileActionIconSize = 20.dp
-private val InputProfileActionStartGap = 8.dp
+private val InputProfileActionSize = 38.dp
+private val InputProfileActionIconSize = 25.dp
+private val InputProfileActionStartGap = 6.dp
 private val InputProfileSelectorMaxWidth = 420.dp
 private val InputPrimaryTextSize = 13.sp
 private val InputSecondaryTextSize = 11.sp
@@ -375,6 +375,8 @@ private fun SectionLabel(text: String) {
 @Composable
 private fun CardShell(
     onClick: (() -> Unit)? = null,
+    horizontalPadding: Dp = InputCardHorizontalPadding,
+    verticalPadding: Dp = InputCardVerticalPadding,
     content: @Composable () -> Unit,
 ) {
     val clickableModifier =
@@ -396,7 +398,7 @@ private fun CardShell(
                 .background(InputCard)
                 .border(1.dp, InputOutline, RoundedCornerShape(InputCardCorner))
                 .then(clickableModifier)
-                .padding(horizontal = InputCardHorizontalPadding, vertical = InputCardVerticalPadding),
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding),
     ) {
         content()
     }
@@ -1224,7 +1226,10 @@ private fun ProfileCard(
         label = "profileSelectorPressed",
     )
 
-    CardShell {
+    CardShell(
+        horizontalPadding = 10.dp,
+        verticalPadding = 8.dp,
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -1337,12 +1342,8 @@ private fun ProfileActionRow(
     var menuOpen by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
-        IconActionButton(
-            image = Icons.Outlined.MoreVert,
-            contentDescription = stringResource(R.string.common_ui_options),
+        ProfileOverflowButton(
             onClick = { menuOpen = true },
-            size = InputProfileActionSize,
-            iconSize = InputProfileActionIconSize,
         )
         DropdownMenu(
             expanded = menuOpen,
@@ -1392,6 +1393,29 @@ private fun ProfileActionRow(
                 },
             )
         }
+    }
+}
+
+@Composable
+private fun ProfileOverflowButton(onClick: () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .size(InputProfileActionSize)
+                .clip(RoundedCornerShape(InputFieldCorner))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClick,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.MoreVert,
+            contentDescription = stringResource(R.string.common_ui_options),
+            tint = Color.White,
+            modifier = Modifier.size(InputProfileActionIconSize),
+        )
     }
 }
 

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -1,7 +1,14 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.winlator.cmod.feature.settings
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -46,6 +53,7 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.MoreVert
@@ -55,9 +63,11 @@ import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.SliderState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -70,10 +80,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalFocusManager
@@ -115,6 +125,7 @@ private val InputItemGap = 8.dp
 private val InputIconBoxSize = 38.dp
 private val InputActionSize = 30.dp
 private val InputSliderHeight = 24.dp
+private const val InputSliderTrackScaleY = 0.72f
 private val InputProfileIconBoxSize = 42.dp
 private val InputProfileActionSize = 38.dp
 private val InputProfileActionIconSize = 25.dp
@@ -1203,6 +1214,15 @@ private fun sliderColors() =
         inactiveTickColor = InputTickHidden,
     )
 
+@Composable
+private fun InputSliderTrack(sliderState: SliderState) {
+    SliderDefaults.Track(
+        sliderState = sliderState,
+        colors = sliderColors(),
+        modifier = Modifier.scale(scaleX = 1f, scaleY = InputSliderTrackScaleY),
+    )
+}
+
 private fun snapToStep(
     value: Float,
     step: Int,
@@ -1482,6 +1502,7 @@ private fun OverlayOpacityCard(
                 steps = 17,
                 modifier = Modifier.height(InputSliderHeight),
                 colors = sliderColors(),
+                track = { InputSliderTrack(it) },
             )
         }
     }
@@ -1538,10 +1559,11 @@ private fun Subcard(
     content: @Composable () -> Unit,
 ) {
     val chevronRotation by animateFloatAsState(
-        targetValue = if (expanded) 90f else 0f,
-        animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
         label = "subcardChevronRotation",
     )
+    val borderColor = if (expanded) InputAccent.copy(alpha = 0.45f) else InputOutline
 
     Column(
         modifier =
@@ -1549,8 +1571,7 @@ private fun Subcard(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(InputCardCorner))
                 .background(InputSubcard)
-                .border(1.dp, InputOutline, RoundedCornerShape(InputCardCorner))
-                .padding(horizontal = 8.dp, vertical = 5.dp),
+                .border(1.dp, borderColor, RoundedCornerShape(InputCardCorner)),
     ) {
         Row(
             modifier =
@@ -1560,28 +1581,20 @@ private fun Subcard(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = onToggleExpanded,
-                    ),
+                    )
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(
+            Icon(
+                imageVector = Icons.Outlined.ExpandMore,
+                contentDescription = null,
+                tint = if (expanded) InputAccent else InputTextSecondary,
                 modifier =
                     Modifier
-                        .size(28.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(InputIconBox),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = InputTextSecondary,
-                    modifier =
-                        Modifier
-                            .size(13.dp)
-                            .graphicsLayer { rotationZ = chevronRotation },
-                )
-            }
-            Spacer(Modifier.width(InputItemGap))
+                        .size(18.dp)
+                        .rotate(chevronRotation),
+            )
+            Spacer(Modifier.width(8.dp))
             Text(
                 text = title,
                 color = InputTextSecondary,
@@ -1589,8 +1602,29 @@ private fun Subcard(
                 modifier = Modifier.weight(1f),
             )
         }
-        if (expanded) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter =
+                fadeIn(tween(110)) +
+                    expandVertically(
+                        animationSpec = tween(durationMillis = 170, easing = FastOutSlowInEasing),
+                        expandFrom = Alignment.Top,
+                    ),
+            exit =
+                fadeOut(tween(90)) +
+                    shrinkVertically(
+                        animationSpec = tween(durationMillis = 140, easing = FastOutSlowInEasing),
+                        shrinkTowards = Alignment.Top,
+                    ),
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(InputSubcard)
+                        .padding(start = 12.dp, end = 12.dp, bottom = 6.dp),
+            ) {
                 content()
             }
         }
@@ -1618,6 +1652,7 @@ private fun SliderField(
             steps = steps,
             modifier = Modifier.height(InputSliderHeight),
             colors = sliderColors(),
+            track = { InputSliderTrack(it) },
         )
     }
 }

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -112,6 +112,9 @@ private val InputItemGap = 8.dp
 private val InputIconBoxSize = 38.dp
 private val InputActionSize = 30.dp
 private val InputSliderHeight = 24.dp
+private val InputProfileIconBoxSize = 42.dp
+private val InputProfileActionSize = 34.dp
+private val InputProfileSelectorMaxWidth = 420.dp
 private val InputPrimaryTextSize = 13.sp
 private val InputSecondaryTextSize = 11.sp
 private val InputSectionTextSize = 10.sp
@@ -442,7 +445,7 @@ private fun IconActionButton(
             imageVector = image,
             contentDescription = contentDescription,
             tint = tint,
-            modifier = Modifier.size(if (size <= 28.dp) 14.dp else 16.dp),
+            modifier = Modifier.size(if (size <= 28.dp) 14.dp else if (size >= InputProfileActionSize) 18.dp else 16.dp),
         )
     }
 }
@@ -641,13 +644,13 @@ private fun ProfileSelectorIconBox(tint: Color) {
     Box(
         modifier =
             Modifier
-                .size(InputIconBoxSize)
+                .size(InputProfileIconBoxSize)
                 .clip(RoundedCornerShape(InputFieldCorner))
                 .background(InputIconBox),
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(5.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             repeat(2) {
                 Row(
@@ -656,15 +659,15 @@ private fun ProfileSelectorIconBox(tint: Color) {
                     Box(
                         modifier =
                             Modifier
-                                .size(6.dp)
-                                .clip(RoundedCornerShape(3.dp))
+                                .size(7.dp)
+                                .clip(RoundedCornerShape(4.dp))
                                 .background(tint),
                     )
-                    Spacer(Modifier.width(5.dp))
+                    Spacer(Modifier.width(6.dp))
                     Box(
                         modifier =
                             Modifier
-                                .width(15.dp)
+                                .width(18.dp)
                                 .height(3.dp)
                                 .clip(RoundedCornerShape(2.dp))
                                 .background(tint.copy(alpha = 0.95f)),
@@ -1219,6 +1222,7 @@ private fun ProfileCard(
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             ProfileSelectorRow(
                 state = state,
@@ -1226,9 +1230,11 @@ private fun ProfileCard(
                 selectorTint = selectorTint,
                 selectorPressed = selectorPressed,
                 onClick = actions.onSelectProfile,
-                modifier = Modifier.weight(1f),
+                modifier =
+                    Modifier
+                        .weight(1f, fill = false)
+                        .widthIn(max = InputProfileSelectorMaxWidth),
             )
-            Spacer(Modifier.width(InputItemGap))
             ProfileActionRow(actions = actions)
         }
     }
@@ -1309,7 +1315,7 @@ private fun ProfileSelectorRow(
                 } else {
                     InputAccent.copy(alpha = 0.9f)
                 },
-            modifier = Modifier.size(16.dp),
+            modifier = Modifier.size(18.dp),
         )
     }
 }
@@ -1324,27 +1330,32 @@ private fun ProfileActionRow(actions: InputControlsScreenActions) {
             image = Icons.Outlined.SportsEsports,
             contentDescription = stringResource(R.string.input_controls_editor_title),
             onClick = actions.onOpenEditor,
+            size = InputProfileActionSize,
         )
         IconActionButton(
             image = Icons.Outlined.Add,
             contentDescription = stringResource(R.string.common_ui_add),
             onClick = actions.onAddProfile,
+            size = InputProfileActionSize,
         )
         IconActionButton(
             image = Icons.Outlined.Edit,
             contentDescription = stringResource(R.string.common_ui_edit),
             onClick = actions.onEditProfile,
+            size = InputProfileActionSize,
         )
         IconActionButton(
             image = Icons.Outlined.ContentCopy,
             contentDescription = stringResource(R.string.common_ui_duplicate),
             onClick = actions.onDuplicateProfile,
+            size = InputProfileActionSize,
         )
         IconActionButton(
             image = Icons.Outlined.Delete,
             contentDescription = stringResource(R.string.common_ui_remove),
             tint = InputDanger,
             onClick = actions.onRemoveProfile,
+            size = InputProfileActionSize,
         )
     }
 }

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -113,7 +113,9 @@ private val InputIconBoxSize = 38.dp
 private val InputActionSize = 30.dp
 private val InputSliderHeight = 24.dp
 private val InputProfileIconBoxSize = 42.dp
-private val InputProfileActionSize = 34.dp
+private val InputProfileActionSize = 36.dp
+private val InputProfileActionIconSize = 20.dp
+private val InputProfileActionStartGap = 8.dp
 private val InputProfileSelectorMaxWidth = 420.dp
 private val InputPrimaryTextSize = 13.sp
 private val InputSecondaryTextSize = 11.sp
@@ -426,6 +428,7 @@ private fun IconActionButton(
     tint: Color = InputTextSecondary,
     onClick: () -> Unit,
     size: Dp = InputActionSize,
+    iconSize: Dp = if (size <= 28.dp) 14.dp else if (size >= InputProfileActionSize) 18.dp else 16.dp,
 ) {
     Box(
         modifier =
@@ -445,7 +448,7 @@ private fun IconActionButton(
             imageVector = image,
             contentDescription = contentDescription,
             tint = tint,
-            modifier = Modifier.size(if (size <= 28.dp) 14.dp else if (size >= InputProfileActionSize) 18.dp else 16.dp),
+            modifier = Modifier.size(iconSize),
         )
     }
 }
@@ -1235,7 +1238,10 @@ private fun ProfileCard(
                         .weight(1f, fill = false)
                         .widthIn(max = InputProfileSelectorMaxWidth),
             )
-            ProfileActionRow(actions = actions)
+            ProfileActionRow(
+                actions = actions,
+                modifier = Modifier.padding(start = InputProfileActionStartGap),
+            )
         }
     }
 }
@@ -1321,8 +1327,12 @@ private fun ProfileSelectorRow(
 }
 
 @Composable
-private fun ProfileActionRow(actions: InputControlsScreenActions) {
+private fun ProfileActionRow(
+    actions: InputControlsScreenActions,
+    modifier: Modifier = Modifier,
+) {
     Row(
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -1331,24 +1341,28 @@ private fun ProfileActionRow(actions: InputControlsScreenActions) {
             contentDescription = stringResource(R.string.input_controls_editor_title),
             onClick = actions.onOpenEditor,
             size = InputProfileActionSize,
+            iconSize = InputProfileActionIconSize,
         )
         IconActionButton(
             image = Icons.Outlined.Add,
             contentDescription = stringResource(R.string.common_ui_add),
             onClick = actions.onAddProfile,
             size = InputProfileActionSize,
+            iconSize = InputProfileActionIconSize,
         )
         IconActionButton(
             image = Icons.Outlined.Edit,
             contentDescription = stringResource(R.string.common_ui_edit),
             onClick = actions.onEditProfile,
             size = InputProfileActionSize,
+            iconSize = InputProfileActionIconSize,
         )
         IconActionButton(
             image = Icons.Outlined.ContentCopy,
             contentDescription = stringResource(R.string.common_ui_duplicate),
             onClick = actions.onDuplicateProfile,
             size = InputProfileActionSize,
+            iconSize = InputProfileActionIconSize,
         )
         IconActionButton(
             image = Icons.Outlined.Delete,
@@ -1356,6 +1370,7 @@ private fun ProfileActionRow(actions: InputControlsScreenActions) {
             tint = InputDanger,
             onClick = actions.onRemoveProfile,
             size = InputProfileActionSize,
+            iconSize = InputProfileActionIconSize,
         )
     }
 }

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -90,6 +90,7 @@ private val SurfaceDark = Color(0xFF21212A)
 private val Accent = Color(0xFF1A9FFF)
 private val TextPrimary = Color(0xFFF0F4FF)
 private val TextSecondary = Color(0xFF7A8FA8)
+private val SettingsSliderHeight = 24.dp
 
 // State
 data class OtherSettingsState(
@@ -880,7 +881,10 @@ private fun CursorSpeedCard(
                         activeTickColor = Color.Transparent,
                         inactiveTickColor = Color.Transparent,
                     ),
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(SettingsSliderHeight),
             )
         }
     }

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 /* Settings > Other screen — Jetpack Compose / Material3.
  * Uses a LazyColumn for the main content so the screen scrolls natively in Compose. */
 package com.winlator.cmod.feature.settings
@@ -50,11 +52,13 @@ import androidx.compose.material.icons.outlined.SystemUpdate
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.SliderState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -91,6 +95,7 @@ private val Accent = Color(0xFF1A9FFF)
 private val TextPrimary = Color(0xFFF0F4FF)
 private val TextSecondary = Color(0xFF7A8FA8)
 private val SettingsSliderHeight = 24.dp
+private const val SettingsSliderTrackScaleY = 0.72f
 
 // State
 data class OtherSettingsState(
@@ -110,6 +115,25 @@ data class OtherSettingsState(
     val shareClipboard: Boolean = false,
     val imagefsInstallProgress: Int? = null,
 )
+
+@Composable
+private fun settingsSliderColors() =
+    SliderDefaults.colors(
+        thumbColor = Accent,
+        activeTrackColor = Accent,
+        inactiveTrackColor = SurfaceDark,
+        activeTickColor = Color.Transparent,
+        inactiveTickColor = Color.Transparent,
+    )
+
+@Composable
+private fun SettingsSliderTrack(sliderState: SliderState) {
+    SliderDefaults.Track(
+        sliderState = sliderState,
+        colors = settingsSliderColors(),
+        modifier = Modifier.scale(scaleX = 1f, scaleY = SettingsSliderTrackScaleY),
+    )
+}
 
 // Root
 @Composable
@@ -873,14 +897,8 @@ private fun CursorSpeedCard(
                 onValueChange = { onPercentChanged(it.toInt()) },
                 valueRange = 10f..200f,
                 steps = 0,
-                colors =
-                    SliderDefaults.colors(
-                        thumbColor = Accent,
-                        activeTrackColor = Accent,
-                        inactiveTrackColor = SurfaceDark,
-                        activeTickColor = Color.Transparent,
-                        inactiveTickColor = Color.Transparent,
-                    ),
+                colors = settingsSliderColors(),
+                track = { SettingsSliderTrack(it) },
                 modifier =
                     Modifier
                         .fillMaxWidth()

--- a/app/src/main/feature/settings/presets/PresetsScreen.kt
+++ b/app/src/main/feature/settings/presets/PresetsScreen.kt
@@ -877,7 +877,7 @@ private fun EnvVarCard(
                     Modifier
                         .fillMaxWidth()
                         .noRippleClickable { expanded = !expanded }
-                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
@@ -934,7 +934,7 @@ private fun EnvVarCard(
                         Modifier
                             .fillMaxWidth()
                             .background(CardDarker)
-                            .padding(horizontal = 38.dp, vertical = 10.dp),
+                            .padding(horizontal = 38.dp, vertical = 8.dp),
                 )
             }
         }
@@ -1055,7 +1055,7 @@ private fun EnvVarDropdownControl(
                 .background(CardDarker)
                 .border(1.dp, CardBorder, RoundedCornerShape(8.dp))
                 .noRippleClickable(enabled = editable && values.isNotEmpty()) { open = true }
-                .padding(horizontal = 10.dp, vertical = 8.dp),
+                .padding(horizontal = 10.dp, vertical = 7.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -1117,7 +1117,7 @@ private fun EnvVarTextControl(
                 .clip(RoundedCornerShape(8.dp))
                 .background(CardDarker)
                 .border(borderWidth, borderColor, RoundedCornerShape(8.dp))
-                .padding(horizontal = 10.dp, vertical = 8.dp),
+                .padding(horizontal = 10.dp, vertical = 7.dp),
         contentAlignment = Alignment.CenterStart,
     ) {
         BasicTextField(

--- a/app/src/main/feature/setup/SetupWizardActivity.kt
+++ b/app/src/main/feature/setup/SetupWizardActivity.kt
@@ -55,6 +55,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -2713,21 +2716,25 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                 )
             }
         } else {
-            Box(
+            BoxWithConstraints(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.TopCenter,
             ) {
-                LazyColumn(
+                val gridColumns = 3
+                val compactGrid = maxWidth < 720.dp || maxHeight < 280.dp
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(gridColumns),
                     modifier =
                         Modifier
-                            .widthIn(max = 420.dp)
+                            .widthIn(max = 960.dp)
                             .fillMaxWidth()
                             .fillMaxHeight(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    contentPadding = PaddingValues(bottom = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(if (compactGrid) 8.dp else 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(if (compactGrid) 6.dp else 10.dp),
+                    contentPadding = PaddingValues(bottom = if (compactGrid) 4.dp else 12.dp),
                 ) {
-                    items(installedRuntimes) { profile ->
-                        RuntimeContainerCard(profile)
+                    gridItems(installedRuntimes) { profile ->
+                        RuntimeContainerCard(profile, compact = compactGrid)
                     }
                 }
             }
@@ -2735,7 +2742,10 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
     }
 
     @Composable
-    private fun RuntimeContainerCard(profile: ContentProfile) {
+    private fun RuntimeContainerCard(
+        profile: ContentProfile,
+        compact: Boolean = false,
+    ) {
         val entryName = ContentsManager.getEntryName(profile)
         val displayName = runtimeDisplayLabel(profile)
         val isArm64 = profile.verName.contains("arm64ec", ignoreCase = true)
@@ -2768,7 +2778,7 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                     .fillMaxWidth()
                     .background(bgColor, cardShape)
                     .border(1.dp, outlineColor, cardShape)
-                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                    .padding(horizontal = if (compact) 10.dp else 12.dp, vertical = if (compact) 6.dp else 10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
@@ -2787,23 +2797,23 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                         text = archLabel,
                         color = if (hasContainer) activeColor else Color(0xFF8B949E),
                         fontFamily = InterFont,
-                        fontSize = 9.sp,
+                        fontSize = if (compact) 8.sp else 9.sp,
                         letterSpacing = 1.sp,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
-                Spacer(Modifier.height(3.dp))
+                Spacer(Modifier.height(if (compact) 1.dp else 3.dp))
                 Text(
                     text = displayName,
                     color = Color(0xFFE6EDF3),
                     fontFamily = InterFont,
                     fontWeight = FontWeight.Medium,
-                    fontSize = 12.sp,
+                    fontSize = if (compact) 11.sp else 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(if (compact) 6.dp else 8.dp))
             if (existingContainer == null) {
                 Button(
                     onClick = {
@@ -2834,8 +2844,8 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                     },
                     enabled = !creating && transferState.value == null,
                     shape = RoundedCornerShape(8.dp),
-                    modifier = Modifier.height(28.dp),
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                    modifier = Modifier.height(if (compact) 24.dp else 28.dp),
+                    contentPadding = PaddingValues(horizontal = if (compact) 9.dp else 12.dp, vertical = 0.dp),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = turquoise.copy(alpha = 0.14f),
@@ -2847,20 +2857,20 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                 ) {
                     if (creating) {
                         CircularProgressIndicator(
-                            modifier = Modifier.size(14.dp),
+                            modifier = Modifier.size(if (compact) 12.dp else 14.dp),
                             color = turquoise,
                             strokeWidth = 2.dp,
                         )
-                        Spacer(Modifier.width(6.dp))
+                        Spacer(Modifier.width(if (compact) 4.dp else 6.dp))
                     }
                     Text(
                         text =
                             stringResource(
                                 if (creating) R.string.setup_wizard_creating_container else R.string.setup_wizard_create_container,
-                            ),
+                        ),
                         fontFamily = InterFont,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 10.sp,
+                        fontSize = if (compact) 9.sp else 10.sp,
                     )
                 }
             } else {
@@ -2871,8 +2881,8 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                         openContainerDefaultSettings(id, type)
                     },
                     shape = RoundedCornerShape(8.dp),
-                    modifier = Modifier.height(28.dp),
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                    modifier = Modifier.height(if (compact) 24.dp else 28.dp),
+                    contentPadding = PaddingValues(horizontal = if (compact) 9.dp else 12.dp, vertical = 0.dp),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = completedTurquoise.copy(alpha = 0.14f),
@@ -2883,7 +2893,7 @@ class SetupWizardActivity : FixedFontScaleFragmentActivity() {
                         text = stringResource(R.string.setup_wizard_default_settings),
                         fontFamily = InterFont,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 10.sp,
+                        fontSize = if (compact) 9.sp else 10.sp,
                     )
                 }
             }

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -8,7 +8,7 @@ import android.content.pm.ShortcutManager
 import android.graphics.BitmapFactory
 import android.graphics.drawable.Icon
 import android.net.Uri
-import android.util.DisplayMetrics
+import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
 import android.view.Window
@@ -17,7 +17,10 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
@@ -166,10 +169,15 @@ class ShortcutSettingsComposeDialog private constructor(
             setViewTreeSavedStateRegistryOwner(activity as SavedStateRegistryOwner)
             setContent {
                 WinNativeTheme {
-                    GameSettingsContent(
-                        state = state,
-                        callbacks = createCallbacks()
-                    )
+                    val defaultDensity = LocalDensity.current
+                    CompositionLocalProvider(
+                        LocalDensity provides Density(defaultDensity.density, fontScale = 1f)
+                    ) {
+                        GameSettingsContent(
+                            state = state,
+                            callbacks = createCallbacks()
+                        )
+                    }
                 }
             }
         }
@@ -2246,36 +2254,44 @@ class ShortcutSettingsComposeDialog private constructor(
     fun show() {
         dialog.show()
         dialog.window?.apply {
-            val dm = activity.resources.displayMetrics
-            val screenWidthDp = dm.widthPixels / dm.density
-            val dialogWidthDp = screenWidthDp * 0.88f
-            // When the usable width is below the content's compact-layout breakpoint
-            // (720dp in GameSettingsContent), the Compose UI switches to stacked tabs
-            // with a bottom action bar, which needs more vertical room than the sidebar
-            // layout. Give the dialog near-full-height whenever compact layout will
-            // kick in; keep the roomier sidebar layout at a comfortable 88% otherwise.
-            val isCompactLayout = dialogWidthDp < 720f
-            if (screenWidthDp < 600f) {
-                // Small screen: most of the display with a comfortable margin.
-                val dialogWidth = (dm.widthPixels * 0.96f).toInt()
-                val dialogHeight = (dm.heightPixels * 0.90f).toInt()
-                setLayout(dialogWidth, dialogHeight)
-            } else {
-                val dialogWidth = (dm.widthPixels * 0.88f).toInt()
-                val heightFactor = if (isCompactLayout) 0.90f else 0.88f
-                val dialogHeight = (dm.heightPixels * heightFactor).toInt()
-                setLayout(dialogWidth, dialogHeight)
-            }
+            applyDialogLayout()
+            decorView.post { applyDialogLayout() }
 
             // Post-attach blur: set flag + radius in one setAttributes call so
             // WindowManager applies them atomically (otherwise blur can flicker).
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 val params = attributes
                 params.flags = params.flags or WindowManager.LayoutParams.FLAG_BLUR_BEHIND
                 params.blurBehindRadius = 10
                 attributes = params
             }
         }
+    }
+
+    private fun Window.applyDialogLayout() {
+        val dm = activity.resources.displayMetrics
+        val hostView = activity.window?.decorView
+        val hostWidth = hostView?.width?.takeIf { it > 0 }
+        val hostHeight = hostView?.height?.takeIf { it > 0 }
+        val bounds =
+            if (hostWidth != null && hostHeight != null) {
+                hostWidth to hostHeight
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val windowBounds = activity.windowManager.currentWindowMetrics.bounds
+                windowBounds.width() to windowBounds.height()
+            } else {
+                dm.widthPixels to dm.heightPixels
+            }
+
+        val screenWidthDp = bounds.first / dm.density
+        val needsNearFullWidth = screenWidthDp < 820f
+        val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
+        val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
+
+        setLayout(
+            (bounds.first * widthFactor).toInt(),
+            (bounds.second * heightFactor).toInt(),
+        )
     }
 
     fun dismiss() {

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -2288,17 +2288,30 @@ class ShortcutSettingsComposeDialog private constructor(
         val needsNearFullWidth = screenWidthDp < 820f
         val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
         val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
-        val systemInsets =
+        val navInsets =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
-                    WindowInsets.Type.navigationBars() or WindowInsets.Type.displayCutout()
+                    WindowInsets.Type.navigationBars()
+                )
+            } else {
+                null
+            }
+        val cutoutInsets =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
+                    WindowInsets.Type.displayCutout()
                 )
             } else {
                 null
             }
         val edgePaddingPx = (12f * dm.density).toInt().coerceAtLeast(1)
-        val horizontalInsetPx = maxOf(systemInsets?.left ?: 0, systemInsets?.right ?: 0)
-        val verticalInsetPx = maxOf(systemInsets?.top ?: 0, systemInsets?.bottom ?: 0)
+        val cutoutPaddingCapPx = (8f * dm.density).toInt()
+        val leftInsetPx = maxOf(navInsets?.left ?: 0, (cutoutInsets?.left ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val rightInsetPx = maxOf(navInsets?.right ?: 0, (cutoutInsets?.right ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val topInsetPx = maxOf(navInsets?.top ?: 0, (cutoutInsets?.top ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val bottomInsetPx = maxOf(navInsets?.bottom ?: 0, (cutoutInsets?.bottom ?: 0).coerceAtMost(cutoutPaddingCapPx))
+        val horizontalInsetPx = maxOf(leftInsetPx, rightInsetPx)
+        val verticalInsetPx = maxOf(topInsetPx, bottomInsetPx)
         val maxDialogWidth = (bounds.first - ((horizontalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
         val maxDialogHeight = (bounds.second - ((verticalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
 

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
 import android.view.Window
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -2287,10 +2288,23 @@ class ShortcutSettingsComposeDialog private constructor(
         val needsNearFullWidth = screenWidthDp < 820f
         val widthFactor = if (needsNearFullWidth) 0.96f else 0.88f
         val heightFactor = if (needsNearFullWidth) 0.90f else 0.88f
+        val systemInsets =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity.windowManager.currentWindowMetrics.windowInsets.getInsetsIgnoringVisibility(
+                    WindowInsets.Type.navigationBars() or WindowInsets.Type.displayCutout()
+                )
+            } else {
+                null
+            }
+        val edgePaddingPx = (12f * dm.density).toInt().coerceAtLeast(1)
+        val horizontalInsetPx = maxOf(systemInsets?.left ?: 0, systemInsets?.right ?: 0)
+        val verticalInsetPx = maxOf(systemInsets?.top ?: 0, systemInsets?.bottom ?: 0)
+        val maxDialogWidth = (bounds.first - ((horizontalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
+        val maxDialogHeight = (bounds.second - ((verticalInsetPx + edgePaddingPx) * 2)).coerceAtLeast(1)
 
         setLayout(
-            (bounds.first * widthFactor).toInt(),
-            (bounds.second * heightFactor).toInt(),
+            (bounds.first * widthFactor).toInt().coerceAtMost(maxDialogWidth),
+            (bounds.second * heightFactor).toInt().coerceAtMost(maxDialogHeight),
         )
     }
 

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -1734,7 +1734,9 @@ class ShortcutSettingsComposeDialog private constructor(
     private fun buildEnvVarsString(): String {
         // Keep the SDL2 keys in sync with the toggle.
         val sdl2Keys = sdl2EnvVars.map { it.first }.toSet()
-        val filtered = state.envVars.value.filterNot { it.key in sdl2Keys }
+        val filtered = state.envVars.value
+            .filter { it.key.isNotBlank() }
+            .filterNot { it.key in sdl2Keys }
         val merged = if (state.sdl2Compatibility.value) {
             filtered + sdl2EnvVars.map { EnvVarItem(it.first, it.second) }
         } else {

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.winlator.cmod.R
@@ -83,6 +84,7 @@ private val TextSecondary = Color(0xFF7A8FA8)
 private val StatusGreen = Color(0xFF3FB950)
 private val WarningAmber = Color(0xFFFFC857)
 private val DangerRed = Color(0xFFFF6B6B)
+private val StoreLoginActionButtonWidth = 112.dp
 
 @Composable
 fun GoogleScreen() {
@@ -571,12 +573,26 @@ private fun StoreLoginCard(
                 StatusIconBox(statusColor = statusColor)
                 Spacer(Modifier.width(14.dp))
                 Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.google_cloud_store_logins),
-                        color = TextPrimary,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.google_cloud_store_logins),
+                            color = TextPrimary,
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        if (stores.isNotEmpty()) {
+                            Spacer(Modifier.width(10.dp))
+                            StoreBadgeRow(
+                                stores = stores,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = if (busy) stringResource(R.string.google_cloud_store_login_sync_busy) else state.detail,
@@ -584,10 +600,6 @@ private fun StoreLoginCard(
                         fontSize = 12.sp,
                     )
                 }
-            }
-
-            if (stores.isNotEmpty()) {
-                StoreBadgeRow(stores = stores)
             }
 
             if (compact) {
@@ -639,6 +651,7 @@ private fun StoreLoginCard(
                             textColor = WarningAmber,
                             icon = Icons.Outlined.Upload,
                             enabled = !busy && state.googleSignedIn && state.localStores.isNotEmpty(),
+                            modifier = Modifier.width(StoreLoginActionButtonWidth),
                             onClick = onBackup,
                         )
                         Spacer(Modifier.width(8.dp))
@@ -647,6 +660,7 @@ private fun StoreLoginCard(
                             textColor = Accent,
                             icon = Icons.Outlined.Restore,
                             enabled = !busy && state.googleSignedIn && state.cloudStores.isNotEmpty(),
+                            modifier = Modifier.width(StoreLoginActionButtonWidth),
                             onClick = onRestore,
                         )
                     }
@@ -697,6 +711,7 @@ private fun StoreLoginCard(
                             textColor = WarningAmber,
                             icon = Icons.Outlined.Upload,
                             enabled = !busy && state.googleSignedIn && state.localStores.isNotEmpty(),
+                            modifier = Modifier.width(StoreLoginActionButtonWidth),
                             onClick = onBackup,
                         )
                         ActionButton(
@@ -704,6 +719,7 @@ private fun StoreLoginCard(
                             textColor = Accent,
                             icon = Icons.Outlined.Restore,
                             enabled = !busy && state.googleSignedIn && state.cloudStores.isNotEmpty(),
+                            modifier = Modifier.width(StoreLoginActionButtonWidth),
                             onClick = onRestore,
                         )
                     }
@@ -714,9 +730,12 @@ private fun StoreLoginCard(
 }
 
 @Composable
-private fun StoreBadgeRow(stores: List<String>) {
+private fun StoreBadgeRow(
+    stores: List<String>,
+    modifier: Modifier = Modifier,
+) {
     Row(
-        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        modifier = modifier.horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         stores.forEach { store ->
@@ -807,6 +826,7 @@ private fun ActionButton(
     label: String,
     textColor: Color,
     enabled: Boolean,
+    modifier: Modifier = Modifier,
     icon: ImageVector? = null,
     onClick: () -> Unit,
 ) {
@@ -819,7 +839,7 @@ private fun ActionButton(
 
     Box(
         modifier =
-            Modifier
+            modifier
                 .scale(scale)
                 .clip(RoundedCornerShape(8.dp))
                 .background(Color(0xFF222232))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -983,6 +983,7 @@ Installed path:
     <string name="setup_wizard_create_container">Create Container</string>
     <string name="setup_wizard_creating_container">Creating\u2026</string>
 
+    <string name="input_controls_tap_to_click">Tap to Click</string>
     <!-- Steam > Login -->
     <string name="steam_login_auth_webview_title">Authorization</string>
     <string name="steam_login_sign_in_to_your_account">Sign in to your account</string>

--- a/app/src/main/runtime/audio/alsaserver/ALSAClient.java
+++ b/app/src/main/runtime/audio/alsaserver/ALSAClient.java
@@ -34,16 +34,22 @@ public class ALSAClient {
   private AudioTrack audioTrack;
   private int bufferCapacityFrames;
   private int previousUnderrunCount = 0;
+  private float[] bassLowpassState = new float[2];
+  private float bassLowpassAlpha = 0.0f;
   private static short framesPerBuffer = 256;
   private final Options options;
 
   public static class Options {
     public static final int DEFAULT_LATENCY_MILLIS = 16;
     public static final float DEFAULT_VOLUME = 1.0f;
+    public static final float MAX_VOLUME = 16.0f;
+    public static final float DEFAULT_BASS_BOOST = 0.0f;
+    public static final float MAX_BASS_BOOST = 2.0f;
 
     public int latencyMillis = DEFAULT_LATENCY_MILLIS;
     public int performanceMode = AudioTrack.PERFORMANCE_MODE_LOW_LATENCY;
     public float volume = DEFAULT_VOLUME;
+    public float bassBoost = DEFAULT_BASS_BOOST;
 
     public static Options fromEnvVars(EnvVars envVars) {
       Options options = new Options();
@@ -59,7 +65,13 @@ public class ALSAClient {
           parseFloat(
               firstNonEmpty(envVars.get("ANDROID_ALSA_VOLUME"), envVars.get("WINNATIVE_ALSA_VOLUME")),
               DEFAULT_VOLUME);
-      options.volume = Math.max(0.0f, Math.min(options.volume, 1.0f));
+      options.volume = Math.max(0.0f, Math.min(options.volume, MAX_VOLUME));
+
+      options.bassBoost =
+          parseFloat(
+              firstNonEmpty(envVars.get("ANDROID_ALSA_BASS_BOOST"), envVars.get("WINNATIVE_ALSA_BASS_BOOST")),
+              DEFAULT_BASS_BOOST);
+      options.bassBoost = Math.max(0.0f, Math.min(options.bassBoost, MAX_BASS_BOOST));
 
       String performanceMode =
           firstNonEmpty(
@@ -133,6 +145,8 @@ public class ALSAClient {
     positionFrames = 0;
     previousUnderrunCount = 0;
     frameBytes = channelCount * dataType.byteCount;
+    bassLowpassState = new float[Math.max(1, channelCount)];
+    bassLowpassAlpha = computeBassLowpassAlpha(sampleRate);
     release();
 
     if (!isValidBufferSize()) return;
@@ -153,7 +167,7 @@ public class ALSAClient {
               .setBufferSizeInBytes(audioTrackBufferSize)
               .build();
       bufferCapacityFrames = audioTrack.getBufferCapacityInFrames();
-      if (options.volume != Options.DEFAULT_VOLUME) audioTrack.setVolume(options.volume);
+      if (options.volume < Options.DEFAULT_VOLUME) audioTrack.setVolume(options.volume);
       audioTrack.play();
     } catch (Exception e) {
       release();
@@ -209,6 +223,7 @@ public class ALSAClient {
 
     if (audioTrack != null) {
       data.position(0);
+      applyAudioProcessing(data);
 
       while (data.position() != data.limit()) {
         int bytesWritten;
@@ -224,6 +239,66 @@ public class ALSAClient {
       }
       data.rewind();
     }
+  }
+
+  private void applyAudioProcessing(ByteBuffer data) {
+    if (options.volume == Options.DEFAULT_VOLUME && options.bassBoost == Options.DEFAULT_BASS_BOOST) {
+      return;
+    }
+
+    ByteBuffer buffer = data.duplicate();
+    buffer.order(data.order());
+    int start = data.position();
+    int end = data.limit();
+
+    switch (dataType) {
+      case U8:
+        for (int i = start, sampleIndex = 0; i < end; i++, sampleIndex++) {
+          float sample = ((buffer.get(i) & 0xFF) - 128) / 128.0f;
+          int scaledSample = Math.round(processSample(sample, sampleIndex) * 128.0f) + 128;
+          buffer.put(i, (byte) clamp(scaledSample, 0, 255));
+        }
+        break;
+      case S16LE:
+      case S16BE:
+        for (int i = start, sampleIndex = 0; i + 1 < end; i += 2, sampleIndex++) {
+          float sample = buffer.getShort(i) / 32768.0f;
+          int scaledSample = Math.round(processSample(sample, sampleIndex) * 32768.0f);
+          buffer.putShort(i, (short) clamp(scaledSample, Short.MIN_VALUE, Short.MAX_VALUE));
+        }
+        break;
+      case FLOATLE:
+      case FLOATBE:
+        for (int i = start, sampleIndex = 0; i + 3 < end; i += 4, sampleIndex++) {
+          buffer.putFloat(i, clamp(processSample(buffer.getFloat(i), sampleIndex), -1.0f, 1.0f));
+        }
+        break;
+    }
+  }
+
+  private float processSample(float sample, int sampleIndex) {
+    int channel = sampleIndex % Math.max(1, channelCount);
+    if (options.bassBoost > Options.DEFAULT_BASS_BOOST && channel < bassLowpassState.length) {
+      bassLowpassState[channel] += bassLowpassAlpha * (sample - bassLowpassState[channel]);
+      sample += bassLowpassState[channel] * options.bassBoost;
+    }
+    return clamp(sample * options.volume, -1.0f, 1.0f);
+  }
+
+  private static float computeBassLowpassAlpha(int sampleRate) {
+    if (sampleRate <= 0) return 0.0f;
+    float cutoffHz = 180.0f;
+    float dt = 1.0f / sampleRate;
+    float rc = 1.0f / (2.0f * (float) Math.PI * cutoffHz);
+    return dt / (rc + dt);
+  }
+
+  private static int clamp(int value, int min, int max) {
+    return Math.max(min, Math.min(value, max));
+  }
+
+  private static float clamp(float value, float min, float max) {
+    return Math.max(min, Math.min(value, max));
   }
 
   public int pointer() {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -247,6 +247,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private ImageFs imageFs;
     private FrameRating frameRating = null;
     private boolean effectiveShowFPS = false;
+    private boolean isTapToClickEnabled = true;
     private int runtimeFpsLimit = 0;
     private String lastRendererName = "OpenGL";
     private String lastGpuName = null;
@@ -551,7 +552,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         // Check for Dark Mode
         isDarkMode = preferences.getBoolean("dark_mode", false);
-
+        isTapToClickEnabled = true;
         boolean isOpenWithAndroidBrowser = preferences.getBoolean("open_with_android_browser", false);
         boolean isShareAndroidClipboard = preferences.getBoolean("share_android_clipboard", false);
 
@@ -3970,6 +3971,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         globalCursorSpeed = preferences.getFloat("cursor_speed", 1.0f);
         touchpadView = new TouchpadView(this, xServer, timeoutHandler, hideControlsRunnable);
+        touchpadView.setTapToClickEnabled(isTapToClickEnabled);
         touchpadView.setSensitivity(globalCursorSpeed);
         touchpadView.setMouseEnabled(!isMouseDisabled);
         touchpadView.setFourFingersTapCallback(() -> {
@@ -4248,6 +4250,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         // Initialize checkbox states
         dialog.getShowTouchscreenControls().setValue(preferences.getBoolean("show_touchscreen_controls_enabled", false));
+        dialog.getTapToClickEnabled().setValue(isTapToClickEnabled);
         dialog.getOverlayOpacity().setValue(preferences.getFloat("overlay_opacity", InputControlsView.DEFAULT_OVERLAY_OPACITY));
         dialog.getTouchscreenHaptics().setValue(preferences.getBoolean("touchscreen_haptics_enabled", false));
         dialog.getGamepadVibration().setValue(preferences.getBoolean(ControllerManager.PREF_VIBRATION_GLOBAL, true));
@@ -4278,6 +4281,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Confirm callback
         dialog.setOnConfirmCallback(() -> {
             inputControlsView.setShowTouchscreenControls(dialog.getShowTouchscreenControls().getValue());
+            isTapToClickEnabled = dialog.getTapToClickEnabled().getValue();
+            if (touchpadView != null) touchpadView.setTapToClickEnabled(isTapToClickEnabled);
+
             float overlayOpacity = dialog.getOverlayOpacity().getValue();
             inputControlsView.setOverlayOpacity(overlayOpacity);
             boolean isHapticsEnabled = dialog.getTouchscreenHaptics().getValue();

--- a/app/src/main/runtime/input/InputControlsDialog.kt
+++ b/app/src/main/runtime/input/InputControlsDialog.kt
@@ -25,6 +25,7 @@ class InputControlsDialog(
     val profileNames = mutableStateOf<List<String>>(emptyList())
     val selectedProfileIndex = mutableIntStateOf(0)
     val showTouchscreenControls = mutableStateOf(false)
+    val tapToClickEnabled = mutableStateOf(true)
     val overlayOpacity = mutableStateOf(0.4f)
     val touchscreenHaptics = mutableStateOf(false)
     val gamepadVibration = mutableStateOf(true)
@@ -65,6 +66,7 @@ class InputControlsDialog(
                                     profileNames = profileNames.value,
                                     selectedProfileIndex = selectedProfileIndex.intValue,
                                     showTouchscreenControls = showTouchscreenControls.value,
+                                    tapToClickEnabled = tapToClickEnabled.value,
                                     overlayOpacity = overlayOpacity.value,
                                     touchscreenHaptics = touchscreenHaptics.value,
                                     gamepadVibration = gamepadVibration.value,
@@ -74,6 +76,7 @@ class InputControlsDialog(
                             },
                             onSettingsClick = { onSettingsClickCallback?.run() },
                             onShowTouchscreenControlsChange = { showTouchscreenControls.value = it },
+                            onTapToClickChange = { tapToClickEnabled.value = it },
                             onOverlayOpacityChange = { overlayOpacity.value = it },
                             onTouchscreenHapticsChange = { touchscreenHaptics.value = it },
                             onGamepadVibrationChange = { gamepadVibration.value = it },

--- a/app/src/main/runtime/input/InputControlsDialogContent.kt
+++ b/app/src/main/runtime/input/InputControlsDialogContent.kt
@@ -71,6 +71,7 @@ data class InputControlsState(
     val profileNames: List<String> = emptyList(),
     val selectedProfileIndex: Int = 0,
     val showTouchscreenControls: Boolean = false,
+    val tapToClickEnabled: Boolean = true,
     val overlayOpacity: Float = 0.4f,
     val touchscreenHaptics: Boolean = false,
     val gamepadVibration: Boolean = true,
@@ -82,6 +83,7 @@ fun InputControlsDialogContent(
     onProfileSelected: (Int) -> Unit,
     onSettingsClick: () -> Unit,
     onShowTouchscreenControlsChange: (Boolean) -> Unit,
+    onTapToClickChange: (Boolean) -> Unit,
     onOverlayOpacityChange: (Float) -> Unit,
     onTouchscreenHapticsChange: (Boolean) -> Unit,
     onGamepadVibrationChange: (Boolean) -> Unit,
@@ -163,6 +165,12 @@ fun InputControlsDialogContent(
                             OverlayOpacitySlider(
                                 value = state.overlayOpacity,
                                 onValueChange = onOverlayOpacityChange
+                            )
+
+                            OptionCheckbox(
+                                label = stringResource(R.string.input_controls_tap_to_click),
+                                checked = state.tapToClickEnabled,
+                                onCheckedChange = onTapToClickChange,
                             )
                         }
 

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -89,6 +89,7 @@ public class ControlElement {
   private boolean selected = false;
   private boolean toggleSwitch = false;
   private boolean radialMenuExpanded = false;
+  private int activeRadialBindingIndex = -1;
   private boolean wasExpandedOnDown = false;
   private int currentPointerId = -1;
   private final Rect boundingBox = new Rect();
@@ -581,7 +582,7 @@ return boundingBox;
             if (paths != null && paths.length == bindings.length) {
               for (int i = 0; i < bindings.length; i++) {
                 paint.setStyle(Paint.Style.FILL);
-                paint.setColor(fillColor);
+                paint.setColor(i == activeRadialBindingIndex ? secondaryColor : fillColor);
                 canvas.drawPath(paths[i], paint);
 
                 paint.setStyle(Paint.Style.STROKE);
@@ -937,9 +938,14 @@ return boundingBox;
         if (!radialMenuExpanded) {
           radialMenuExpanded = true;
           paths = null;
-        } else if (Mathf.distance((float) boundingBox.centerX(), (float) boundingBox.centerY(), x, y) < boundingBox.width() * 0.5f) {
-          radialMenuExpanded = false;
-          paths = null;
+        } else {
+          activeRadialBindingIndex = getRadialBindingIndexAt(x, y);
+          if (activeRadialBindingIndex != -1) {
+            inputControlsView.handleInputEvent(getBindingAt(activeRadialBindingIndex), true);
+          } else if (Mathf.distance((float) boundingBox.centerX(), (float) boundingBox.centerY(), x, y) < boundingBox.width() * 0.5f) {
+            radialMenuExpanded = false;
+            paths = null;
+          }
         }
         inputControlsView.invalidate();
         return true;
@@ -964,6 +970,22 @@ return boundingBox;
       }
       return true;
     }
+
+    if (pointerId == currentPointerId && type == Type.RADIAL_MENU && radialMenuExpanded) {
+      int index = getRadialBindingIndexAt(x, y);
+      if (index != activeRadialBindingIndex) {
+        if (activeRadialBindingIndex != -1) {
+          inputControlsView.handleInputEvent(getBindingAt(activeRadialBindingIndex), false);
+        }
+        activeRadialBindingIndex = index;
+        if (activeRadialBindingIndex != -1) {
+          inputControlsView.handleInputEvent(getBindingAt(activeRadialBindingIndex), true);
+        }
+        inputControlsView.invalidate();
+      }
+      return true;
+    }
+
     if (pointerId == currentPointerId
         && (type == Type.D_PAD || type == Type.STICK || type == Type.TRACKPAD)) {
       float deltaX, deltaY;
@@ -1135,7 +1157,12 @@ return boundingBox;
       }
       inputControlsView.invalidate();
     } else if (type == Type.RADIAL_MENU) {
-      if (wasExpandedOnDown && radialMenuExpanded) handleRadialMenuClick(x, y);
+      if (activeRadialBindingIndex != -1) {
+        inputControlsView.handleInputEvent(getBindingAt(activeRadialBindingIndex), false);
+        activeRadialBindingIndex = -1;
+        radialMenuExpanded = false;
+        paths = null;
+      } else if (wasExpandedOnDown && radialMenuExpanded) handleRadialMenuClick(x, y);
       inputControlsView.invalidate();
     } else if (type == Type.RANGE_BUTTON
         || type == Type.D_PAD
@@ -1171,8 +1198,8 @@ return boundingBox;
     return true;
   }
 
-  private void handleRadialMenuClick(float x, float y) {
-    if (bindings.length == 0) return;
+  private int getRadialBindingIndexAt(float x, float y) {
+    if (bindings.length == 0) return -1;
     int snappingSize = inputControlsView.getSnappingSize();
     float cx = boundingBox.centerX();
     float cy = boundingBox.centerY();
@@ -1187,14 +1214,20 @@ return boundingBox;
       angle = (angle + 90) % 360;
 
       int index = (int) (angle / (360.0f / bindings.length));
-      if (index >= 0 && index < bindings.length) {
-        Binding binding = getBindingAt(index);
-        if (binding != Binding.NONE) {
-          radialMenuExpanded = false;
-          paths = null;
-          inputControlsView.handleInputEvent(binding, true);
-          inputControlsView.postDelayed(() -> inputControlsView.handleInputEvent(binding, false), 30);
-        }
+      return (index >= 0 && index < bindings.length) ? index : -1;
+    }
+    return -1;
+  }
+
+  private void handleRadialMenuClick(float x, float y) {
+    int index = getRadialBindingIndexAt(x, y);
+    if (index != -1) {
+      Binding binding = getBindingAt(index);
+      if (binding != Binding.NONE) {
+        radialMenuExpanded = false;
+        paths = null;
+        inputControlsView.handleInputEvent(binding, true);
+        inputControlsView.postDelayed(() -> inputControlsView.handleInputEvent(binding, false), 30);
       }
     }
   }

--- a/app/src/main/runtime/input/ui/TouchpadView.kt
+++ b/app/src/main/runtime/input/ui/TouchpadView.kt
@@ -60,13 +60,14 @@ class TouchpadView(
     private var lastTouchedPosY = 0
     private var resolutionScale = 0f
     private var mouseEnabled = true
+    var tapToClickEnabled = true
     private var fourFingersTapCallback: Runnable? = null
     private val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
     private val longPressHandler = Handler(Looper.getMainLooper())
     private var longPressActive = false
     private val longPressRunnable =
         Runnable {
-            if (numFingers.toInt() == 1 && fingers[0] != null && fingers[0]!!.travelDistance() < MAX_TAP_TRAVEL_DISTANCE) {
+            if (tapToClickEnabled && numFingers.toInt() == 1 && fingers[0] != null && fingers[0]!!.travelDistance() < MAX_TAP_TRAVEL_DISTANCE) {
                 longPressActive = true
                 if (xServer.isRelativeMouseMovement) {
                     xServer.winHandler.mouseEvent(MouseEventFlags.RIGHTDOWN, 0, 0, 0)
@@ -415,7 +416,7 @@ class TouchpadView(
             xServer.injectPointerMove(transformedPoint[0].toInt(), transformedPoint[1].toInt())
         }
 
-        if (numFingers.toInt() == 1) {
+        if (tapToClickEnabled && numFingers.toInt() == 1) {
             if (xServer.isRelativeMouseMovement) {
                 xServer.winHandler.mouseEvent(MouseEventFlags.LEFTDOWN, 0, 0, 0)
             } else {
@@ -434,10 +435,12 @@ class TouchpadView(
     }
 
     private fun handleTouchUp() {
-        if (xServer.isRelativeMouseMovement) {
-            xServer.winHandler.mouseEvent(MouseEventFlags.LEFTUP, 0, 0, 0)
-        } else {
-            xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT)
+        if (tapToClickEnabled) {
+            if (xServer.isRelativeMouseMovement) {
+                xServer.winHandler.mouseEvent(MouseEventFlags.LEFTUP, 0, 0, 0)
+            } else {
+                xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT)
+            }
         }
     }
 
@@ -455,6 +458,7 @@ class TouchpadView(
     }
 
     private fun handleTwoFingerTap() {
+        if (!tapToClickEnabled) return
         // FIX: Ensure clean right-click by clearing left button first
         if (xServer.pointer.isButtonPressed(Pointer.Button.BUTTON_LEFT)) {
             if (xServer.isRelativeMouseMovement) {
@@ -484,26 +488,28 @@ class TouchpadView(
     }
 
     private fun handleFingerUp(finger1: Finger) {
-        when (numFingers.toInt()) {
-            1 -> {
-                if (simTouchScreen) {
-                    postDelayed(
-                        { if (continueClick) xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT) },
-                        CLICK_DELAYED_TIME.toLong(),
-                    )
-                } else if (finger1.isTap()) {
-                    pressPointerButtonLeft(finger1)
+        if (tapToClickEnabled) {
+            when (numFingers.toInt()) {
+                1 -> {
+                    if (simTouchScreen) {
+                        postDelayed(
+                            { if (continueClick) xServer.injectPointerButtonRelease(Pointer.Button.BUTTON_LEFT) },
+                            CLICK_DELAYED_TIME.toLong(),
+                        )
+                    } else if (finger1.isTap()) {
+                        pressPointerButtonLeft(finger1)
+                    }
                 }
-            }
 
-            2 -> {
-                val finger2 = findSecondFinger(finger1)
-                if (finger2 != null && finger1.isTap()) pressPointerButtonRight(finger1)
-            }
+                2 -> {
+                    val finger2 = findSecondFinger(finger1)
+                    if (finger2 != null && finger1.isTap()) pressPointerButtonRight(finger1)
+                }
 
-            4 -> {
-                fourFingersTapCallback?.let {
-                    if (fingers.filterNotNull().all { it.isTap() }) it.run()
+                4 -> {
+                    fourFingersTapCallback?.let {
+                        if (fingers.filterNotNull().all { it.isTap() }) it.run()
+                    }
                 }
             }
         }

--- a/app/src/main/shared/android/FixedFontScaleActivity.kt
+++ b/app/src/main/shared/android/FixedFontScaleActivity.kt
@@ -8,6 +8,11 @@ import androidx.fragment.app.FragmentActivity
 
 private const val LOCKED_APP_FONT_SCALE = 1f
 
+private fun fontScaleOnlyConfiguration(): Configuration =
+    Configuration().apply {
+        fontScale = LOCKED_APP_FONT_SCALE
+    }
+
 private fun lockFontScale(configuration: Configuration?): Configuration? =
     configuration?.let {
         Configuration(it).apply {
@@ -17,8 +22,7 @@ private fun lockFontScale(configuration: Configuration?): Configuration? =
 
 private fun lockFontScale(base: Context?): Context? {
     if (base == null) return null
-    val configuration = lockFontScale(base.resources.configuration) ?: return base
-    return base.createConfigurationContext(configuration)
+    return base.createConfigurationContext(fontScaleOnlyConfiguration())
 }
 
 open class FixedFontScaleAppCompatActivity : AppCompatActivity() {

--- a/app/src/main/shared/ui/dialog/PreloaderDialogContent.kt
+++ b/app/src/main/shared/ui/dialog/PreloaderDialogContent.kt
@@ -115,6 +115,7 @@ private val TrackColor = Color(0xFF21293D)
 private val IndicatorColor = Color(0xFF57CBDE)
 private val CardBg = Color(0xFF1A2028)
 private val CardBorder = Color(0xFF253443)
+private val SteamPlatformBlue = Color(0xFF66C0F4)
 
 private val InterFont = FontFamily(Font(R.font.inter_medium))
 
@@ -129,10 +130,10 @@ private fun platformStringRes(source: String): Int? =
 
 private fun platformColor(source: String): Color =
     when (source.uppercase()) {
-        "STEAM" -> Color(0xFF66C0F4)
+        "STEAM" -> SteamPlatformBlue
         "EPIC" -> Color(0xFF8A8A8A)
         "GOG" -> Color(0xFFAB47BC)
-        "CUSTOM" -> Color(0xFF4CAF50)
+        "CUSTOM" -> SteamPlatformBlue
         else -> Color(0xFF57CBDE)
     }
 

--- a/app/src/main/shared/ui/widget/EnvVarsView.java
+++ b/app/src/main/shared/ui/widget/EnvVarsView.java
@@ -101,6 +101,10 @@ public class EnvVarsView extends FrameLayout {
     {"WRAPPER_MAX_IMAGE_COUNT", "TEXT"},
     {"MESA_GL_VERSION_OVERRIDE", "TEXT"},
     {"PULSE_LATENCY_MSEC", "NUMBER"},
+    {"WINNATIVE_ALSA_LATENCY_MS", "NUMBER"},
+    {"WINNATIVE_ALSA_VOLUME", "DECIMAL"},
+    {"WINNATIVE_ALSA_BASS_BOOST", "DECIMAL"},
+    {"WINNATIVE_ALSA_PERFORMANCE_MODE", "SELECT", "low_latency", "none", "power_saving"},
     {"WINE_DO_NOT_CREATE_DXGI_DEVICE_MANAGER", "CHECKBOX", "0", "1"},
     {"WINE_NEW_MEDIASOURCE", "CHECKBOX", "0", "1"},
     {"WINE_LARGE_ADDRESS_AWARE", "CHECKBOX", "0", "1"},
@@ -213,6 +217,13 @@ public class EnvVarsView extends FrameLayout {
         editTextNumber.setText(value);
         editTextNumber.setInputType(InputType.TYPE_CLASS_NUMBER);
         getValueCallback = () -> editTextNumber.getText().toString();
+        break;
+      case "DECIMAL":
+        EditText editTextDecimal = itemView.findViewById(R.id.EditText);
+        editTextDecimal.setVisibility(VISIBLE);
+        editTextDecimal.setText(value);
+        editTextDecimal.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+        getValueCallback = () -> editTextDecimal.getText().toString();
         break;
       case "TEXT":
       default:


### PR DESCRIPTION
## Summary

Fixes the first-launch setup wizard path where opening the container settings dialog could render at the wrong scale and appear oversized until the app was closed and reopened.

## Details

- Size the container settings dialog from the host activity window when it has already been laid out, falling back to window metrics or display metrics when needed.
- Reapply the dialog layout after attach so first-launch setup metrics settle before the final size is used.
- Pin the dialog Compose font scale to `1f` to match the app's fixed font-scale behavior across setup and normal app launches.

## Validation

- `git diff --check -- app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt`
- Attempted `./gradlew.bat :app:compileStandardDebugKotlin`, but this environment does not have Java available: `JAVA_HOME` is unset and `java` is not on `PATH`.