### PR TITLE
fix: allow selecting .xz/.txz/.tzst archives in component file picker

### DIFF
--- a/app/src/main/feature/settings/contents/ContentsFragment.kt
+++ b/app/src/main/feature/settings/contents/ContentsFragment.kt
@@ -306,7 +306,7 @@ class ContentsFragment : Fragment() {
         DirectoryPickerDialog.showFile(
             activity = activity,
             title = getString(R.string.settings_content_install),
-            allowedExtensions = setOf("wcp"),
+            allowedExtensions = setOf("wcp", "xz", "txz", "tzst"),
         ) { path ->
             updateDownloadProgress(
                 title = getString(R.string.settings_content_installing_title),


### PR DESCRIPTION
Fixes the component manager file picker to accept .xz .txz and tzst. Per the component manager compatability. 