### PR TITLE
fix(controls): Replace file writing with a mmap ring buffer

### DIFF
--- a/app/src/main/cpp/winlator/fakeinput.cpp
+++ b/app/src/main/cpp/winlator/fakeinput.cpp
@@ -290,8 +290,10 @@ __attribute__((visibility("hidden"))) static int
 open_fake_input_ring(const char *event, int flags) {
   int slot = get_event_number(event);
   const char *ring_path = get_ring_path_for_slot(slot);
-  if (!ring_path)
+  if (!ring_path) {
+    errno = ENODEV;
     return -1;
+  }
 
   if (!my_open)
     *(void **)&my_open = dlsym(RTLD_NEXT, "open");
@@ -347,34 +349,25 @@ __attribute__((visibility("hidden"))) static bool is_fake_input_fd(int fd) {
 
 __attribute__((visibility("hidden"))) static bool fake_fd_is_stale(int fd) {
   auto controller = controller_map.find(fd);
-  return controller != controller_map.end() && controller->second.ring &&
+  return controller != controller_map.end() &&
          ring_generation(controller->second.ring) != controller->second.generation;
 }
 
 __attribute__((visibility("hidden"))) static bool
 fake_fd_has_unread_data(int fd) {
   auto controller = controller_map.find(fd);
-  if (controller != controller_map.end() && controller->second.ring) {
-    FakeController &fake = controller->second;
-    if (ring_generation(fake.ring) != fake.generation)
-      return false;
-    uint64_t write_seq = ring_write_seq(fake.ring);
-    if (write_seq < fake.read_seq)
-      fake.read_seq = write_seq;
-    if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
-      fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
-    return write_seq > fake.read_seq;
-  }
-
-  off_t current = lseek(fd, 0, SEEK_CUR);
-  if (current == (off_t)-1)
+  if (controller == controller_map.end())
     return false;
 
-  struct stat st = {};
-  if (fstat(fd, &st) != 0)
+  FakeController &fake = controller->second;
+  if (ring_generation(fake.ring) != fake.generation)
     return false;
-
-  return current < st.st_size;
+  uint64_t write_seq = ring_write_seq(fake.ring);
+  if (write_seq < fake.read_seq)
+    fake.read_seq = write_seq;
+  if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
+    fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
+  return write_seq > fake.read_seq;
 }
 
 __attribute__((visibility("hidden"))) static long long
@@ -404,12 +397,10 @@ EXPORT int open(const char *pathname, int flags, ...) {
   mode_t mode;
   int fd;
   bool hasMode;
-  bool isFromInput;
 
   va_start(va, flags);
 
   hasMode = flags & O_CREAT;
-  isFromInput = false;
 
   if (hasMode) {
     mode = va_arg(va, mode_t);
@@ -432,9 +423,12 @@ EXPORT int open(const char *pathname, int flags, ...) {
           free(fake_path);
           return fd;
         }
+        int saved_errno = errno;
+        free(fake_path);
+        errno = saved_errno;
+        return -1;
       }
       pathname = fake_path;
-      isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
     }
@@ -444,16 +438,6 @@ EXPORT int open(const char *pathname, int flags, ...) {
     fd = my_open(pathname, flags, mode);
   else
     fd = my_open(pathname, flags);
-
-  if (isFromInput && fd >= 0) {
-    const char *controller_event = event ? event : get_event(pathname);
-    Logger::log("Adding file-backed controller fallback, fd %d event %s\n", fd,
-                controller_event);
-    FakeController controller = {};
-    controller.event = strdup(controller_event);
-    controller.slot = get_event_number(controller_event);
-    controller_map[fd] = controller;
-  }
 
   if (fake_path)
     free(fake_path);
@@ -466,11 +450,9 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
   mode_t mode;
   int fd;
   bool hasMode;
-  bool isFromInput;
 
   va_start(va, flags);
 
-  isFromInput = false;
   hasMode = flags & O_CREAT;
 
   if (hasMode) {
@@ -494,9 +476,12 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
           free(fake_path);
           return fd;
         }
+        int saved_errno = errno;
+        free(fake_path);
+        errno = saved_errno;
+        return -1;
       }
       pathname = fake_path;
-      isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
     }
@@ -506,16 +491,6 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
     fd = my_openat(dirfd, pathname, flags, mode);
   else
     fd = my_openat(dirfd, pathname, flags);
-
-  if (isFromInput && fd >= 0) {
-    const char *controller_event = event ? event : get_event(pathname);
-    Logger::log("Adding file-backed controller fallback, fd %d event %s\n", fd,
-                controller_event);
-    FakeController controller = {};
-    controller.event = strdup(controller_event);
-    controller.slot = get_event_number(controller_event);
-    controller_map[fd] = controller;
-  }
 
   if (fake_path)
     free(fake_path);
@@ -795,84 +770,61 @@ EXPORT ssize_t read(int fd, void *buf, size_t count) {
 
   if (controller != controller_map.end()) {
     FakeController &fake = controller->second;
-    if (fake.ring) {
-      if (count < FAKE_INPUT_EVENT_SIZE) {
-        errno = EINVAL;
-        return -1;
-      }
+    if (count < FAKE_INPUT_EVENT_SIZE) {
+      errno = EINVAL;
+      return -1;
+    }
 
-      int flags = fcntl(fd, F_GETFL);
-      bool isNonBlock = flags >= 0 && (flags & O_NONBLOCK);
+    int flags = fcntl(fd, F_GETFL);
+    bool isNonBlock = flags >= 0 && (flags & O_NONBLOCK);
 
+    if (fake_fd_is_stale(fd)) {
+      errno = ENODEV;
+      return -1;
+    }
+
+    while (!fake_fd_has_unread_data(fd)) {
       if (fake_fd_is_stale(fd)) {
         errno = ENODEV;
         return -1;
       }
-
-      while (!fake_fd_has_unread_data(fd)) {
-        if (fake_fd_is_stale(fd)) {
-          errno = ENODEV;
-          return -1;
-        }
-        if (isNonBlock) {
-          errno = EAGAIN;
-          return -1;
-        }
-        setup_signal_handler();
-        if (stop_flag) {
-          errno = EINTR;
-          return -1;
-        }
-        struct timespec sleep_time = {0, 5 * 1000 * 1000};
-        nanosleep(&sleep_time, nullptr);
+      if (isNonBlock) {
+        errno = EAGAIN;
+        return -1;
       }
-
-      uint64_t write_seq = ring_write_seq(fake.ring);
-      if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
-        fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
-
-      size_t available_events =
-          static_cast<size_t>(std::min<uint64_t>(write_seq - fake.read_seq,
-                                                FAKE_INPUT_RING_CAPACITY));
-      size_t requested_events = count / FAKE_INPUT_EVENT_SIZE;
-      size_t events_to_read = std::min(requested_events, available_events);
-      uint8_t *out = static_cast<uint8_t *>(buf);
-      const uint8_t *ring_events =
-          reinterpret_cast<const uint8_t *>(fake.ring) +
-          FAKE_INPUT_RING_HEADER_SIZE;
-
-      for (size_t i = 0; i < events_to_read; i++) {
-        size_t event_index =
-            static_cast<size_t>((fake.read_seq + i) % FAKE_INPUT_RING_CAPACITY);
-        memcpy(out + (i * FAKE_INPUT_EVENT_SIZE),
-               ring_events + (event_index * FAKE_INPUT_EVENT_SIZE),
-               FAKE_INPUT_EVENT_SIZE);
-      }
-
-      fake.read_seq += events_to_read;
-      return static_cast<ssize_t>(events_to_read * FAKE_INPUT_EVENT_SIZE);
-    }
-
-    ssize_t bytes_read = 0;
-    int flags = fcntl(fd, F_GETFL);
-    bool isNonBlock = flags & O_NONBLOCK;
-    bytes_read = syscall(SYS_read, fd, buf, count);
-    if (bytes_read == 0 && isNonBlock) {
-      errno = EAGAIN;
-      return -1;
-    }
-    while (bytes_read == 0 && !isNonBlock) {
       setup_signal_handler();
       if (stop_flag) {
-        bytes_read = -1;
         errno = EINTR;
-        return bytes_read;
+        return -1;
       }
-      bytes_read = syscall(SYS_read, fd, buf, count);
-      continue;
+      struct timespec sleep_time = {0, 5 * 1000 * 1000};
+      nanosleep(&sleep_time, nullptr);
     }
 
-    return bytes_read;
+    uint64_t write_seq = ring_write_seq(fake.ring);
+    if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
+      fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
+
+    size_t available_events =
+        static_cast<size_t>(std::min<uint64_t>(write_seq - fake.read_seq,
+                                              FAKE_INPUT_RING_CAPACITY));
+    size_t requested_events = count / FAKE_INPUT_EVENT_SIZE;
+    size_t events_to_read = std::min(requested_events, available_events);
+    uint8_t *out = static_cast<uint8_t *>(buf);
+    const uint8_t *ring_events =
+        reinterpret_cast<const uint8_t *>(fake.ring) +
+        FAKE_INPUT_RING_HEADER_SIZE;
+
+    for (size_t i = 0; i < events_to_read; i++) {
+      size_t event_index =
+          static_cast<size_t>((fake.read_seq + i) % FAKE_INPUT_RING_CAPACITY);
+      memcpy(out + (i * FAKE_INPUT_EVENT_SIZE),
+             ring_events + (event_index * FAKE_INPUT_EVENT_SIZE),
+             FAKE_INPUT_EVENT_SIZE);
+    }
+
+    fake.read_seq += events_to_read;
+    return static_cast<ssize_t>(events_to_read * FAKE_INPUT_EVENT_SIZE);
   }
   return syscall(SYS_read, fd, buf, count);
 }
@@ -895,14 +847,7 @@ EXPORT ssize_t write(int fd, const void *buf, size_t count) {
       check_ff_event(ev, slot);
     }
 
-    if (controller->second.ring)
-      return static_cast<ssize_t>(count);
-
-    // FF control events are commands sent to the fake device, not controller input.
-    // Writing them back into the fake evdev file lets Wine read them as input and can
-    // stall or corrupt controller state, so consume them here.
-    if (ev && ev->type == EV_FF)
-      return static_cast<ssize_t>(count);
+    return static_cast<ssize_t>(count);
   }
   return my_write(fd, buf, count);
 }
@@ -916,44 +861,16 @@ EXPORT ssize_t writev(int fd, const struct iovec *iov, int iovcnt) {
     }
 
     uint16_t slot = static_cast<uint16_t>(controller->second.slot);
-    if (controller->second.ring) {
-      ssize_t total = 0;
-      for (int i = 0; i < iovcnt; i++) {
-        if (iov[i].iov_len == sizeof(struct input_event)) {
-          const struct input_event *ev =
-              static_cast<const struct input_event *>(iov[i].iov_base);
-          check_ff_event(ev, slot);
-        }
-        total += static_cast<ssize_t>(iov[i].iov_len);
-      }
-      return total;
-    }
-
-    std::vector<struct iovec> filtered;
-    filtered.reserve(iovcnt);
-    ssize_t filtered_out_bytes = 0;
-
+    ssize_t total = 0;
     for (int i = 0; i < iovcnt; i++) {
       if (iov[i].iov_len == sizeof(struct input_event)) {
         const struct input_event *ev =
             static_cast<const struct input_event *>(iov[i].iov_base);
         check_ff_event(ev, slot);
-        if (ev->type == EV_FF) {
-          filtered_out_bytes += static_cast<ssize_t>(iov[i].iov_len);
-          continue;
-        }
       }
-      filtered.push_back(iov[i]);
+      total += static_cast<ssize_t>(iov[i].iov_len);
     }
-
-    if (filtered.empty())
-      return filtered_out_bytes;
-
-    ssize_t written =
-        syscall(SYS_writev, fd, filtered.data(), static_cast<int>(filtered.size()));
-    if (written < 0)
-      return written;
-    return written + filtered_out_bytes;
+    return total;
   }
   return syscall(SYS_writev, fd, iov, iovcnt);
 }

--- a/app/src/main/cpp/winlator/fakeinput.cpp
+++ b/app/src/main/cpp/winlator/fakeinput.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <cerrno>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -22,6 +24,7 @@
 #include <string.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -43,8 +46,42 @@ static constexpr const char *GAMEPAD_PHYS_TEMPLATE = "usb-fakeinput/input%d";
 static constexpr const char *GAMEPAD_UNIQ_TEMPLATE = "0000000000%02d";
 static constexpr uint8_t GAMEPAD_AXIS_COUNT = 8;
 static constexpr uint8_t GAMEPAD_BUTTON_COUNT = 11;
+static constexpr uint32_t FAKE_INPUT_RING_MAGIC = 0x46494252;
+static constexpr uint32_t FAKE_INPUT_RING_VERSION = 1;
+static constexpr uint32_t FAKE_INPUT_EVENT_SIZE = sizeof(struct input_event);
+static constexpr uint32_t FAKE_INPUT_RING_CAPACITY = 512;
 
-std::unordered_map<int, const char *> controller_map;
+struct FakeInputRingHeader {
+  uint32_t magic;
+  uint32_t version;
+  uint32_t event_size;
+  uint32_t capacity;
+  uint64_t write_seq;
+  uint64_t generation;
+  uint8_t reserved[32];
+};
+
+static_assert(sizeof(FakeInputRingHeader) == 64,
+              "fake input ring header must stay ABI-stable");
+
+static constexpr size_t FAKE_INPUT_RING_HEADER_SIZE =
+    sizeof(FakeInputRingHeader);
+static constexpr size_t FAKE_INPUT_RING_SIZE =
+    FAKE_INPUT_RING_HEADER_SIZE +
+    (FAKE_INPUT_RING_CAPACITY * FAKE_INPUT_EVENT_SIZE);
+
+struct FakeController {
+  char *event = nullptr;
+  int slot = -1;
+  FakeInputRingHeader *ring = nullptr;
+  uint64_t read_seq = 0;
+  uint64_t generation = 0;
+  size_t mapping_size = 0;
+};
+
+static std::unordered_map<int, FakeController> controller_map;
+static std::unordered_map<int, std::string> ring_paths;
+static bool ring_paths_loaded = false;
 static bool initialized = false;
 static const char *hook_dir = nullptr;
 static bool vibration_enabled = true;
@@ -191,6 +228,106 @@ __attribute__((visibility("hidden"))) int get_event_number(const char *event) {
   return event_number;
 }
 
+__attribute__((visibility("hidden"))) static void load_ring_paths() {
+  if (ring_paths_loaded)
+    return;
+
+  ring_paths_loaded = true;
+  const char *spec = getenv("FAKE_EVDEV_MEMFD_PATHS");
+  if (!spec || !*spec)
+    return;
+
+  char *copy = strdup(spec);
+  if (!copy)
+    return;
+
+  char *saveptr = nullptr;
+  for (char *token = strtok_r(copy, ";", &saveptr); token;
+       token = strtok_r(nullptr, ";", &saveptr)) {
+    char *equals = strchr(token, '=');
+    if (!equals)
+      continue;
+    *equals = '\0';
+    int slot = atoi(token);
+    const char *path = equals + 1;
+    if (slot >= 0 && *path)
+      ring_paths[slot] = path;
+  }
+
+  free(copy);
+}
+
+__attribute__((visibility("hidden"))) static const char *
+get_ring_path_for_slot(int slot) {
+  load_ring_paths();
+  auto it = ring_paths.find(slot);
+  return it == ring_paths.end() ? nullptr : it->second.c_str();
+}
+
+__attribute__((visibility("hidden"))) static uint64_t
+ring_write_seq(const FakeInputRingHeader *ring) {
+  return __atomic_load_n(&ring->write_seq, __ATOMIC_ACQUIRE);
+}
+
+__attribute__((visibility("hidden"))) static uint64_t
+ring_generation(const FakeInputRingHeader *ring) {
+  return __atomic_load_n(&ring->generation, __ATOMIC_ACQUIRE);
+}
+
+__attribute__((visibility("hidden"))) static bool
+ring_header_is_valid(const FakeInputRingHeader *ring) {
+  return ring && ring->magic == FAKE_INPUT_RING_MAGIC &&
+         ring->version == FAKE_INPUT_RING_VERSION &&
+         ring->event_size == FAKE_INPUT_EVENT_SIZE &&
+         ring->capacity == FAKE_INPUT_RING_CAPACITY;
+}
+
+__attribute__((visibility("hidden"))) static int
+open_fake_input_ring(const char *event, int flags) {
+  int slot = get_event_number(event);
+  const char *ring_path = get_ring_path_for_slot(slot);
+  if (!ring_path)
+    return -1;
+
+  if (!my_open)
+    *(void **)&my_open = dlsym(RTLD_NEXT, "open");
+
+  int fd = my_open(ring_path, O_RDWR | (flags & O_NONBLOCK));
+  if (fd < 0)
+    return -1;
+
+  void *mapping =
+      mmap(nullptr, FAKE_INPUT_RING_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+  if (mapping == MAP_FAILED) {
+    int saved_errno = errno;
+    syscall(SYS_close, fd);
+    errno = saved_errno;
+    return -1;
+  }
+
+  FakeInputRingHeader *ring =
+      reinterpret_cast<FakeInputRingHeader *>(mapping);
+  if (!ring_header_is_valid(ring)) {
+    munmap(mapping, FAKE_INPUT_RING_SIZE);
+    syscall(SYS_close, fd);
+    errno = ENODEV;
+    return -1;
+  }
+
+  FakeController controller = {};
+  controller.event = strdup(event);
+  controller.slot = slot;
+  controller.ring = ring;
+  controller.mapping_size = FAKE_INPUT_RING_SIZE;
+  controller.read_seq = ring_write_seq(ring);
+  controller.generation = ring_generation(ring);
+  controller_map[fd] = controller;
+
+  Logger::log("Adding ring-backed controller, fd %d event %s slot %d\n", fd,
+              event, slot);
+  return fd;
+}
+
 __attribute__((visibility("hidden"))) static void
 copy_slot_ioctl_string(int op, void *argp, const char *format, int event_number) {
   size_t size = _IOC_SIZE(op);
@@ -204,8 +341,27 @@ __attribute__((visibility("hidden"))) static bool is_fake_input_fd(int fd) {
   return controller_map.find(fd) != controller_map.end();
 }
 
+__attribute__((visibility("hidden"))) static bool fake_fd_is_stale(int fd) {
+  auto controller = controller_map.find(fd);
+  return controller != controller_map.end() && controller->second.ring &&
+         ring_generation(controller->second.ring) != controller->second.generation;
+}
+
 __attribute__((visibility("hidden"))) static bool
 fake_fd_has_unread_data(int fd) {
+  auto controller = controller_map.find(fd);
+  if (controller != controller_map.end() && controller->second.ring) {
+    FakeController &fake = controller->second;
+    if (ring_generation(fake.ring) != fake.generation)
+      return false;
+    uint64_t write_seq = ring_write_seq(fake.ring);
+    if (write_seq < fake.read_seq)
+      fake.read_seq = write_seq;
+    if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
+      fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
+    return write_seq > fake.read_seq;
+  }
+
   off_t current = lseek(fd, 0, SEEK_CUR);
   if (current == (off_t)-1)
     return false;
@@ -260,9 +416,17 @@ EXPORT int open(const char *pathname, int flags, ...) {
   if (!my_open)
     *(void **)&my_open = dlsym(RTLD_NEXT, "open");
 
+  char *fake_path = nullptr;
+  const char *event = nullptr;
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
-      pathname = from_real_to_fake_path(pathname);
+      event = get_event(pathname);
+      fd = open_fake_input_ring(event, flags);
+      if (fd >= 0)
+        return fd;
+
+      fake_path = from_real_to_fake_path(pathname);
+      pathname = fake_path;
       isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
@@ -274,10 +438,18 @@ EXPORT int open(const char *pathname, int flags, ...) {
   else
     fd = my_open(pathname, flags);
 
-  if (isFromInput) {
-    Logger::log("Adding controller, fd %d event %s\n", fd, get_event(pathname));
-    controller_map[fd] = strdup(get_event(pathname));
+  if (isFromInput && fd >= 0) {
+    const char *controller_event = event ? event : get_event(pathname);
+    Logger::log("Adding file-backed controller fallback, fd %d event %s\n", fd,
+                controller_event);
+    FakeController controller = {};
+    controller.event = strdup(controller_event);
+    controller.slot = get_event_number(controller_event);
+    controller_map[fd] = controller;
   }
+
+  if (fake_path)
+    free(fake_path);
 
   return fd;
 }
@@ -303,9 +475,17 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
   if (!my_openat)
     *(void **)&my_openat = dlsym(RTLD_NEXT, "openat");
 
+  char *fake_path = nullptr;
+  const char *event = nullptr;
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
-      pathname = from_real_to_fake_path(pathname);
+      event = get_event(pathname);
+      fd = open_fake_input_ring(event, flags);
+      if (fd >= 0)
+        return fd;
+
+      fake_path = from_real_to_fake_path(pathname);
+      pathname = fake_path;
       isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
@@ -317,10 +497,18 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
   else
     fd = my_openat(dirfd, pathname, flags);
 
-  if (isFromInput) {
-    Logger::log("Adding controller, fd %d event %s\n", fd, get_event(pathname));
-    controller_map[fd] = strdup(get_event(pathname));
+  if (isFromInput && fd >= 0) {
+    const char *controller_event = event ? event : get_event(pathname);
+    Logger::log("Adding file-backed controller fallback, fd %d event %s\n", fd,
+                controller_event);
+    FakeController controller = {};
+    controller.event = strdup(controller_event);
+    controller.slot = get_event_number(controller_event);
+    controller_map[fd] = controller;
   }
+
+  if (fake_path)
+    free(fake_path);
 
   return fd;
 }
@@ -331,22 +519,36 @@ EXPORT int stat(const char *pathname, struct stat *statbuf) {
 
   const char *event = nullptr;
   int event_number = -1;
+  bool has_ring_path = false;
+  char *fake_path = nullptr;
 
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
-      pathname = from_real_to_fake_path(pathname);
       event = get_event(pathname);
       event_number = get_event_number(event);
+      has_ring_path = get_ring_path_for_slot(event_number) != nullptr;
+      fake_path = from_real_to_fake_path(pathname);
+      pathname = fake_path;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
     }
   }
 
   int ret = my_stat(pathname, statbuf);
+  if (ret != 0 && has_ring_path && statbuf) {
+    memset(statbuf, 0, sizeof(*statbuf));
+    statbuf->st_mode = S_IFCHR | 0660;
+    statbuf->st_nlink = 1;
+    ret = 0;
+  }
 
-  if (event && event_number >= 0) {
+  if (ret == 0 && event && event_number >= 0) {
+    statbuf->st_mode = (statbuf->st_mode & ~S_IFMT) | S_IFCHR;
     statbuf->st_rdev = makedev(1, event_number);
   }
+
+  if (fake_path)
+    free(fake_path);
 
   return ret;
 }
@@ -358,8 +560,9 @@ EXPORT int fstat(int fd, struct stat *buf) {
   int ret = my_fstat(fd, buf);
 
   auto controller = controller_map.find(fd);
-  if (controller != controller_map.end()) {
-    buf->st_rdev = makedev(1, get_event_number(controller->second));
+  if (ret == 0 && controller != controller_map.end()) {
+    buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
+    buf->st_rdev = makedev(1, controller->second.slot);
   }
 
   return ret;
@@ -385,15 +588,20 @@ EXPORT int inotify_add_watch(int fd, const char *pathname, uint32_t mask) {
   if (!my_inotify_add_watch)
     *(void **)&my_inotify_add_watch = dlsym(RTLD_NEXT, "inotify_add_watch");
 
+  char *fake_path = nullptr;
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
-      pathname = from_real_to_fake_path(pathname);
+      fake_path = from_real_to_fake_path(pathname);
+      pathname = fake_path;
     } else if (!strcmp(pathname, "/dev/input")) {
       pathname = hook_dir;
     }
   }
 
-  return my_inotify_add_watch(fd, pathname, mask);
+  int ret = my_inotify_add_watch(fd, pathname, mask);
+  if (fake_path)
+    free(fake_path);
+  return ret;
 }
 
 EXPORT int ioctl(int fd, int op, ...) {
@@ -411,8 +619,8 @@ EXPORT int ioctl(int fd, int op, ...) {
 
   int type = (op >> 8 & 0xFF);
   int number = (op >> 0 & 0xFF);
-  const char *event = controller->second;
-  int event_number = get_event_number(event);
+  const char *event = controller->second.event ? controller->second.event : "event0";
+  int event_number = controller->second.slot;
 
   if (type == 0x45 && number == 0x1) {
     Logger::log("Hooking ioctl EVIOCGVERSION for event %s\n", event);
@@ -499,7 +707,7 @@ EXPORT int ioctl(int fd, int op, ...) {
     ff_effects[effect->id] = *effect;
 
     uint16_t duration = effect->replay.length;
-    uint16_t slot = static_cast<uint16_t>(get_event_number(event));
+    uint16_t slot = static_cast<uint16_t>(event_number);
     if (effect->type == FF_RUMBLE) {
       send_vibration(effect->u.rumble.strong_magnitude,
                      effect->u.rumble.weak_magnitude, duration, slot);
@@ -570,8 +778,10 @@ EXPORT int close(int fd) {
   auto controller = controller_map.find(fd);
   if (controller != controller_map.end()) {
     Logger::log("Removing controller, fd %d event %s\n", controller->first,
-                controller->second);
-    free((void *)controller->second);
+                controller->second.event ? controller->second.event : "(unknown)");
+    if (controller->second.ring)
+      munmap(controller->second.ring, controller->second.mapping_size);
+    free(controller->second.event);
     controller_map.erase(fd);
   }
 
@@ -582,6 +792,65 @@ EXPORT ssize_t read(int fd, void *buf, size_t count) {
   auto controller = controller_map.find(fd);
 
   if (controller != controller_map.end()) {
+    FakeController &fake = controller->second;
+    if (fake.ring) {
+      if (count < FAKE_INPUT_EVENT_SIZE) {
+        errno = EINVAL;
+        return -1;
+      }
+
+      int flags = fcntl(fd, F_GETFL);
+      bool isNonBlock = flags >= 0 && (flags & O_NONBLOCK);
+
+      if (fake_fd_is_stale(fd)) {
+        errno = ENODEV;
+        return -1;
+      }
+
+      while (!fake_fd_has_unread_data(fd)) {
+        if (fake_fd_is_stale(fd)) {
+          errno = ENODEV;
+          return -1;
+        }
+        if (isNonBlock) {
+          errno = EAGAIN;
+          return -1;
+        }
+        setup_signal_handler();
+        if (stop_flag) {
+          errno = EINTR;
+          return -1;
+        }
+        struct timespec sleep_time = {0, 5 * 1000 * 1000};
+        nanosleep(&sleep_time, nullptr);
+      }
+
+      uint64_t write_seq = ring_write_seq(fake.ring);
+      if (write_seq - fake.read_seq > FAKE_INPUT_RING_CAPACITY)
+        fake.read_seq = write_seq - FAKE_INPUT_RING_CAPACITY;
+
+      size_t available_events =
+          static_cast<size_t>(std::min<uint64_t>(write_seq - fake.read_seq,
+                                                FAKE_INPUT_RING_CAPACITY));
+      size_t requested_events = count / FAKE_INPUT_EVENT_SIZE;
+      size_t events_to_read = std::min(requested_events, available_events);
+      uint8_t *out = static_cast<uint8_t *>(buf);
+      const uint8_t *ring_events =
+          reinterpret_cast<const uint8_t *>(fake.ring) +
+          FAKE_INPUT_RING_HEADER_SIZE;
+
+      for (size_t i = 0; i < events_to_read; i++) {
+        size_t event_index =
+            static_cast<size_t>((fake.read_seq + i) % FAKE_INPUT_RING_CAPACITY);
+        memcpy(out + (i * FAKE_INPUT_EVENT_SIZE),
+               ring_events + (event_index * FAKE_INPUT_EVENT_SIZE),
+               FAKE_INPUT_EVENT_SIZE);
+      }
+
+      fake.read_seq += events_to_read;
+      return static_cast<ssize_t>(events_to_read * FAKE_INPUT_EVENT_SIZE);
+    }
+
     ssize_t bytes_read = 0;
     int flags = fcntl(fd, F_GETFL);
     bool isNonBlock = flags & O_NONBLOCK;
@@ -611,15 +880,26 @@ EXPORT ssize_t write(int fd, const void *buf, size_t count) {
     *(void **)&my_write = dlsym(RTLD_NEXT, "write");
 
   auto controller = controller_map.find(fd);
-  if (controller != controller_map.end() &&
-      count == sizeof(struct input_event)) {
-    const struct input_event *ev = static_cast<const struct input_event *>(buf);
-    uint16_t slot = static_cast<uint16_t>(get_event_number(controller->second));
-    check_ff_event(ev, slot);
+  if (controller != controller_map.end()) {
+    if (fake_fd_is_stale(fd)) {
+      errno = ENODEV;
+      return -1;
+    }
+
+    const struct input_event *ev = nullptr;
+    uint16_t slot = static_cast<uint16_t>(controller->second.slot);
+    if (count == sizeof(struct input_event)) {
+      ev = static_cast<const struct input_event *>(buf);
+      check_ff_event(ev, slot);
+    }
+
+    if (controller->second.ring)
+      return static_cast<ssize_t>(count);
+
     // FF control events are commands sent to the fake device, not controller input.
     // Writing them back into the fake evdev file lets Wine read them as input and can
     // stall or corrupt controller state, so consume them here.
-    if (ev->type == EV_FF)
+    if (ev && ev->type == EV_FF)
       return static_cast<ssize_t>(count);
   }
   return my_write(fd, buf, count);
@@ -628,7 +908,25 @@ EXPORT ssize_t write(int fd, const void *buf, size_t count) {
 EXPORT ssize_t writev(int fd, const struct iovec *iov, int iovcnt) {
   auto controller = controller_map.find(fd);
   if (controller != controller_map.end()) {
-    uint16_t slot = static_cast<uint16_t>(get_event_number(controller->second));
+    if (fake_fd_is_stale(fd)) {
+      errno = ENODEV;
+      return -1;
+    }
+
+    uint16_t slot = static_cast<uint16_t>(controller->second.slot);
+    if (controller->second.ring) {
+      ssize_t total = 0;
+      for (int i = 0; i < iovcnt; i++) {
+        if (iov[i].iov_len == sizeof(struct input_event)) {
+          const struct input_event *ev =
+              static_cast<const struct input_event *>(iov[i].iov_base);
+          check_ff_event(ev, slot);
+        }
+        total += static_cast<ssize_t>(iov[i].iov_len);
+      }
+      return total;
+    }
+
     std::vector<struct iovec> filtered;
     filtered.reserve(iovcnt);
     ssize_t filtered_out_bytes = 0;
@@ -704,6 +1002,8 @@ EXPORT int poll(struct pollfd *fds, nfds_t nfds, int timeout) {
         continue;
 
       short revents = 0;
+      if (fake_fd_is_stale(fds[i].fd))
+        revents |= POLLHUP;
       if ((fds[i].events & (POLLIN | POLLRDNORM)) &&
           fake_fd_has_unread_data(fds[i].fd))
         revents |= (fds[i].events & (POLLIN | POLLRDNORM));
@@ -834,8 +1134,11 @@ EXPORT int select(int nfds, fd_set *readfds, fd_set *writefds,
     for (int fd = 0; fd < nfds; fd++) {
       if (!is_fake_input_fd(fd))
         continue;
-      if (readfds && FD_ISSET(fd, &original_readfds) &&
-          fake_fd_has_unread_data(fd)) {
+      if (readfds && FD_ISSET(fd, &original_readfds) && fake_fd_is_stale(fd)) {
+        FD_SET(fd, readfds);
+        ready++;
+      } else if (readfds && FD_ISSET(fd, &original_readfds) &&
+                 fake_fd_has_unread_data(fd)) {
         FD_SET(fd, readfds);
         ready++;
       }

--- a/app/src/main/cpp/winlator/fakeinput.cpp
+++ b/app/src/main/cpp/winlator/fakeinput.cpp
@@ -211,6 +211,10 @@ from_real_to_fake_path(const char *pathname) {
   return fake_path;
 }
 
+__attribute__((visibility("hidden"))) static bool path_exists(const char *path) {
+  return path && faccessat(AT_FDCWD, path, F_OK, 0) == 0;
+}
+
 __attribute__((visibility("hidden"))) static bool
 is_fake_input_node_path(const char *pathname) {
   return pathname && (!strncmp(pathname, "/dev/input/event", 16) ||
@@ -421,11 +425,14 @@ EXPORT int open(const char *pathname, int flags, ...) {
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
       event = get_event(pathname);
-      fd = open_fake_input_ring(event, flags);
-      if (fd >= 0)
-        return fd;
-
       fake_path = from_real_to_fake_path(pathname);
+      if (path_exists(fake_path)) {
+        fd = open_fake_input_ring(event, flags);
+        if (fd >= 0) {
+          free(fake_path);
+          return fd;
+        }
+      }
       pathname = fake_path;
       isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
@@ -480,11 +487,14 @@ EXPORT int openat(int dirfd, const char *pathname, int flags, ...) {
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
       event = get_event(pathname);
-      fd = open_fake_input_ring(event, flags);
-      if (fd >= 0)
-        return fd;
-
       fake_path = from_real_to_fake_path(pathname);
+      if (path_exists(fake_path)) {
+        fd = open_fake_input_ring(event, flags);
+        if (fd >= 0) {
+          free(fake_path);
+          return fd;
+        }
+      }
       pathname = fake_path;
       isFromInput = true;
     } else if (!strcmp(pathname, "/dev/input")) {
@@ -519,14 +529,12 @@ EXPORT int stat(const char *pathname, struct stat *statbuf) {
 
   const char *event = nullptr;
   int event_number = -1;
-  bool has_ring_path = false;
   char *fake_path = nullptr;
 
   if (pathname) {
     if (is_fake_input_node_path(pathname)) {
       event = get_event(pathname);
       event_number = get_event_number(event);
-      has_ring_path = get_ring_path_for_slot(event_number) != nullptr;
       fake_path = from_real_to_fake_path(pathname);
       pathname = fake_path;
     } else if (!strcmp(pathname, "/dev/input")) {
@@ -535,12 +543,6 @@ EXPORT int stat(const char *pathname, struct stat *statbuf) {
   }
 
   int ret = my_stat(pathname, statbuf);
-  if (ret != 0 && has_ring_path && statbuf) {
-    memset(statbuf, 0, sizeof(*statbuf));
-    statbuf->st_mode = S_IFCHR | 0660;
-    statbuf->st_nlink = 1;
-    ret = 0;
-  }
 
   if (ret == 0 && event && event_number >= 0) {
     statbuf->st_mode = (statbuf->st_mode & ~S_IFMT) | S_IFCHR;

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -814,8 +814,8 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
 
     File devInputDir = new File(imageFs.getRootDir(), "dev/input");
     devInputDir.mkdirs();
-    FakeInputWriter.prepareMemfdSlots(4);
-    String fakeEvdevMemfdPaths = FakeInputWriter.getMemfdEnv();
+    FakeInputWriter.prepareRingSlots(devInputDir, 4);
+    String fakeEvdevMemfdPaths = FakeInputWriter.getRingEnv(devInputDir);
     if (!fakeEvdevMemfdPaths.isEmpty()) {
       envVars.put("FAKE_EVDEV_MEMFD_PATHS", fakeEvdevMemfdPaths);
     }

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -18,6 +18,7 @@ import com.winlator.cmod.runtime.content.ContentsManager;
 import com.winlator.cmod.runtime.display.connector.UnixSocketConfig;
 import com.winlator.cmod.runtime.display.environment.EnvironmentComponent;
 import com.winlator.cmod.runtime.display.environment.ImageFs;
+import com.winlator.cmod.runtime.input.controls.FakeInputWriter;
 import com.winlator.cmod.runtime.system.GPUInformation;
 import com.winlator.cmod.runtime.system.ProcessHelper;
 import com.winlator.cmod.runtime.wine.EnvVars;
@@ -236,7 +237,11 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
       Log.d("GuestLauncher", "execShellCommand LD_PRELOAD=" + ldPreload.toString());
     }
     envVars.put("WINEESYNC_WINLATOR", "1");
-    mergeExternalEnvVars(envVars, envVars.get("LD_PRELOAD"), envVars.get("FAKE_EVDEV_DIR"));
+    mergeExternalEnvVars(
+        envVars,
+        envVars.get("LD_PRELOAD"),
+        envVars.get("FAKE_EVDEV_DIR"),
+        envVars.get("FAKE_EVDEV_MEMFD_PATHS"));
     FEXCorePresetManager.normalizeSmcChecksEnvVars(envVars, this.envVars);
 
     // For arm64ec Wine builds the wine binary is native ARM64 — call it directly
@@ -607,7 +612,10 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
   }
 
   private void mergeExternalEnvVars(
-      EnvVars envVars, String protectedLdPreload, String protectedFakeEvdevDir) {
+      EnvVars envVars,
+      String protectedLdPreload,
+      String protectedFakeEvdevDir,
+      String protectedFakeEvdevMemfdPaths) {
     if (this.envVars == null) {
       return;
     }
@@ -622,6 +630,7 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
 
     String overrideLdPreload = this.envVars.get("LD_PRELOAD");
     String overrideFakeEvdevDir = this.envVars.get("FAKE_EVDEV_DIR");
+    String overrideFakeEvdevMemfdPaths = this.envVars.get("FAKE_EVDEV_MEMFD_PATHS");
 
     envVars.putAll(this.envVars);
 
@@ -633,6 +642,12 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
       envVars.put("FAKE_EVDEV_DIR", protectedFakeEvdevDir);
     } else if (overrideFakeEvdevDir != null && !overrideFakeEvdevDir.isEmpty()) {
       envVars.put("FAKE_EVDEV_DIR", overrideFakeEvdevDir);
+    }
+
+    if (protectedFakeEvdevMemfdPaths != null && !protectedFakeEvdevMemfdPaths.isEmpty()) {
+      envVars.put("FAKE_EVDEV_MEMFD_PATHS", protectedFakeEvdevMemfdPaths);
+    } else if (overrideFakeEvdevMemfdPaths != null && !overrideFakeEvdevMemfdPaths.isEmpty()) {
+      envVars.put("FAKE_EVDEV_MEMFD_PATHS", overrideFakeEvdevMemfdPaths);
     }
   }
 
@@ -799,6 +814,11 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
 
     File devInputDir = new File(imageFs.getRootDir(), "dev/input");
     devInputDir.mkdirs();
+    FakeInputWriter.prepareMemfdSlots(4);
+    String fakeEvdevMemfdPaths = FakeInputWriter.getMemfdEnv();
+    if (!fakeEvdevMemfdPaths.isEmpty()) {
+      envVars.put("FAKE_EVDEV_MEMFD_PATHS", fakeEvdevMemfdPaths);
+    }
     // XServerDisplayActivity pre-creates the configured controller count after the
     // shortcut is loaded. Keep event0 available here as a minimum fallback.
     File event0 = new File(devInputDir, "event0");
@@ -822,7 +842,11 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
 
     // Preserve the launcher-owned preload/input paths while restoring the
     // full env built upstream in XServerDisplayActivity (driver, DXVK, Vulkan, etc).
-    mergeExternalEnvVars(envVars, envVars.get("LD_PRELOAD"), envVars.get("FAKE_EVDEV_DIR"));
+    mergeExternalEnvVars(
+        envVars,
+        envVars.get("LD_PRELOAD"),
+        envVars.get("FAKE_EVDEV_DIR"),
+        envVars.get("FAKE_EVDEV_MEMFD_PATHS"));
     FEXCorePresetManager.normalizeSmcChecksEnvVars(envVars, this.envVars);
 
     String emulator = container.getEmulator();

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -815,17 +815,17 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     File devInputDir = new File(imageFs.getRootDir(), "dev/input");
     devInputDir.mkdirs();
     FakeInputWriter.prepareRingSlots(devInputDir, 4);
-    String fakeEvdevMemfdPaths = FakeInputWriter.getRingEnv(devInputDir);
-    if (!fakeEvdevMemfdPaths.isEmpty()) {
-      envVars.put("FAKE_EVDEV_MEMFD_PATHS", fakeEvdevMemfdPaths);
-    }
-    // XServerDisplayActivity pre-creates the configured controller count after the
-    // shortcut is loaded. Keep event0 available here as a minimum fallback.
-    File event0 = new File(devInputDir, "event0");
-    if (!event0.exists()) {
-      try {
-        event0.createNewFile();
-      } catch (Exception e) {
+    String fakeEvdevRingPaths = FakeInputWriter.getRingEnv(devInputDir);
+    if (!fakeEvdevRingPaths.isEmpty()) {
+      envVars.put("FAKE_EVDEV_MEMFD_PATHS", fakeEvdevRingPaths);
+      // XServerDisplayActivity pre-creates the configured controller count after the
+      // shortcut is loaded. Keep event0 discoverable once the ring transport exists.
+      File event0 = new File(devInputDir, "event0");
+      if (!event0.exists()) {
+        try {
+          event0.createNewFile();
+        } catch (Exception e) {
+        }
       }
     }
     envVars.put("FAKE_EVDEV_DIR", devInputDir.getAbsolutePath());

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 import android.hardware.input.InputManager;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.Log;
@@ -57,6 +59,7 @@ public class WinHandler {
   private static final int MAX_CONTROLLERS = 4;
   private static final int OSC_DEVICE_ID = -1;
   private static final short SERVER_PORT = 7947;
+  private static final long VIRTUAL_REBALANCE_AFTER_PHYSICAL_DISCONNECT_MS = 200;
   private static final float GYRO_AXIS_EPSILON = 0.001f;
   private static final float GYRO_TRIGGER_PRESS_THRESHOLD = 0.15f;
   private final XServerDisplayActivity activity;
@@ -71,6 +74,7 @@ public class WinHandler {
   private final ByteBuffer receiveData = ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN);
   private final DatagramPacket sendPacket = new DatagramPacket(this.sendData.array(), 64);
   private final DatagramPacket receivePacket = new DatagramPacket(this.receiveData.array(), 64);
+  private final Handler inputHandler = new Handler(Looper.getMainLooper());
   private final ArrayDeque<Runnable> actions = new ArrayDeque<>();
   private boolean initReceived = false;
   private volatile boolean running = false;
@@ -104,6 +108,7 @@ public class WinHandler {
   private boolean gyroActivatorPressed = false;
   private int lastGyroTargetSource = 0;
   private ExternalController lastGyroTargetController;
+  private Runnable pendingVirtualGamepadRebalance;
   private final InputManager.InputDeviceListener inputDeviceListener =
       new InputManager.InputDeviceListener() {
         @Override
@@ -726,13 +731,45 @@ public class WinHandler {
     }
   }
 
+  private void cancelPendingVirtualGamepadRebalance() {
+    if (this.pendingVirtualGamepadRebalance == null) {
+      return;
+    }
+    this.inputHandler.removeCallbacks(this.pendingVirtualGamepadRebalance);
+    this.pendingVirtualGamepadRebalance = null;
+  }
+
+  private void scheduleVirtualGamepadRebalance() {
+    if (!this.deviceToSlot.containsKey(OSC_DEVICE_ID)) {
+      return;
+    }
+    cancelPendingVirtualGamepadRebalance();
+    this.pendingVirtualGamepadRebalance =
+        () -> {
+          this.pendingVirtualGamepadRebalance = null;
+          rebalanceVirtualGamepadSlot();
+        };
+    this.inputHandler.postDelayed(
+        this.pendingVirtualGamepadRebalance, VIRTUAL_REBALANCE_AFTER_PHYSICAL_DISCONNECT_MS);
+    Log.d(
+        "WinHandler",
+        "Scheduled virtual gamepad slot rebalance after physical disconnect.");
+  }
+
   private int assignSlot(int deviceId) {
+    if (deviceId != OSC_DEVICE_ID) {
+      cancelPendingVirtualGamepadRebalance();
+    }
+
     // Fast path: already assigned
     Integer existing = this.deviceToSlot.get(deviceId);
     if (existing != null) {
       if (deviceId == OSC_DEVICE_ID) {
         int preferredVirtualSlot = findPreferredVirtualSlot(existing);
         if (preferredVirtualSlot != -1 && preferredVirtualSlot != existing) {
+          if (this.pendingVirtualGamepadRebalance != null) {
+            return existing;
+          }
           moveVirtualGamepadToSlot(preferredVirtualSlot);
           Integer updatedSlot = this.deviceToSlot.get(deviceId);
           return updatedSlot != null ? updatedSlot : -1;
@@ -805,6 +842,9 @@ public class WinHandler {
   }
 
   private void releaseSlot(int deviceId) {
+    if (deviceId == OSC_DEVICE_ID) {
+      cancelPendingVirtualGamepadRebalance();
+    }
     Integer slot = this.deviceToSlot.remove(deviceId);
     if (slot != null) {
       // Check if any other deviceId still maps to this slot (same physical controller)
@@ -829,7 +869,7 @@ public class WinHandler {
         }
         if (this.writers[slot] != null) {
           // Remove the discovery node so winebus sees a disconnect; event bytes live in
-          // the slot memfd ring and are not replayed by reopening this path.
+          // the slot ring and are not replayed by reopening this path.
           this.writers[slot].destroy();
           this.writers[slot] = null;
         }
@@ -846,7 +886,9 @@ public class WinHandler {
       }
       this.controllers.remove(deviceId);
       if (deviceId != OSC_DEVICE_ID) {
-        rebalanceVirtualGamepadSlot();
+        if (!slotStillInUse) {
+          scheduleVirtualGamepadRebalance();
+        }
       }
     }
   }
@@ -1002,6 +1044,7 @@ public class WinHandler {
   }
 
   public void closeFakeInputWriter() {
+    cancelPendingVirtualGamepadRebalance();
     if (this.inputManager != null && this.inputDeviceListener != null) {
       this.inputManager.unregisterInputDeviceListener(this.inputDeviceListener);
     }

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -759,6 +759,13 @@ public class WinHandler {
   private int assignSlot(int deviceId) {
     if (deviceId != OSC_DEVICE_ID) {
       cancelPendingVirtualGamepadRebalance();
+      android.view.InputDevice physicalDevice = android.view.InputDevice.getDevice(deviceId);
+      if (!ExternalController.isGameController(physicalDevice)) {
+        Log.d(
+            "WinHandler",
+            "Ignoring stale controller device " + deviceId + ": device is no longer connected.");
+        return -1;
+      }
     }
 
     // Fast path: already assigned

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -828,8 +828,8 @@ public class WinHandler {
           this.fallbackSlot = -1;
         }
         if (this.writers[slot] != null) {
-          // Fake evdev nodes are regular files; preserving them across release keeps old events
-          // readable on the next open and can replay stale input.
+          // Remove the discovery node so winebus sees a disconnect; event bytes live in
+          // the slot memfd ring and are not replayed by reopening this path.
           this.writers[slot].destroy();
           this.writers[slot] = null;
         }
@@ -1011,6 +1011,7 @@ public class WinHandler {
         this.writers[i] = null;
       }
     }
+    FakeInputWriter.releaseAllMemfdSlots();
     this.deviceToSlot.clear();
     this.descriptorToSlot.clear();
     this.deviceToDescriptor.clear();

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -1054,7 +1054,7 @@ public class WinHandler {
         this.writers[i] = null;
       }
     }
-    FakeInputWriter.releaseAllMemfdSlots();
+    FakeInputWriter.releaseAllRingSlots();
     this.deviceToSlot.clear();
     this.descriptorToSlot.clear();
     this.deviceToDescriptor.clear();

--- a/app/src/main/runtime/input/controls/FakeInputWriter.java
+++ b/app/src/main/runtime/input/controls/FakeInputWriter.java
@@ -2,12 +2,12 @@ package com.winlator.cmod.runtime.input.controls;
 
 import android.util.Log;
 import androidx.core.app.NotificationCompat;
+import com.winlator.cmod.runtime.display.connector.XConnectorEpoll;
+import com.winlator.cmod.sharedmemory.SysVSharedMemory;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
 
 public class FakeInputWriter {
   public static final short ABS_BRAKE = 10;
@@ -20,6 +20,18 @@ public class FakeInputWriter {
   public static final short ABS_Y = 1;
   private static final int BUFFER_SIZE = 768;
   private static final int EVENT_SIZE = 24;
+  private static final int MAX_FAKE_INPUT_SLOTS = 4;
+  private static final int RING_CAPACITY_EVENTS = 512;
+  private static final int RING_HEADER_SIZE = 64;
+  private static final int RING_SIZE = RING_HEADER_SIZE + (RING_CAPACITY_EVENTS * EVENT_SIZE);
+  private static final int RING_MAGIC = 0x46494252; // FIBR
+  private static final int RING_VERSION = 1;
+  private static final int RING_MAGIC_OFFSET = 0;
+  private static final int RING_VERSION_OFFSET = 4;
+  private static final int RING_EVENT_SIZE_OFFSET = 8;
+  private static final int RING_CAPACITY_OFFSET = 12;
+  private static final int RING_WRITE_SEQ_OFFSET = 16;
+  private static final int RING_GENERATION_OFFSET = 24;
   public static final short EV_ABS = 3;
   public static final short EV_KEY = 1;
   public static final short EV_MSC = 4;
@@ -28,8 +40,10 @@ public class FakeInputWriter {
   public static final short MSC_SCAN = 4;
   public static final short SYN_REPORT = 0;
   private static final String TAG = "FakeInputWriter";
-  private FileChannel channel;
+  private static final Object RING_LOCK = new Object();
+  private static final RingSlot[] RING_SLOTS = new RingSlot[MAX_FAKE_INPUT_SLOTS];
   private final File eventFile;
+  private final int slot;
   private int prevHatX;
   private int prevHatY;
   private int prevThumbLX;
@@ -38,7 +52,6 @@ public class FakeInputWriter {
   private int prevThumbRY;
   private int prevTriggerL;
   private int prevTriggerR;
-  private RandomAccessFile raf;
   public static final short BTN_A = 304;
   public static final short BTN_B = 305;
   public static final short BTN_X = 307;
@@ -59,8 +72,174 @@ public class FakeInputWriter {
   private final ByteBuffer buffer = ByteBuffer.allocateDirect(BUFFER_SIZE);
 
   public FakeInputWriter(String fakeInputPath, int slot) {
+    this.slot = slot;
     this.eventFile = new File(fakeInputPath, NotificationCompat.CATEGORY_EVENT + slot);
     this.buffer.order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private static final class RingSlot {
+    int fd = -1;
+    ByteBuffer data;
+    long generation;
+    boolean active;
+    boolean everActivated;
+  }
+
+  public static void prepareMemfdSlots(int slotCount) {
+    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
+    synchronized (RING_LOCK) {
+      for (int slot = 0; slot < boundedSlotCount; slot++) {
+        ensureRingSlotLocked(slot);
+      }
+    }
+  }
+
+  public static String getMemfdEnv() {
+    synchronized (RING_LOCK) {
+      prepareMemfdSlotsLocked(MAX_FAKE_INPUT_SLOTS);
+      StringBuilder builder = new StringBuilder();
+      int pid = android.os.Process.myPid();
+      for (int slot = 0; slot < RING_SLOTS.length; slot++) {
+        RingSlot ringSlot = RING_SLOTS[slot];
+        if (ringSlot == null || ringSlot.fd < 0) {
+          continue;
+        }
+        if (builder.length() > 0) {
+          builder.append(';');
+        }
+        builder.append(slot).append("=/proc/").append(pid).append("/fd/").append(ringSlot.fd);
+      }
+      return builder.toString();
+    }
+  }
+
+  public static void releaseAllMemfdSlots() {
+    synchronized (RING_LOCK) {
+      for (int slot = 0; slot < RING_SLOTS.length; slot++) {
+        RingSlot ringSlot = RING_SLOTS[slot];
+        if (ringSlot == null) {
+          continue;
+        }
+        if (ringSlot.data != null) {
+          SysVSharedMemory.unmapSHMSegment(ringSlot.data, RING_SIZE);
+          ringSlot.data = null;
+        }
+        if (ringSlot.fd >= 0) {
+          XConnectorEpoll.closeFd(ringSlot.fd);
+          ringSlot.fd = -1;
+        }
+        RING_SLOTS[slot] = null;
+      }
+    }
+  }
+
+  private static void prepareMemfdSlotsLocked(int slotCount) {
+    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
+    for (int slot = 0; slot < boundedSlotCount; slot++) {
+      ensureRingSlotLocked(slot);
+    }
+  }
+
+  private static RingSlot ensureRingSlotLocked(int slot) {
+    if (slot < 0 || slot >= MAX_FAKE_INPUT_SLOTS) {
+      return null;
+    }
+    RingSlot existing = RING_SLOTS[slot];
+    if (existing != null && existing.fd >= 0 && existing.data != null) {
+      return existing;
+    }
+
+    int fd = SysVSharedMemory.createMemoryFd("fakeinput-" + slot, RING_SIZE);
+    if (fd < 0) {
+      Log.e(TAG, "Failed to create fake input memfd for slot " + slot);
+      return null;
+    }
+
+    ByteBuffer data = SysVSharedMemory.mapSHMSegment(fd, RING_SIZE, 0, false);
+    if (data == null) {
+      XConnectorEpoll.closeFd(fd);
+      Log.e(TAG, "Failed to map fake input memfd for slot " + slot);
+      return null;
+    }
+
+    data.order(ByteOrder.LITTLE_ENDIAN);
+    data.putInt(RING_MAGIC_OFFSET, RING_MAGIC);
+    data.putInt(RING_VERSION_OFFSET, RING_VERSION);
+    data.putInt(RING_EVENT_SIZE_OFFSET, EVENT_SIZE);
+    data.putInt(RING_CAPACITY_OFFSET, RING_CAPACITY_EVENTS);
+    data.putLong(RING_WRITE_SEQ_OFFSET, 0L);
+    data.putLong(RING_GENERATION_OFFSET, 0L);
+
+    RingSlot ringSlot = new RingSlot();
+    ringSlot.fd = fd;
+    ringSlot.data = data;
+    RING_SLOTS[slot] = ringSlot;
+    Log.i(TAG, "Created fake input memfd ring for slot " + slot + ": fd=" + fd);
+    return ringSlot;
+  }
+
+  private RingSlot ensureRingSlot() {
+    synchronized (RING_LOCK) {
+      return ensureRingSlotLocked(this.slot);
+    }
+  }
+
+  private boolean activateRingSlot() {
+    RingSlot ringSlot = ensureRingSlot();
+    if (ringSlot == null || ringSlot.data == null) {
+      return false;
+    }
+    synchronized (ringSlot) {
+      if (!ringSlot.active) {
+        if (ringSlot.everActivated) {
+          ringSlot.generation++;
+        } else {
+          ringSlot.everActivated = true;
+        }
+        ringSlot.data.putLong(RING_WRITE_SEQ_OFFSET, 0L);
+        ringSlot.data.putLong(RING_GENERATION_OFFSET, ringSlot.generation);
+        ringSlot.active = true;
+      }
+    }
+    return true;
+  }
+
+  private void deactivateRingSlot() {
+    RingSlot ringSlot;
+    synchronized (RING_LOCK) {
+      ringSlot =
+          this.slot >= 0 && this.slot < RING_SLOTS.length ? RING_SLOTS[this.slot] : null;
+    }
+    if (ringSlot == null) {
+      return;
+    }
+    synchronized (ringSlot) {
+      ringSlot.active = false;
+    }
+  }
+
+  private boolean flushBufferToRing() {
+    RingSlot ringSlot = ensureRingSlot();
+    if (ringSlot == null || ringSlot.data == null) {
+      return false;
+    }
+
+    ByteBuffer source = this.buffer.duplicate();
+    source.order(ByteOrder.LITTLE_ENDIAN);
+    synchronized (ringSlot) {
+      ByteBuffer ring = ringSlot.data;
+      long writeSeq = ring.getLong(RING_WRITE_SEQ_OFFSET);
+      while (source.remaining() >= EVENT_SIZE) {
+        int eventIndex = (int) (writeSeq % RING_CAPACITY_EVENTS);
+        int targetOffset = RING_HEADER_SIZE + (eventIndex * EVENT_SIZE);
+        for (int i = 0; i < EVENT_SIZE; i++) {
+          ring.put(targetOffset + i, source.get());
+        }
+        writeSeq++;
+      }
+      ring.putLong(RING_WRITE_SEQ_OFFSET, writeSeq);
+    }
+    return true;
   }
 
   public synchronized boolean open() {
@@ -75,11 +254,11 @@ public class FakeInputWriter {
       if (!this.eventFile.exists()) {
         this.eventFile.createNewFile();
       }
-      this.raf = new RandomAccessFile(this.eventFile, "rw");
-      this.raf.seek(this.raf.length());
-      this.channel = this.raf.getChannel();
+      if (!activateRingSlot()) {
+        return false;
+      }
       this.isOpen = true;
-      Log.i(TAG, "Opened fake input: " + this.eventFile.getAbsolutePath());
+      Log.i(TAG, "Opened fake input ring: " + this.eventFile.getAbsolutePath());
       return true;
     } catch (IOException e) {
       Log.e(TAG, "Failed to open: " + e.getMessage());
@@ -88,20 +267,6 @@ public class FakeInputWriter {
   }
 
   public synchronized void close() {
-    if (this.channel != null) {
-      try {
-        this.channel.close();
-      } catch (IOException e) {
-      }
-      this.channel = null;
-    }
-    if (this.raf != null) {
-      try {
-        this.raf.close();
-      } catch (IOException e2) {
-      }
-      this.raf = null;
-    }
     this.isOpen = false;
   }
 
@@ -151,11 +316,7 @@ public class FakeInputWriter {
       if (this.hasChanges) {
         writeEvent((short) 0, (short) 0, 0);
         this.buffer.flip();
-        try {
-          this.channel.write(this.buffer);
-        } catch (IOException e) {
-          Log.e(TAG, "Reset write error: " + e.getMessage());
-        }
+        if (!flushBufferToRing()) Log.e(TAG, "Reset write error: memfd ring unavailable");
         Log.i(TAG, "Reset fake input to neutral state: " + this.eventFile.getAbsolutePath());
         return;
       }
@@ -173,9 +334,16 @@ public class FakeInputWriter {
     this.destroyed = true;
     reset();
     close();
+    deactivateRingSlot();
     if (this.eventFile != null && this.eventFile.exists()) {
       boolean deleted = this.eventFile.delete();
-      Log.i(TAG, "Deleted fake input: " + this.eventFile.getAbsolutePath() + " (" + deleted + ")");
+      Log.i(
+          TAG,
+          "Deleted fake input discovery node: "
+              + this.eventFile.getAbsolutePath()
+              + " ("
+              + deleted
+              + ")");
     }
   }
 
@@ -271,7 +439,7 @@ public class FakeInputWriter {
     if (this.hasChanges) {
       writeEvent((short) 0, (short) 0, 0);
       this.buffer.flip();
-      this.channel.write(this.buffer);
+      if (!flushBufferToRing()) Log.e(TAG, "Gamepad write error: memfd ring unavailable");
     }
   }
 }

--- a/app/src/main/runtime/input/controls/FakeInputWriter.java
+++ b/app/src/main/runtime/input/controls/FakeInputWriter.java
@@ -2,8 +2,6 @@ package com.winlator.cmod.runtime.input.controls;
 
 import android.util.Log;
 import androidx.core.app.NotificationCompat;
-import com.winlator.cmod.runtime.display.connector.XConnectorEpoll;
-import com.winlator.cmod.sharedmemory.SysVSharedMemory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -47,7 +45,6 @@ public class FakeInputWriter {
   private static final RingSlot[] RING_SLOTS = new RingSlot[MAX_FAKE_INPUT_SLOTS];
   private final File eventFile;
   private final int slot;
-  private FileChannel queueChannel;
   private int prevHatX;
   private int prevHatY;
   private int prevThumbLX;
@@ -56,7 +53,6 @@ public class FakeInputWriter {
   private int prevThumbRY;
   private int prevTriggerL;
   private int prevTriggerR;
-  private RandomAccessFile queueRaf;
   public static final short BTN_A = 304;
   public static final short BTN_B = 305;
   public static final short BTN_X = 307;
@@ -72,7 +68,6 @@ public class FakeInputWriter {
   };
   private boolean isOpen = false;
   private volatile boolean destroyed = false;
-  private boolean fileQueueFallback = false;
   private final boolean[] prevButtonStates = new boolean[12];
   private boolean hasChanges = false;
   private final ByteBuffer buffer = ByteBuffer.allocateDirect(BUFFER_SIZE);
@@ -84,7 +79,6 @@ public class FakeInputWriter {
   }
 
   private static final class RingSlot {
-    int fd = -1;
     ByteBuffer data;
     File ringFile;
     FileChannel ringChannel;
@@ -93,23 +87,6 @@ public class FakeInputWriter {
     long generation;
     boolean active;
     boolean everActivated;
-    boolean nativeMapped;
-  }
-
-  public static void prepareMemfdSlots(int slotCount) {
-    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
-    synchronized (RING_LOCK) {
-      for (int slot = 0; slot < boundedSlotCount; slot++) {
-        ensureRingSlotLocked(slot, null);
-      }
-    }
-  }
-
-  public static String getMemfdEnv() {
-    synchronized (RING_LOCK) {
-      prepareRingSlotsLocked(null, MAX_FAKE_INPUT_SLOTS);
-      return buildRingEnvLocked();
-    }
   }
 
   public static void prepareRingSlots(File fakeInputDir, int slotCount) {
@@ -128,7 +105,7 @@ public class FakeInputWriter {
     }
   }
 
-  public static void releaseAllMemfdSlots() {
+  public static void releaseAllRingSlots() {
     synchronized (RING_LOCK) {
       for (int slot = 0; slot < RING_SLOTS.length; slot++) {
         releaseRingSlotLocked(slot);
@@ -188,14 +165,7 @@ public class FakeInputWriter {
     if (ringSlot == null) {
       return;
     }
-    if (ringSlot.data != null && ringSlot.nativeMapped) {
-      SysVSharedMemory.unmapSHMSegment(ringSlot.data, RING_SIZE);
-    }
     ringSlot.data = null;
-    if (ringSlot.fd >= 0) {
-      XConnectorEpoll.closeFd(ringSlot.fd);
-      ringSlot.fd = -1;
-    }
     if (ringSlot.ringChannel != null) {
       try {
         ringSlot.ringChannel.close();
@@ -224,40 +194,27 @@ public class FakeInputWriter {
   }
 
   private static RingSlot ensureRingSlotLocked(int slot, File fakeInputDir) {
-    if (slot < 0 || slot >= MAX_FAKE_INPUT_SLOTS) {
+    if (slot < 0 || slot >= MAX_FAKE_INPUT_SLOTS || fakeInputDir == null) {
       return null;
     }
 
     File desiredRingFile = getRingFile(fakeInputDir, slot);
-    if (desiredRingFile != null) {
-      desiredRingFile = desiredRingFile.getAbsoluteFile();
+    if (desiredRingFile == null) {
+      return null;
     }
+    desiredRingFile = desiredRingFile.getAbsoluteFile();
     RingSlot existing = RING_SLOTS[slot];
     if (existing != null && existing.data != null) {
-      if (desiredRingFile == null
-          || (existing.ringFile != null && existing.ringFile.equals(desiredRingFile))) {
+      if (existing.ringFile != null && existing.ringFile.equals(desiredRingFile)) {
         return existing;
       }
       releaseRingSlotLocked(slot);
     }
 
-    if (desiredRingFile != null) {
-      RingSlot fileRingSlot = createFileRingSlotLocked(slot, desiredRingFile);
-      if (fileRingSlot != null) {
-        RING_SLOTS[slot] = fileRingSlot;
-        return fileRingSlot;
-      }
-    }
-
-    RingSlot existingAfterFileAttempt = RING_SLOTS[slot];
-    if (existingAfterFileAttempt != null && existingAfterFileAttempt.data != null) {
-      return existingAfterFileAttempt;
-    }
-
-    RingSlot memfdRingSlot = createMemfdRingSlotLocked(slot);
-    if (memfdRingSlot != null) {
-      RING_SLOTS[slot] = memfdRingSlot;
-      return memfdRingSlot;
+    RingSlot fileRingSlot = createFileRingSlotLocked(slot, desiredRingFile);
+    if (fileRingSlot != null) {
+      RING_SLOTS[slot] = fileRingSlot;
+      return fileRingSlot;
     }
     return null;
   }
@@ -304,36 +261,6 @@ public class FakeInputWriter {
     }
   }
 
-  private static RingSlot createMemfdRingSlotLocked(int slot) {
-    RingSlot existing = RING_SLOTS[slot];
-    if (existing != null && existing.data != null) {
-      return existing;
-    }
-
-    int fd = SysVSharedMemory.createMemoryFd("fakeinput-" + slot, RING_SIZE);
-    if (fd < 0) {
-      Log.e(TAG, "Failed to create fake input memfd for slot " + slot);
-      return null;
-    }
-
-    ByteBuffer data = SysVSharedMemory.mapSHMSegment(fd, RING_SIZE, 0, false);
-    if (data == null) {
-      XConnectorEpoll.closeFd(fd);
-      Log.e(TAG, "Failed to map fake input memfd for slot " + slot);
-      return null;
-    }
-
-    initializeRingHeader(data);
-
-    RingSlot ringSlot = new RingSlot();
-    ringSlot.fd = fd;
-    ringSlot.data = data;
-    ringSlot.nativeMapped = true;
-    ringSlot.exportPath = "/proc/" + android.os.Process.myPid() + "/fd/" + fd;
-    Log.i(TAG, "Created fake input memfd ring for slot " + slot + ": fd=" + fd);
-    return ringSlot;
-  }
-
   private RingSlot ensureRingSlot() {
     synchronized (RING_LOCK) {
       return ensureRingSlotLocked(this.slot, this.eventFile.getParentFile());
@@ -357,15 +284,6 @@ public class FakeInputWriter {
         ringSlot.active = true;
       }
     }
-    return true;
-  }
-
-  private boolean openFileQueueFallback() throws IOException {
-    this.queueRaf = new RandomAccessFile(this.eventFile, "rw");
-    this.queueRaf.seek(this.queueRaf.length());
-    this.queueChannel = this.queueRaf.getChannel();
-    this.fileQueueFallback = true;
-    Log.w(TAG, "Falling back to fake input file queue: " + this.eventFile.getAbsolutePath());
     return true;
   }
 
@@ -418,17 +336,8 @@ public class FakeInputWriter {
     return true;
   }
 
-  private boolean flushBuffer() throws IOException {
-    if (!this.fileQueueFallback && flushBufferToRing()) {
-      return true;
-    }
-    if (this.queueChannel == null) {
-      return false;
-    }
-    while (this.buffer.hasRemaining()) {
-      this.queueChannel.write(this.buffer);
-    }
-    return true;
+  private boolean flushBuffer() {
+    return flushBufferToRing();
   }
 
   public synchronized boolean open() {
@@ -444,9 +353,11 @@ public class FakeInputWriter {
         this.eventFile.createNewFile();
       }
       if (!activateRingSlot()) {
-        openFileQueueFallback();
-      } else {
-        this.fileQueueFallback = false;
+        if (this.eventFile.exists()) {
+          this.eventFile.delete();
+        }
+        Log.e(TAG, "Failed to open fake input mmap ring: " + this.eventFile.getAbsolutePath());
+        return false;
       }
       this.isOpen = true;
       Log.i(TAG, "Opened fake input: " + this.eventFile.getAbsolutePath());
@@ -458,21 +369,6 @@ public class FakeInputWriter {
   }
 
   public synchronized void close() {
-    if (this.queueChannel != null) {
-      try {
-        this.queueChannel.close();
-      } catch (IOException ignored) {
-      }
-      this.queueChannel = null;
-    }
-    if (this.queueRaf != null) {
-      try {
-        this.queueRaf.close();
-      } catch (IOException ignored) {
-      }
-      this.queueRaf = null;
-    }
-    this.fileQueueFallback = false;
     this.isOpen = false;
   }
 
@@ -522,11 +418,7 @@ public class FakeInputWriter {
       if (this.hasChanges) {
         writeEvent((short) 0, (short) 0, 0);
         this.buffer.flip();
-        try {
-          if (!flushBuffer()) Log.e(TAG, "Reset write error: fake input queue unavailable");
-        } catch (IOException e) {
-          Log.e(TAG, "Reset write error: " + e.getMessage());
-        }
+        if (!flushBuffer()) Log.e(TAG, "Reset write error: fake input mmap ring unavailable");
         Log.i(TAG, "Reset fake input to neutral state: " + this.eventFile.getAbsolutePath());
         return;
       }
@@ -601,7 +493,7 @@ public class FakeInputWriter {
     int tl = (int) (state.triggerL * 255.0f);
     int tr = (int) (state.triggerR * 255.0f);
 
-    // The fake evdev file is effectively a queue, so unchanged axes must stay silent.
+    // The fake evdev ring is event-queue semantics, so unchanged axes must stay silent.
     if (lx != this.prevThumbLX) {
       this.prevThumbLX = lx;
       writeEvent((short) 3, (short) 0, lx);
@@ -649,7 +541,7 @@ public class FakeInputWriter {
     if (this.hasChanges) {
       writeEvent((short) 0, (short) 0, 0);
       this.buffer.flip();
-      if (!flushBuffer()) Log.e(TAG, "Gamepad write error: fake input queue unavailable");
+      if (!flushBuffer()) Log.e(TAG, "Gamepad write error: fake input mmap ring unavailable");
     }
   }
 }

--- a/app/src/main/runtime/input/controls/FakeInputWriter.java
+++ b/app/src/main/runtime/input/controls/FakeInputWriter.java
@@ -6,8 +6,10 @@ import com.winlator.cmod.runtime.display.connector.XConnectorEpoll;
 import com.winlator.cmod.sharedmemory.SysVSharedMemory;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 
 public class FakeInputWriter {
   public static final short ABS_BRAKE = 10;
@@ -32,6 +34,7 @@ public class FakeInputWriter {
   private static final int RING_CAPACITY_OFFSET = 12;
   private static final int RING_WRITE_SEQ_OFFSET = 16;
   private static final int RING_GENERATION_OFFSET = 24;
+  private static final String RING_DIR_NAME = "fakeinput-rings";
   public static final short EV_ABS = 3;
   public static final short EV_KEY = 1;
   public static final short EV_MSC = 4;
@@ -44,6 +47,7 @@ public class FakeInputWriter {
   private static final RingSlot[] RING_SLOTS = new RingSlot[MAX_FAKE_INPUT_SLOTS];
   private final File eventFile;
   private final int slot;
+  private FileChannel queueChannel;
   private int prevHatX;
   private int prevHatY;
   private int prevThumbLX;
@@ -52,6 +56,7 @@ public class FakeInputWriter {
   private int prevThumbRY;
   private int prevTriggerL;
   private int prevTriggerR;
+  private RandomAccessFile queueRaf;
   public static final short BTN_A = 304;
   public static final short BTN_B = 305;
   public static final short BTN_X = 307;
@@ -67,6 +72,7 @@ public class FakeInputWriter {
   };
   private boolean isOpen = false;
   private volatile boolean destroyed = false;
+  private boolean fileQueueFallback = false;
   private final boolean[] prevButtonStates = new boolean[12];
   private boolean hasChanges = false;
   private final ByteBuffer buffer = ByteBuffer.allocateDirect(BUFFER_SIZE);
@@ -80,72 +86,227 @@ public class FakeInputWriter {
   private static final class RingSlot {
     int fd = -1;
     ByteBuffer data;
+    File ringFile;
+    FileChannel ringChannel;
+    RandomAccessFile ringRaf;
+    String exportPath;
     long generation;
     boolean active;
     boolean everActivated;
+    boolean nativeMapped;
   }
 
   public static void prepareMemfdSlots(int slotCount) {
     int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
     synchronized (RING_LOCK) {
       for (int slot = 0; slot < boundedSlotCount; slot++) {
-        ensureRingSlotLocked(slot);
+        ensureRingSlotLocked(slot, null);
       }
     }
   }
 
   public static String getMemfdEnv() {
     synchronized (RING_LOCK) {
-      prepareMemfdSlotsLocked(MAX_FAKE_INPUT_SLOTS);
-      StringBuilder builder = new StringBuilder();
-      int pid = android.os.Process.myPid();
-      for (int slot = 0; slot < RING_SLOTS.length; slot++) {
-        RingSlot ringSlot = RING_SLOTS[slot];
-        if (ringSlot == null || ringSlot.fd < 0) {
-          continue;
-        }
-        if (builder.length() > 0) {
-          builder.append(';');
-        }
-        builder.append(slot).append("=/proc/").append(pid).append("/fd/").append(ringSlot.fd);
+      prepareRingSlotsLocked(null, MAX_FAKE_INPUT_SLOTS);
+      return buildRingEnvLocked();
+    }
+  }
+
+  public static void prepareRingSlots(File fakeInputDir, int slotCount) {
+    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
+    synchronized (RING_LOCK) {
+      for (int slot = 0; slot < boundedSlotCount; slot++) {
+        ensureRingSlotLocked(slot, fakeInputDir);
       }
-      return builder.toString();
+    }
+  }
+
+  public static String getRingEnv(File fakeInputDir) {
+    synchronized (RING_LOCK) {
+      prepareRingSlotsLocked(fakeInputDir, MAX_FAKE_INPUT_SLOTS);
+      return buildRingEnvLocked();
     }
   }
 
   public static void releaseAllMemfdSlots() {
     synchronized (RING_LOCK) {
       for (int slot = 0; slot < RING_SLOTS.length; slot++) {
-        RingSlot ringSlot = RING_SLOTS[slot];
-        if (ringSlot == null) {
-          continue;
-        }
-        if (ringSlot.data != null) {
-          SysVSharedMemory.unmapSHMSegment(ringSlot.data, RING_SIZE);
-          ringSlot.data = null;
-        }
-        if (ringSlot.fd >= 0) {
-          XConnectorEpoll.closeFd(ringSlot.fd);
-          ringSlot.fd = -1;
-        }
-        RING_SLOTS[slot] = null;
+        releaseRingSlotLocked(slot);
       }
     }
   }
 
-  private static void prepareMemfdSlotsLocked(int slotCount) {
-    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
-    for (int slot = 0; slot < boundedSlotCount; slot++) {
-      ensureRingSlotLocked(slot);
+  private static String buildRingEnvLocked() {
+    StringBuilder builder = new StringBuilder();
+    for (int slot = 0; slot < RING_SLOTS.length; slot++) {
+      RingSlot ringSlot = RING_SLOTS[slot];
+      if (ringSlot == null || ringSlot.data == null || ringSlot.exportPath == null) {
+        continue;
+      }
+      if (builder.length() > 0) {
+        builder.append(';');
+      }
+      builder.append(slot).append('=').append(ringSlot.exportPath);
+    }
+    return builder.toString();
+  }
+
+  private static File getRingDir(File fakeInputDir) {
+    if (fakeInputDir == null) {
+      return null;
+    }
+    File inputDir = fakeInputDir.getAbsoluteFile();
+    File parent = inputDir.getParentFile();
+    return new File(parent != null ? parent : inputDir, RING_DIR_NAME);
+  }
+
+  private static File getRingFile(File fakeInputDir, int slot) {
+    File ringDir = getRingDir(fakeInputDir);
+    return ringDir != null ? new File(ringDir, "ring" + slot) : null;
+  }
+
+  private static String getCanonicalOrAbsolutePath(File file) {
+    try {
+      return file.getCanonicalPath();
+    } catch (IOException e) {
+      return file.getAbsolutePath();
     }
   }
 
-  private static RingSlot ensureRingSlotLocked(int slot) {
+  private static void initializeRingHeader(ByteBuffer data) {
+    data.order(ByteOrder.LITTLE_ENDIAN);
+    data.putInt(RING_MAGIC_OFFSET, RING_MAGIC);
+    data.putInt(RING_VERSION_OFFSET, RING_VERSION);
+    data.putInt(RING_EVENT_SIZE_OFFSET, EVENT_SIZE);
+    data.putInt(RING_CAPACITY_OFFSET, RING_CAPACITY_EVENTS);
+    data.putLong(RING_WRITE_SEQ_OFFSET, 0L);
+    data.putLong(RING_GENERATION_OFFSET, 0L);
+  }
+
+  private static void releaseRingSlotLocked(int slot) {
+    RingSlot ringSlot = RING_SLOTS[slot];
+    if (ringSlot == null) {
+      return;
+    }
+    if (ringSlot.data != null && ringSlot.nativeMapped) {
+      SysVSharedMemory.unmapSHMSegment(ringSlot.data, RING_SIZE);
+    }
+    ringSlot.data = null;
+    if (ringSlot.fd >= 0) {
+      XConnectorEpoll.closeFd(ringSlot.fd);
+      ringSlot.fd = -1;
+    }
+    if (ringSlot.ringChannel != null) {
+      try {
+        ringSlot.ringChannel.close();
+      } catch (IOException ignored) {
+      }
+      ringSlot.ringChannel = null;
+    }
+    if (ringSlot.ringRaf != null) {
+      try {
+        ringSlot.ringRaf.close();
+      } catch (IOException ignored) {
+      }
+      ringSlot.ringRaf = null;
+    }
+    if (ringSlot.ringFile != null && ringSlot.ringFile.exists()) {
+      ringSlot.ringFile.delete();
+    }
+    RING_SLOTS[slot] = null;
+  }
+
+  private static void prepareRingSlotsLocked(File fakeInputDir, int slotCount) {
+    int boundedSlotCount = Math.max(0, Math.min(slotCount, MAX_FAKE_INPUT_SLOTS));
+    for (int slot = 0; slot < boundedSlotCount; slot++) {
+      ensureRingSlotLocked(slot, fakeInputDir);
+    }
+  }
+
+  private static RingSlot ensureRingSlotLocked(int slot, File fakeInputDir) {
     if (slot < 0 || slot >= MAX_FAKE_INPUT_SLOTS) {
       return null;
     }
+
+    File desiredRingFile = getRingFile(fakeInputDir, slot);
+    if (desiredRingFile != null) {
+      desiredRingFile = desiredRingFile.getAbsoluteFile();
+    }
     RingSlot existing = RING_SLOTS[slot];
-    if (existing != null && existing.fd >= 0 && existing.data != null) {
+    if (existing != null && existing.data != null) {
+      if (desiredRingFile == null
+          || (existing.ringFile != null && existing.ringFile.equals(desiredRingFile))) {
+        return existing;
+      }
+      releaseRingSlotLocked(slot);
+    }
+
+    if (desiredRingFile != null) {
+      RingSlot fileRingSlot = createFileRingSlotLocked(slot, desiredRingFile);
+      if (fileRingSlot != null) {
+        RING_SLOTS[slot] = fileRingSlot;
+        return fileRingSlot;
+      }
+    }
+
+    RingSlot existingAfterFileAttempt = RING_SLOTS[slot];
+    if (existingAfterFileAttempt != null && existingAfterFileAttempt.data != null) {
+      return existingAfterFileAttempt;
+    }
+
+    RingSlot memfdRingSlot = createMemfdRingSlotLocked(slot);
+    if (memfdRingSlot != null) {
+      RING_SLOTS[slot] = memfdRingSlot;
+      return memfdRingSlot;
+    }
+    return null;
+  }
+
+  private static RingSlot createFileRingSlotLocked(int slot, File ringFile) {
+    File ringDir = ringFile.getParentFile();
+    if (ringDir == null || (!ringDir.exists() && !ringDir.mkdirs())) {
+      Log.e(TAG, "Failed to create fake input ring directory for slot " + slot);
+      return null;
+    }
+
+    RandomAccessFile raf = null;
+    FileChannel channel = null;
+    try {
+      raf = new RandomAccessFile(ringFile, "rw");
+      raf.setLength(RING_SIZE);
+      channel = raf.getChannel();
+      ByteBuffer data = channel.map(FileChannel.MapMode.READ_WRITE, 0, RING_SIZE);
+      initializeRingHeader(data);
+
+      RingSlot ringSlot = new RingSlot();
+      ringSlot.data = data;
+      ringSlot.ringFile = ringFile.getAbsoluteFile();
+      ringSlot.ringRaf = raf;
+      ringSlot.ringChannel = channel;
+      ringSlot.exportPath = getCanonicalOrAbsolutePath(ringFile);
+      Log.i(TAG, "Created fake input file ring for slot " + slot + ": " + ringSlot.exportPath);
+      return ringSlot;
+    } catch (IOException e) {
+      Log.e(TAG, "Failed to create fake input file ring for slot " + slot + ": " + e.getMessage());
+      if (channel != null) {
+        try {
+          channel.close();
+        } catch (IOException ignored) {
+        }
+      }
+      if (raf != null) {
+        try {
+          raf.close();
+        } catch (IOException ignored) {
+        }
+      }
+      return null;
+    }
+  }
+
+  private static RingSlot createMemfdRingSlotLocked(int slot) {
+    RingSlot existing = RING_SLOTS[slot];
+    if (existing != null && existing.data != null) {
       return existing;
     }
 
@@ -162,25 +323,20 @@ public class FakeInputWriter {
       return null;
     }
 
-    data.order(ByteOrder.LITTLE_ENDIAN);
-    data.putInt(RING_MAGIC_OFFSET, RING_MAGIC);
-    data.putInt(RING_VERSION_OFFSET, RING_VERSION);
-    data.putInt(RING_EVENT_SIZE_OFFSET, EVENT_SIZE);
-    data.putInt(RING_CAPACITY_OFFSET, RING_CAPACITY_EVENTS);
-    data.putLong(RING_WRITE_SEQ_OFFSET, 0L);
-    data.putLong(RING_GENERATION_OFFSET, 0L);
+    initializeRingHeader(data);
 
     RingSlot ringSlot = new RingSlot();
     ringSlot.fd = fd;
     ringSlot.data = data;
-    RING_SLOTS[slot] = ringSlot;
+    ringSlot.nativeMapped = true;
+    ringSlot.exportPath = "/proc/" + android.os.Process.myPid() + "/fd/" + fd;
     Log.i(TAG, "Created fake input memfd ring for slot " + slot + ": fd=" + fd);
     return ringSlot;
   }
 
   private RingSlot ensureRingSlot() {
     synchronized (RING_LOCK) {
-      return ensureRingSlotLocked(this.slot);
+      return ensureRingSlotLocked(this.slot, this.eventFile.getParentFile());
     }
   }
 
@@ -204,6 +360,15 @@ public class FakeInputWriter {
     return true;
   }
 
+  private boolean openFileQueueFallback() throws IOException {
+    this.queueRaf = new RandomAccessFile(this.eventFile, "rw");
+    this.queueRaf.seek(this.queueRaf.length());
+    this.queueChannel = this.queueRaf.getChannel();
+    this.fileQueueFallback = true;
+    Log.w(TAG, "Falling back to fake input file queue: " + this.eventFile.getAbsolutePath());
+    return true;
+  }
+
   private void deactivateRingSlot() {
     RingSlot ringSlot;
     synchronized (RING_LOCK) {
@@ -214,6 +379,17 @@ public class FakeInputWriter {
       return;
     }
     synchronized (ringSlot) {
+      if (ringSlot.active && ringSlot.data != null) {
+        ringSlot.generation++;
+        ringSlot.data.putLong(RING_WRITE_SEQ_OFFSET, 0L);
+        ringSlot.data.putLong(RING_GENERATION_OFFSET, ringSlot.generation);
+        Log.i(
+            TAG,
+            "Deactivated fake input ring for slot "
+                + this.slot
+                + " generation="
+                + ringSlot.generation);
+      }
       ringSlot.active = false;
     }
   }
@@ -242,6 +418,19 @@ public class FakeInputWriter {
     return true;
   }
 
+  private boolean flushBuffer() throws IOException {
+    if (!this.fileQueueFallback && flushBufferToRing()) {
+      return true;
+    }
+    if (this.queueChannel == null) {
+      return false;
+    }
+    while (this.buffer.hasRemaining()) {
+      this.queueChannel.write(this.buffer);
+    }
+    return true;
+  }
+
   public synchronized boolean open() {
     if (this.destroyed) {
       return false;
@@ -255,10 +444,12 @@ public class FakeInputWriter {
         this.eventFile.createNewFile();
       }
       if (!activateRingSlot()) {
-        return false;
+        openFileQueueFallback();
+      } else {
+        this.fileQueueFallback = false;
       }
       this.isOpen = true;
-      Log.i(TAG, "Opened fake input ring: " + this.eventFile.getAbsolutePath());
+      Log.i(TAG, "Opened fake input: " + this.eventFile.getAbsolutePath());
       return true;
     } catch (IOException e) {
       Log.e(TAG, "Failed to open: " + e.getMessage());
@@ -267,6 +458,21 @@ public class FakeInputWriter {
   }
 
   public synchronized void close() {
+    if (this.queueChannel != null) {
+      try {
+        this.queueChannel.close();
+      } catch (IOException ignored) {
+      }
+      this.queueChannel = null;
+    }
+    if (this.queueRaf != null) {
+      try {
+        this.queueRaf.close();
+      } catch (IOException ignored) {
+      }
+      this.queueRaf = null;
+    }
+    this.fileQueueFallback = false;
     this.isOpen = false;
   }
 
@@ -316,7 +522,11 @@ public class FakeInputWriter {
       if (this.hasChanges) {
         writeEvent((short) 0, (short) 0, 0);
         this.buffer.flip();
-        if (!flushBufferToRing()) Log.e(TAG, "Reset write error: memfd ring unavailable");
+        try {
+          if (!flushBuffer()) Log.e(TAG, "Reset write error: fake input queue unavailable");
+        } catch (IOException e) {
+          Log.e(TAG, "Reset write error: " + e.getMessage());
+        }
         Log.i(TAG, "Reset fake input to neutral state: " + this.eventFile.getAbsolutePath());
         return;
       }
@@ -439,7 +649,7 @@ public class FakeInputWriter {
     if (this.hasChanges) {
       writeEvent((short) 0, (short) 0, 0);
       this.buffer.flip();
-      if (!flushBufferToRing()) Log.e(TAG, "Gamepad write error: memfd ring unavailable");
+      if (!flushBuffer()) Log.e(TAG, "Gamepad write error: fake input queue unavailable");
     }
   }
 }


### PR DESCRIPTION
This replaces append-only fake evdev files with per-slot mmap ring buffers while keeping `/dev/input/eventN` files only as Wine/winebus discovery nodes.

Java now creates a fixed-size private ring file per controller slot under the app runtime input area (`fakeinput-rings/ringN` next to `dev/input`). Each ring has the same 64-byte ABI header plus 512 `struct input_event` records, and the legacy `FAKE_EVDEV_MEMFD_PATHS` env key now carries those ring file paths. This avoids Samsung/OEM restrictions on opening another process's `/proc/<pid>/fd/<memfd>` path while keeping the low-latency shared-memory read path.

There are no transport fallbacks now. The memfd fallback and the old append-style fake evdev file queue were removed, and the native hook no longer registers a no-ring file-backed controller. If the mmap ring cannot be created or opened, the fake controller fails closed and the discovery node is not kept around as a silent downgrade path.

The native preload hook mmaps the exported ring path, validates magic/version/event size/capacity, and keeps a per-fd `read_seq` so guest readers do not share file offsets. It only opens a ring when the matching discovery node exists, and `stat("/dev/input/eventN")` no longer fabricates success just because a ring path exists. That lets Wine observe real disconnects when Java deletes a fake event node.

Hotplug handling was tightened for rapid controller switching. Deactivating a slot now advances the ring generation immediately, causing stale Wine fds to report `ENODEV`/`POLLHUP` instead of reading from the next logical controller. `WinHandler` also debounces the virtual gamepad's move back to slot 0 after a physical disconnect; if another physical controller appears during that short window, it takes slot 0 directly, avoiding the extra virtual `event0` bounce that could prevent mid-game re-registration.

Validation:

- `./gradlew.bat :app:compileStandardDebugJavaWithJavac`
- `./gradlew.bat :app:externalNativeBuildStandardDebug`
- `git diff --check`
- Logcat controller-switch check: Xbox disconnect deleted/deactivated `event0`, then Odin was assigned directly to slot 0 with no virtual slot 1 -> slot 0 bounce between the physical devices.