### PR TITLE
fix: external HID input + multiplayer networking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/app/src/main/assets/imagefs.txz
+++ b/app/src/main/assets/imagefs.txz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f96d362b7e148e86ab0d2c290978bf39b38e5c7ffc8ae4adf1d2a65c62bbb780
-size 183231056
+oid sha256:7a55cebd8870b1913b8c18944a6e4d2d8bce691c3c4a1beb7fe1c2ff29589134
+size 177328652

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -278,6 +278,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private int taskAffinityMaskWoW64 = 0;
     private int frameRatingWindowId = -1;
     private boolean cursorLock; // Flag to track if pointer capture was requested
+    private android.net.wifi.WifiManager.MulticastLock multicastLock;
     private final float[] xform = XForm.getInstance();
     private ContentsManager contentsManager;
     private boolean navigationFocused = false;
@@ -562,7 +563,19 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         preloaderDialog = new PreloaderDialog(this);
 
-        cursorLock = preferences.getBoolean("cursor_lock", false);
+        cursorLock = preferences.getBoolean("cursor_lock", true);
+
+        try {
+            android.net.wifi.WifiManager wifiManager = (android.net.wifi.WifiManager)
+                    getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager != null) {
+                multicastLock = wifiManager.createMulticastLock("winnative-xserver");
+                multicastLock.setReferenceCounted(false);
+                multicastLock.acquire();
+            }
+        } catch (Exception e) {
+            Log.w("XServerDisplayActivity", "Failed to acquire MulticastLock", e);
+        }
         dualSeriesBattery = preferences.getBoolean(FrameRating.PREF_HUD_DUAL_SERIES_BATTERY, false);
 
         // Check for Dark Mode
@@ -2745,6 +2758,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         activityDestroyed.set(true);
         if (preloaderDialog != null) {
             preloaderDialog.close();
+        }
+        if (multicastLock != null && multicastLock.isHeld()) {
+            try {
+                multicastLock.release();
+            } catch (Exception ignored) {}
         }
         super.onDestroy();
         // Schedule a deferred update check 10 s after game exit
@@ -4942,15 +4960,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             }
         }
 
-        boolean handled = inputControlsView.onKeyEvent(event);
-        if (winHandler != null) {
-            handled |= winHandler.onKeyEvent(event);
-        }
-        if (xServer != null && xServer.keyboard != null) {
-            handled |= xServer.keyboard.onKeyEvent(event);
-        }
-
-        if (handled) return true;
+        if (inputControlsView != null && inputControlsView.onKeyEvent(event)) return true;
+        if (winHandler != null && winHandler.onKeyEvent(event)) return true;
+        if (xServer != null && xServer.keyboard != null && xServer.keyboard.onKeyEvent(event)) return true;
 
         if (event.getAction() == KeyEvent.ACTION_DOWN &&
                 (event.getKeyCode() == KeyEvent.KEYCODE_BUTTON_MODE ||

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
-import java.util.ArrayList;
 
 public class GuestProgramLauncherComponent extends EnvironmentComponent {
   private String guestExecutable;
@@ -731,18 +730,72 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     envVars.put("ANDROID_SYSVSHM_SERVER", rootDir.getPath() + UnixSocketConfig.SYSVSHM_SERVER_PATH);
 
     String primaryDNS = "8.8.4.4";
-    ConnectivityManager connectivityManager =
-        (ConnectivityManager) context.getSystemService(Service.CONNECTIVITY_SERVICE);
-    if (connectivityManager.getActiveNetwork() != null) {
-      ArrayList<InetAddress> dnsServers =
-          new ArrayList<>(
-              connectivityManager
-                  .getLinkProperties(connectivityManager.getActiveNetwork())
-                  .getDnsServers());
-      primaryDNS = dnsServers.get(0).toString().substring(1);
+    java.util.List<String> orderedDns = new java.util.ArrayList<>();
+    try {
+      ConnectivityManager connectivityManager =
+          (ConnectivityManager) context.getSystemService(Service.CONNECTIVITY_SERVICE);
+      android.net.Network activeNetwork =
+          connectivityManager != null ? connectivityManager.getActiveNetwork() : null;
+      android.net.LinkProperties linkProps =
+          activeNetwork != null ? connectivityManager.getLinkProperties(activeNetwork) : null;
+      java.util.List<InetAddress> dnsServers =
+          linkProps != null ? linkProps.getDnsServers() : null;
+      if (dnsServers != null && !dnsServers.isEmpty()) {
+        for (InetAddress dns : dnsServers) {
+          if (dns instanceof java.net.Inet4Address) {
+            String a = dns.getHostAddress();
+            if (a != null && !a.isEmpty()) orderedDns.add(a);
+          }
+        }
+        for (InetAddress dns : dnsServers) {
+          if (!(dns instanceof java.net.Inet4Address)) {
+            String a = dns.getHostAddress();
+            if (a != null && !a.isEmpty()) {
+              int pct = a.indexOf('%');
+              if (pct >= 0) a = a.substring(0, pct);
+              orderedDns.add(a);
+            }
+          }
+        }
+        if (!orderedDns.isEmpty()) primaryDNS = orderedDns.get(0);
+      }
+    } catch (Exception e) {
+      Log.w("GuestLauncher", "DNS capture failed, using fallback " + primaryDNS, e);
+    }
+    if (orderedDns.isEmpty()) {
+      orderedDns.add("8.8.4.4");
+      orderedDns.add("1.1.1.1");
     }
     envVars.put("ANDROID_RESOLV_DNS", primaryDNS);
     envVars.put("WINE_NEW_NDIS", "1");
+
+    // Refresh /usr/etc/resolv.conf and /usr/etc/hosts on every launch.
+    // The shipped imagefs ships stale DNS and a broken localhost mapping; rewrite
+    // them here so Linux-side tools inside the prefix (curl, openssl, busybox) and
+    // anything else that consults hosts/resolv.conf see the correct values.
+    try {
+      File etcDir = imageFs.getEtcDir();
+      if (etcDir.isDirectory() || etcDir.mkdirs()) {
+        StringBuilder resolv = new StringBuilder();
+        resolv.append("# Generated at launch by WinNative from Android DNS.\n");
+        for (String dns : orderedDns) {
+          resolv.append("nameserver ").append(dns).append('\n');
+        }
+        resolv.append("options edns0 timeout:2 attempts:2\n");
+        FileUtils.writeString(new File(etcDir, "resolv.conf"), resolv.toString());
+
+        FileUtils.writeString(
+            new File(etcDir, "hosts"),
+            "127.0.0.1\tlocalhost\n"
+                + "::1\t\tlocalhost ip6-localhost ip6-loopback\n"
+                + "fe00::0\t\tip6-localnet\n"
+                + "ff00::0\t\tip6-mcastprefix\n"
+                + "ff02::1\t\tip6-allnodes\n"
+                + "ff02::2\t\tip6-allrouters\n");
+      }
+    } catch (Exception e) {
+      Log.w("GuestLauncher", "Failed to refresh resolv.conf/hosts in imagefs", e);
+    }
 
     String ld_preload;
     if (!new File(imageFs.getLibDir(), "libandroid-sysvshm.so").exists()) {

--- a/app/src/main/runtime/input/ui/TouchpadView.kt
+++ b/app/src/main/runtime/input/ui/TouchpadView.kt
@@ -636,7 +636,6 @@ class TouchpadView(
 
     fun onExternalMouseEvent(event: MotionEvent): Boolean {
         if (!isExternalPointerEvent(event)) return false
-        if (!mouseEnabled) return true
         resetMousePointerTimeout()
         val actionButton = event.actionButton
         return when (event.action) {


### PR DESCRIPTION
Mouse/keyboard:
- cursor_lock defaults to true so external mice get pointer capture and emit motion deltas instead of absolute view coords
- TouchpadView.onExternalMouseEvent no longer gated by mouseEnabled, so the per-container "disable touchpad mouse" toggle stops killing physical HID
- dispatchKeyEvent short-circuits between inputControlsView, winHandler and xServer.keyboard instead of fanning out with |=, eliminating double-fires

Networking:
- Add CHANGE_WIFI_MULTICAST_STATE permission and hold a MulticastLock for the X server session (LAN/SSDP/mDNS/UPnP discovery)
- DNS capture: collects all Android DNS servers (IPv4 first, IPv6 with scope-id stripping), guards null ConnectivityManager/LinkProperties
- Rewrite /usr/etc/resolv.conf and /usr/etc/hosts inside the imagefs at every launch with the active DNS + correct localhost mapping so curl, openssl, and busybox inside the prefix see live DNS

imagefs.txz repacked:
- usr/etc/hosts: 192.168.5.11 localhost -> 127.0.0.1 localhost (+ ipv6)
- usr/etc/resolv.conf: hardcoded 8.8.8.8/114.114.114.114 -> placeholder rewritten at launch
- All 10,892 entries preserve mode/owner/path; xz integrity verified