### PR TITLE
Fix startup layout scaling

### DIFF
--- a/app/src/main/shared/android/FixedFontScaleActivity.kt
+++ b/app/src/main/shared/android/FixedFontScaleActivity.kt
@@ -13,10 +13,20 @@ private fun fontScaleOnlyConfiguration(): Configuration =
         fontScale = LOCKED_APP_FONT_SCALE
     }
 
+private fun Configuration.clearDisplayMetricOverrides() {
+    orientation = Configuration.ORIENTATION_UNDEFINED
+    screenWidthDp = Configuration.SCREEN_WIDTH_DP_UNDEFINED
+    screenHeightDp = Configuration.SCREEN_HEIGHT_DP_UNDEFINED
+    smallestScreenWidthDp = Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED
+    densityDpi = Configuration.DENSITY_DPI_UNDEFINED
+    screenLayout = screenLayout and Configuration.SCREENLAYOUT_LAYOUTDIR_MASK
+}
+
 private fun lockFontScale(configuration: Configuration?): Configuration? =
     configuration?.let {
         Configuration(it).apply {
             fontScale = LOCKED_APP_FONT_SCALE
+            clearDisplayMetricOverrides()
         }
     }
 

--- a/app/src/main/shared/ui/FourByTwoGridView.kt
+++ b/app/src/main/shared/ui/FourByTwoGridView.kt
@@ -74,7 +74,15 @@ fun <T> FourByTwoGridView(
                 val verticalInset =
                     effectiveContentPadding.calculateTopPadding() +
                         effectiveContentPadding.calculateBottomPadding()
-                val targetRowHeight = (maxHeight - spacing - verticalInset) / 2
+                val horizontalInset =
+                    effectiveContentPadding.calculateStartPadding(layoutDirection) +
+                        effectiveContentPadding.calculateEndPadding(layoutDirection)
+                val effectiveColumns = columns.coerceAtLeast(1)
+                val availableRowHeight = ((maxHeight - spacing - verticalInset) / 2).coerceAtLeast(1.dp)
+                val availableColumnWidth =
+                    ((maxWidth - horizontalInset - spacing * (effectiveColumns - 1).toFloat()) / effectiveColumns.toFloat())
+                        .coerceAtLeast(1.dp)
+                val targetRowHeight = minOf(availableRowHeight, availableColumnWidth * 1.25f)
                 val rowHeight by animateDpAsState(
                     targetValue = targetRowHeight,
                     animationSpec =


### PR DESCRIPTION
- Keep the font-scale context from copying volatile startup display metrics.
- Clear orientation, screen dimensions, and density overrides before applying configuration overrides.
- Bound two-row grid card height by available column width so a portrait or unsettled first measure cannot produce oversized library/store cards.
- Validated with `git diff --check`; debug build remains blocked locally because no Android SDK is configured.