### PR TITLE
Refine XServer drawer gestures

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4825,7 +4825,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent event) {
-        handleDrawerEdgeSwipe(event);
         return super.dispatchTouchEvent(event);
     }
 

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -1,35 +1,62 @@
 package com.winlator.cmod.runtime.display
 
 import android.widget.FrameLayout
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.zIndex
 import com.winlator.cmod.shared.theme.WinNativeTheme
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
-const val XSERVER_DRAWER_EDGE_SWIPE_DP = 120
+const val XSERVER_DRAWER_EDGE_SWIPE_DP = 35
 
 private val DrawerWidth = 340.dp
+private val DrawerStartPadding = 6.dp
+private val DrawerVerticalPadding = 6.dp
+private const val DrawerSettleAnimationMs = 200
+private const val DrawerOpenSettleThreshold = 0.4f
+private const val DrawerCloseSettleThreshold = 0.65f
+private val DrawerSettleAnimationSpec =
+    tween<Float>(
+        durationMillis = DrawerSettleAnimationMs,
+        easing = LinearEasing,
+    )
 
 interface XServerDisplayHostCallbacks {
     fun onDrawerSlide()
@@ -68,7 +95,22 @@ private fun XServerDisplayHost(
     listener: XServerDrawerActionListener,
     callbacks: XServerDisplayHostCallbacks,
 ) {
-    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val animationScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val viewConfiguration = LocalViewConfiguration.current
+    var drawerOffsetPx by remember { mutableFloatStateOf(0f) }
+    var drawerWidthPx by remember { mutableFloatStateOf(0f) }
+    val drawerClosedOffset =
+        if (drawerWidthPx > 0f) {
+            -drawerWidthPx - with(density) { DrawerStartPadding.toPx() }
+        } else {
+            0f
+        }
+    val drawerOpenOffset = 0f
+    val drawerSheetVisible = drawerWidthPx <= 0f ||
+        drawerOffsetPx > drawerClosedOffset + 1f ||
+        stateHolder.isDrawerOpen
+    val dialogVisible = false
 
     DisposableEffect(stateHolder) {
         stateHolder.setPaneVisibilityListener { }
@@ -77,100 +119,178 @@ private fun XServerDisplayHost(
         }
     }
 
-    LaunchedEffect(stateHolder.isDrawerOpen) {
-        if (stateHolder.isDrawerOpen) {
-            if (!drawerState.isOpen) {
-                callbacks.onDrawerSlide()
-                drawerState.open()
-            }
-        } else if (!drawerState.isClosed) {
-            callbacks.onDrawerSlide()
-            drawerState.close()
+    LaunchedEffect(drawerWidthPx) {
+        if (drawerWidthPx > 0f && drawerOffsetPx == 0f && !stateHolder.isDrawerOpen) {
+            drawerOffsetPx = drawerClosedOffset
         }
     }
 
-    LaunchedEffect(drawerState) {
-        var initialized = false
-        snapshotFlow { drawerState.currentValue }
-            .collect { value ->
-                if (!initialized) {
-                    initialized = true
-                    return@collect
-                }
-                if (value == DrawerValue.Open) {
-                    if (!stateHolder.isDrawerOpen) stateHolder.openDrawer()
-                    callbacks.onDrawerOpened()
-                } else {
-                    if (stateHolder.isDrawerOpen) stateHolder.closeDrawer()
-                    callbacks.onDrawerClosed()
-                }
+    LaunchedEffect(stateHolder.isDrawerOpen, drawerWidthPx) {
+        if (drawerWidthPx <= 0f) return@LaunchedEffect
+        val target = if (stateHolder.isDrawerOpen) drawerOpenOffset else drawerClosedOffset
+        if (drawerOffsetPx != target) {
+            callbacks.onDrawerSlide()
+            animate(
+                initialValue = drawerOffsetPx,
+                targetValue = target,
+                animationSpec = DrawerSettleAnimationSpec,
+            ) { value, _ ->
+                drawerOffsetPx = value
+                callbacks.onDrawerSlide()
             }
-    }
-
-    LaunchedEffect(drawerState) {
-        snapshotFlow { drawerState.currentOffset }
-            .collect { offset ->
-                if (!offset.isNaN()) callbacks.onDrawerSlide()
+            if (stateHolder.isDrawerOpen) {
+                callbacks.onDrawerOpened()
+            } else {
+                callbacks.onDrawerClosed()
             }
+        }
     }
-
-    LaunchedEffect(drawerState) {
-        snapshotFlow { drawerState.targetValue }
-            .collect { value ->
-                if (value == DrawerValue.Open && !drawerState.isOpen) {
-                    callbacks.onDrawerGestureClaimed()
-                }
-            }
-    }
-
-    val drawerInMotion =
-        drawerState.currentValue == DrawerValue.Open ||
-            drawerState.targetValue == DrawerValue.Open ||
-            stateHolder.isDrawerOpen
-    val drawerContentVisible = drawerInMotion
-    val dialogVisible = false
 
     LaunchedEffect(dialogVisible) {
         callbacks.onDialogVisibilityChanged(dialogVisible)
     }
 
     WinNativeTheme {
-        Box(modifier = Modifier.fillMaxSize()) {
-            ModalNavigationDrawer(
-                drawerState = drawerState,
-                gesturesEnabled = drawerState.isOpen && !dialogVisible,
-                scrimColor = Color.Transparent,
-                drawerContent = {
-                    ModalDrawerSheet(
-                        drawerShape = RoundedCornerShape(20.dp),
-                        drawerContainerColor = PaneSurfaceColor,
-                        drawerContentColor = Color.Unspecified,
-                        drawerTonalElevation = 0.dp,
-                        windowInsets = WindowInsets(0, 0, 0, 0),
-                        modifier =
-                            Modifier
-                                .padding(start = 6.dp, top = 6.dp, bottom = 6.dp)
-                                .fillMaxHeight()
-                                .width(DrawerWidth),
-                    ) {
-                        if (drawerContentVisible) {
-                            XServerDrawerContent(
-                                state = stateHolder.state,
-                                taskManagerState = stateHolder.taskManagerState,
-                                openPane = stateHolder.openPane,
-                                onOpenPaneChange = { stateHolder.setOpenPaneAndNotify(it) },
-                                listener = listener,
-                                onDismiss = { stateHolder.closeDrawer() },
-                            )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .pointerInput(drawerWidthPx, dialogVisible) {
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            if (dialogVisible || drawerWidthPx <= 0f) return@awaitEachGesture
+
+                            val edgeWidthPx = XSERVER_DRAWER_EDGE_SWIPE_DP.dp.toPx()
+                            val canStartFromHere =
+                                if (stateHolder.isDrawerOpen) {
+                                    down.position.x >= drawerWidthPx &&
+                                        down.position.x <= drawerWidthPx + edgeWidthPx
+                                } else {
+                                    down.position.x <= edgeWidthPx
+                                }
+                            if (!canStartFromHere) return@awaitEachGesture
+
+                            var gestureClaimed = false
+                            var cancelledByVerticalDrag = false
+                            var totalDx = 0f
+                            var totalDy = 0f
+                            var dragStartOffset = drawerOffsetPx
+
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                if (change.changedToUpIgnoreConsumed()) break
+
+                                val delta = change.positionChange()
+                                totalDx += delta.x
+                                totalDy += delta.y
+
+                                if (!gestureClaimed) {
+                                    if (abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)) {
+                                        cancelledByVerticalDrag = true
+                                        break
+                                    }
+                                    val horizontalDragClaimed =
+                                        if (stateHolder.isDrawerOpen) {
+                                            totalDx < -viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
+                                        } else {
+                                            totalDx > viewConfiguration.touchSlop && totalDx > abs(totalDy)
+                                        }
+                                    if (horizontalDragClaimed) {
+                                        gestureClaimed = true
+                                        dragStartOffset = drawerOffsetPx
+                                        totalDx = 0f
+                                        callbacks.onDrawerGestureClaimed()
+                                    }
+                                }
+
+                                if (gestureClaimed) {
+                                    change.consume()
+                                    val nextOffset =
+                                        (dragStartOffset + totalDx)
+                                            .coerceIn(drawerClosedOffset, drawerOpenOffset)
+                                    drawerOffsetPx = nextOffset
+                                    callbacks.onDrawerSlide()
+                                }
+                            }
+
+                            if (gestureClaimed && !cancelledByVerticalDrag) {
+                                val drawerOpenProgress =
+                                    if (drawerClosedOffset < 0f) {
+                                        ((drawerOffsetPx - drawerClosedOffset) / -drawerClosedOffset)
+                                            .coerceIn(0f, 1f)
+                                    } else {
+                                        0f
+                                    }
+                                val shouldOpen =
+                                    if (stateHolder.isDrawerOpen) {
+                                        drawerOpenProgress > DrawerCloseSettleThreshold
+                                    } else {
+                                        drawerOpenProgress >= DrawerOpenSettleThreshold
+                                    }
+                                val target = if (shouldOpen) drawerOpenOffset else drawerClosedOffset
+                                animationScope.launch {
+                                    animate(
+                                        initialValue = drawerOffsetPx,
+                                        targetValue = target,
+                                        animationSpec = DrawerSettleAnimationSpec,
+                                    ) { value, _ ->
+                                        drawerOffsetPx = value
+                                        callbacks.onDrawerSlide()
+                                    }
+                                    if (shouldOpen) {
+                                        if (!stateHolder.isDrawerOpen) stateHolder.openDrawer()
+                                        callbacks.onDrawerOpened()
+                                    } else {
+                                        if (stateHolder.isDrawerOpen) stateHolder.closeDrawer()
+                                        callbacks.onDrawerClosed()
+                                    }
+                                }
+                            }
                         }
-                    }
-                },
+                    },
+        ) {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                AndroidView(
+                    factory = { displayFrame },
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .zIndex(0f),
+                    update = {},
+                )
+            }
+
+            ModalDrawerSheet(
+                drawerShape = RoundedCornerShape(20.dp),
+                drawerContainerColor = PaneSurfaceColor,
+                drawerContentColor = Color.Unspecified,
+                drawerTonalElevation = 0.dp,
+                windowInsets = WindowInsets(0, 0, 0, 0),
+                modifier =
+                    Modifier
+                        .zIndex(2f)
+                        .padding(start = DrawerStartPadding, top = DrawerVerticalPadding, bottom = DrawerVerticalPadding)
+                        .fillMaxHeight()
+                        .width(DrawerWidth)
+                        .onSizeChanged { size ->
+                            drawerWidthPx = size.width.toFloat()
+                        }
+                        .offset {
+                            androidx.compose.ui.unit.IntOffset(
+                                drawerOffsetPx.roundToInt(),
+                                0,
+                            )
+                        },
             ) {
-                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                    AndroidView(
-                        factory = { displayFrame },
-                        modifier = Modifier.fillMaxSize(),
-                        update = {},
+                if (drawerSheetVisible) {
+                    XServerDrawerContent(
+                        state = stateHolder.state,
+                        taskManagerState = stateHolder.taskManagerState,
+                        openPane = stateHolder.openPane,
+                        onOpenPaneChange = { stateHolder.setOpenPaneAndNotify(it) },
+                        listener = listener,
+                        onDismiss = { stateHolder.closeDrawer() },
                     )
                 }
             }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -756,7 +756,6 @@ internal fun XServerDrawerContent(
                                         state = state,
                                         listener = listener,
                                         cardsRevealed = cardsRevealed.value,
-                                        onActionInvoked = onDismiss,
                                         onOpenTaskManager = { onOpenPaneChange(DrawerPane.TASK_MANAGER) },
                                     )
                             }
@@ -997,7 +996,6 @@ private fun ActionCardGrid(
     state: XServerDrawerState,
     listener: XServerDrawerActionListener,
     cardsRevealed: Boolean,
-    onActionInvoked: () -> Unit,
     onOpenTaskManager: () -> Unit,
 ) {
     val paneScale = LocalPaneScale.current
@@ -1036,10 +1034,7 @@ private fun ActionCardGrid(
                             R.id.main_menu_relative_mouse_movement,
                             R.id.main_menu_disable_mouse,
                             R.id.main_menu_toggle_fullscreen -> listener.onActionSelected(item.itemId)
-                            else -> {
-                                onActionInvoked()
-                                listener.onActionSelected(item.itemId)
-                            }
+                            else -> listener.onActionSelected(item.itemId)
                         }
                     },
                 )


### PR DESCRIPTION
- Replace the XServer drawer auto-open trigger with finger-tracked edge dragging.
- Move swipe-close handling outside the drawer so menu controls remain usable.
- Keep action-card clicks from dismissing the drawer unless the selected action explicitly closes it.