### PR TITLE
Add session logs drawer pane

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1038,6 +1038,16 @@ Installeret sti:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Opgaver</string>
     <string name="session_drawer_rail_label_logs">Logs</string>
+    <string name="session_drawer_logs_clear">Ryd</string>
+    <string name="session_drawer_logs_pause">Pause</string>
+    <string name="session_drawer_logs_resume">Fortsæt</string>
+    <string name="session_drawer_logs_paused_indicator">Sat på pause</string>
+    <string name="session_drawer_logs_line_count">%1$d linjer</string>
+    <string name="session_drawer_logs_share">Del</string>
+    <string name="session_drawer_logs_share_subject">Sessionslogs</string>
+    <string name="session_drawer_logs_share_chooser">Del sessionslogs</string>
+    <string name="session_drawer_logs_share_failed">Kunne ikke dele logs</string>
+    <string name="session_drawer_logs_share_empty">Ingen loglinjer at dele</string>
     <string name="session_drawer_super_resolution">Skarphedsfiltre</string>
     <string name="session_drawer_upscaler_mode">Filter</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1038,6 +1038,16 @@ Installierter Pfad:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Aufg.</string>
     <string name="session_drawer_rail_label_logs">Logs</string>
+    <string name="session_drawer_logs_clear">Löschen</string>
+    <string name="session_drawer_logs_pause">Pause</string>
+    <string name="session_drawer_logs_resume">Fortsetzen</string>
+    <string name="session_drawer_logs_paused_indicator">Pausiert</string>
+    <string name="session_drawer_logs_line_count">%1$d Zeilen</string>
+    <string name="session_drawer_logs_share">Teilen</string>
+    <string name="session_drawer_logs_share_subject">Sitzungslogs</string>
+    <string name="session_drawer_logs_share_chooser">Sitzungslogs teilen</string>
+    <string name="session_drawer_logs_share_failed">Logs konnten nicht geteilt werden</string>
+    <string name="session_drawer_logs_share_empty">Keine Logzeilen zum Teilen</string>
     <string name="session_drawer_super_resolution">Schärfungsfilter</string>
     <string name="session_drawer_upscaler_mode">Filter</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1038,6 +1038,16 @@ Ruta instalada:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Tareas</string>
     <string name="session_drawer_rail_label_logs">Reg.</string>
+    <string name="session_drawer_logs_clear">Borrar</string>
+    <string name="session_drawer_logs_pause">Pausar</string>
+    <string name="session_drawer_logs_resume">Reanudar</string>
+    <string name="session_drawer_logs_paused_indicator">Pausado</string>
+    <string name="session_drawer_logs_line_count">%1$d líneas</string>
+    <string name="session_drawer_logs_share">Compartir</string>
+    <string name="session_drawer_logs_share_subject">Registros de sesión</string>
+    <string name="session_drawer_logs_share_chooser">Compartir registros de sesión</string>
+    <string name="session_drawer_logs_share_failed">No se pudieron compartir los registros</string>
+    <string name="session_drawer_logs_share_empty">No hay líneas de registro para compartir</string>
     <string name="session_drawer_super_resolution">Filtros de Nitidez</string>
     <string name="session_drawer_upscaler_mode">Filtro</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1038,6 +1038,16 @@ Chemin installé :
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Tâches</string>
     <string name="session_drawer_rail_label_logs">Logs</string>
+    <string name="session_drawer_logs_clear">Effacer</string>
+    <string name="session_drawer_logs_pause">Pause</string>
+    <string name="session_drawer_logs_resume">Reprendre</string>
+    <string name="session_drawer_logs_paused_indicator">En pause</string>
+    <string name="session_drawer_logs_line_count">%1$d lignes</string>
+    <string name="session_drawer_logs_share">Partager</string>
+    <string name="session_drawer_logs_share_subject">Logs de session</string>
+    <string name="session_drawer_logs_share_chooser">Partager les logs de session</string>
+    <string name="session_drawer_logs_share_failed">Échec du partage des logs</string>
+    <string name="session_drawer_logs_share_empty">Aucune ligne de log à partager</string>
     <string name="session_drawer_super_resolution">Filtres de Netteté</string>
     <string name="session_drawer_upscaler_mode">Filtre</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1038,6 +1038,16 @@ Percorso installato:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Attività</string>
     <string name="session_drawer_rail_label_logs">Log</string>
+    <string name="session_drawer_logs_clear">Cancella</string>
+    <string name="session_drawer_logs_pause">Pausa</string>
+    <string name="session_drawer_logs_resume">Riprendi</string>
+    <string name="session_drawer_logs_paused_indicator">In pausa</string>
+    <string name="session_drawer_logs_line_count">%1$d righe</string>
+    <string name="session_drawer_logs_share">Condividi</string>
+    <string name="session_drawer_logs_share_subject">Log della sessione</string>
+    <string name="session_drawer_logs_share_chooser">Condividi log della sessione</string>
+    <string name="session_drawer_logs_share_failed">Impossibile condividere i log</string>
+    <string name="session_drawer_logs_share_empty">Nessuna riga di log da condividere</string>
     <string name="session_drawer_super_resolution">Filtri Nitidezza</string>
     <string name="session_drawer_upscaler_mode">Filtro</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1038,6 +1038,16 @@
     <string name="session_drawer_rail_label_magnifier">확대</string>
     <string name="session_drawer_rail_label_task_manager">작업</string>
     <string name="session_drawer_rail_label_logs">로그</string>
+    <string name="session_drawer_logs_clear">지우기</string>
+    <string name="session_drawer_logs_pause">일시 중지</string>
+    <string name="session_drawer_logs_resume">다시 시작</string>
+    <string name="session_drawer_logs_paused_indicator">일시 중지됨</string>
+    <string name="session_drawer_logs_line_count">%1$d줄</string>
+    <string name="session_drawer_logs_share">공유</string>
+    <string name="session_drawer_logs_share_subject">세션 로그</string>
+    <string name="session_drawer_logs_share_chooser">세션 로그 공유</string>
+    <string name="session_drawer_logs_share_failed">로그를 공유하지 못했습니다</string>
+    <string name="session_drawer_logs_share_empty">공유할 로그 줄이 없습니다</string>
     <string name="session_drawer_super_resolution">선명도 필터</string>
     <string name="session_drawer_upscaler_mode">필터</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1044,6 +1044,16 @@ Zainstalowana ścieżka:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Zad.</string>
     <string name="session_drawer_rail_label_logs">Logi</string>
+    <string name="session_drawer_logs_clear">Wyczyść</string>
+    <string name="session_drawer_logs_pause">Wstrzymaj</string>
+    <string name="session_drawer_logs_resume">Wznów</string>
+    <string name="session_drawer_logs_paused_indicator">Wstrzymano</string>
+    <string name="session_drawer_logs_line_count">%1$d wierszy</string>
+    <string name="session_drawer_logs_share">Udostępnij</string>
+    <string name="session_drawer_logs_share_subject">Logi sesji</string>
+    <string name="session_drawer_logs_share_chooser">Udostępnij logi sesji</string>
+    <string name="session_drawer_logs_share_failed">Nie udało się udostępnić logów</string>
+    <string name="session_drawer_logs_share_empty">Brak wierszy logu do udostępnienia</string>
     <string name="session_drawer_super_resolution">Filtry Wyostrzania</string>
     <string name="session_drawer_upscaler_mode">Filtr</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1038,6 +1038,16 @@ Caminho instalado:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Tarefas</string>
     <string name="session_drawer_rail_label_logs">Logs</string>
+    <string name="session_drawer_logs_clear">Limpar</string>
+    <string name="session_drawer_logs_pause">Pausar</string>
+    <string name="session_drawer_logs_resume">Retomar</string>
+    <string name="session_drawer_logs_paused_indicator">Pausado</string>
+    <string name="session_drawer_logs_line_count">%1$d linhas</string>
+    <string name="session_drawer_logs_share">Compartilhar</string>
+    <string name="session_drawer_logs_share_subject">Logs da sessão</string>
+    <string name="session_drawer_logs_share_chooser">Compartilhar logs da sessão</string>
+    <string name="session_drawer_logs_share_failed">Falha ao compartilhar logs</string>
+    <string name="session_drawer_logs_share_empty">Não há linhas de log para compartilhar</string>
     <string name="session_drawer_super_resolution">Filtros de Nitidez</string>
     <string name="session_drawer_upscaler_mode">Filtro</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1038,6 +1038,16 @@ Cale instalata:
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Sarcini</string>
     <string name="session_drawer_rail_label_logs">Loguri</string>
+    <string name="session_drawer_logs_clear">Șterge</string>
+    <string name="session_drawer_logs_pause">Pauză</string>
+    <string name="session_drawer_logs_resume">Reia</string>
+    <string name="session_drawer_logs_paused_indicator">În pauză</string>
+    <string name="session_drawer_logs_line_count">%1$d linii</string>
+    <string name="session_drawer_logs_share">Partajează</string>
+    <string name="session_drawer_logs_share_subject">Loguri de sesiune</string>
+    <string name="session_drawer_logs_share_chooser">Partajează logurile sesiunii</string>
+    <string name="session_drawer_logs_share_failed">Nu s-au putut partaja logurile</string>
+    <string name="session_drawer_logs_share_empty">Nu există linii de log de partajat</string>
     <string name="session_drawer_super_resolution">Filtre Claritate</string>
     <string name="session_drawer_upscaler_mode">Filtru</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1044,6 +1044,16 @@
     <string name="session_drawer_rail_label_magnifier">Лупа</string>
     <string name="session_drawer_rail_label_task_manager">Задачі</string>
     <string name="session_drawer_rail_label_logs">Логи</string>
+    <string name="session_drawer_logs_clear">Очистити</string>
+    <string name="session_drawer_logs_pause">Пауза</string>
+    <string name="session_drawer_logs_resume">Відновити</string>
+    <string name="session_drawer_logs_paused_indicator">Призупинено</string>
+    <string name="session_drawer_logs_line_count">%1$d рядків</string>
+    <string name="session_drawer_logs_share">Поділитися</string>
+    <string name="session_drawer_logs_share_subject">Логи сеансу</string>
+    <string name="session_drawer_logs_share_chooser">Поділитися логами сеансу</string>
+    <string name="session_drawer_logs_share_failed">Не вдалося поділитися логами</string>
+    <string name="session_drawer_logs_share_empty">Немає рядків логу для надсилання</string>
     <string name="session_drawer_super_resolution">Фільтри Чіткості</string>
     <string name="session_drawer_upscaler_mode">Фільтр</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1038,6 +1038,16 @@
     <string name="session_drawer_rail_label_magnifier">缩放</string>
     <string name="session_drawer_rail_label_task_manager">任务</string>
     <string name="session_drawer_rail_label_logs">日志</string>
+    <string name="session_drawer_logs_clear">清除</string>
+    <string name="session_drawer_logs_pause">暂停</string>
+    <string name="session_drawer_logs_resume">继续</string>
+    <string name="session_drawer_logs_paused_indicator">已暂停</string>
+    <string name="session_drawer_logs_line_count">%1$d 行</string>
+    <string name="session_drawer_logs_share">分享</string>
+    <string name="session_drawer_logs_share_subject">会话日志</string>
+    <string name="session_drawer_logs_share_chooser">分享会话日志</string>
+    <string name="session_drawer_logs_share_failed">无法分享日志</string>
+    <string name="session_drawer_logs_share_empty">没有可分享的日志行</string>
     <string name="session_drawer_super_resolution">锐化滤镜</string>
     <string name="session_drawer_upscaler_mode">滤镜</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1038,6 +1038,16 @@
     <string name="session_drawer_rail_label_magnifier">縮放</string>
     <string name="session_drawer_rail_label_task_manager">工作</string>
     <string name="session_drawer_rail_label_logs">日誌</string>
+    <string name="session_drawer_logs_clear">清除</string>
+    <string name="session_drawer_logs_pause">暫停</string>
+    <string name="session_drawer_logs_resume">繼續</string>
+    <string name="session_drawer_logs_paused_indicator">已暫停</string>
+    <string name="session_drawer_logs_line_count">%1$d 行</string>
+    <string name="session_drawer_logs_share">分享</string>
+    <string name="session_drawer_logs_share_subject">工作階段日誌</string>
+    <string name="session_drawer_logs_share_chooser">分享工作階段日誌</string>
+    <string name="session_drawer_logs_share_failed">無法分享日誌</string>
+    <string name="session_drawer_logs_share_empty">沒有可分享的日誌行</string>
     <string name="session_drawer_super_resolution">銳化濾鏡</string>
     <string name="session_drawer_upscaler_mode">濾鏡</string>
     <string name="session_drawer_upscaler_fsr">FSR 1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -675,6 +675,16 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_rail_label_magnifier">Zoom</string>
     <string name="session_drawer_rail_label_task_manager">Tasks</string>
     <string name="session_drawer_rail_label_logs">Logs</string>
+    <string name="session_drawer_logs_clear">Clear</string>
+    <string name="session_drawer_logs_pause">Pause</string>
+    <string name="session_drawer_logs_resume">Resume</string>
+    <string name="session_drawer_logs_paused_indicator">Paused</string>
+    <string name="session_drawer_logs_line_count">%1$d lines</string>
+    <string name="session_drawer_logs_share">Share</string>
+    <string name="session_drawer_logs_share_subject">Session logs</string>
+    <string name="session_drawer_logs_share_chooser">Share session logs</string>
+    <string name="session_drawer_logs_share_failed">Failed to share logs</string>
+    <string name="session_drawer_logs_share_empty">No log lines to share</string>
     <string name="session_gyroscope_activator">Activator</string>
 
     <!-- Session > Task Manager -->

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -20,7 +20,9 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.net.Uri;
 import android.opengl.GLSurfaceView;
+import android.text.format.DateFormat;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -52,6 +54,7 @@ import androidx.core.graphics.Insets;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.FileProvider;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.core.view.WindowInsetsCompat;
 import com.winlator.cmod.BuildConfig;
@@ -70,7 +73,6 @@ import com.winlator.cmod.feature.setup.SetupWizardActivity;
 import com.winlator.cmod.runtime.container.Container;
 import com.winlator.cmod.runtime.container.ContainerManager;
 import com.winlator.cmod.runtime.container.Shortcut;
-import com.winlator.cmod.feature.settings.DebugDialog;
 import com.winlator.cmod.feature.settings.DXVKConfigUtils;
 import com.winlator.cmod.feature.settings.GraphicsDriverConfigUtils;
 import com.winlator.cmod.feature.shortcuts.ShortcutsFragment;
@@ -155,12 +157,16 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -273,7 +279,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private WineRequestHandler wineRequestHandler;
     private float globalCursorSpeed = 1.0f;
     private MagnifierView magnifierView;
-    private DebugDialog debugDialog;
+    private Callback<String> logStreamSink;
+    private BufferedWriter logStreamWriter;
+    private File logStreamFile;
     private int taskAffinityMask = 0;
     private int taskAffinityMaskWoW64 = 0;
     private int frameRatingWindowId = -1;
@@ -890,7 +898,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         ProcessHelper.removeAllDebugCallbacks();
         if (enableLogsMenu) {
             LogView.setFilename(getExecutable());
-            ProcessHelper.addDebugCallback(debugDialog = new DebugDialog(this));
+            attachLogStreamSink();
         }
 
         graphicsDriver = container.getGraphicsDriver();
@@ -2093,17 +2101,114 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
     }
 
-    private void cleanupDebugDialog(String trigger) {
-        DebugDialog dialog = debugDialog;
-        if (dialog == null) return;
+    private void attachLogStreamSink() {
         try {
-            ProcessHelper.removeDebugCallback(dialog);
-            dialog.dispose();
-        } catch (Exception e) {
-            Log.w("XServerLeakCheck", "Failed to release debug dialog during " + trigger, e);
-        } finally {
-            debugDialog = null;
+            logStreamFile = LogView.getLogFile(this);
+            logStreamWriter = new BufferedWriter(new FileWriter(logStreamFile));
+        } catch (IOException e) {
+            Log.w("XServerLogs", "Failed to open log file writer", e);
+            logStreamWriter = null;
+            logStreamFile = null;
         }
+        Callback<String> sink = new Callback<String>() {
+            @Override
+            public synchronized void call(String line) {
+                String stamped = "[" + DateFormat.format("HH:mm:ss", System.currentTimeMillis())
+                        + "]  " + line.replace("\n", "");
+                XServerDrawerStateHolder holder = drawerStateHolder;
+                if (holder != null) holder.appendLogLine(stamped);
+                BufferedWriter writer = logStreamWriter;
+                if (writer != null) {
+                    try {
+                        writer.write(stamped);
+                        writer.write("\n");
+                        writer.flush();
+                    } catch (IOException ignored) {
+                    }
+                }
+            }
+        };
+        logStreamSink = sink;
+        ProcessHelper.addDebugCallback(sink);
+    }
+
+    private void shareLogStream() {
+        try {
+            File shareDir = new File(getCacheDir(), "log_shares");
+            if (!shareDir.exists()) shareDir.mkdirs();
+            String stamp = (String) DateFormat.format("yyyy-MM-dd_HH-mm-ss", new Date());
+            File shareFile = new File(shareDir, "session_logs_" + stamp + ".txt");
+
+            BufferedWriter writer = logStreamWriter;
+            if (writer != null) {
+                try {
+                    writer.flush();
+                } catch (IOException ignored) {
+                }
+            }
+
+            File source = logStreamFile;
+            boolean wrote = false;
+            if (source != null && source.exists() && source.length() > 0) {
+                try (java.io.InputStream in = new java.io.FileInputStream(source);
+                     java.io.OutputStream out = new java.io.FileOutputStream(shareFile)) {
+                    byte[] buf = new byte[8192];
+                    int n;
+                    while ((n = in.read(buf)) > 0) out.write(buf, 0, n);
+                    out.flush();
+                    wrote = true;
+                }
+            }
+
+            if (!wrote) {
+                XServerDrawerStateHolder holder = drawerStateHolder;
+                List<String> lines = holder != null ? holder.snapshotLogLines() : new ArrayList<>();
+                if (lines.isEmpty()) {
+                    showToast(this, getString(R.string.session_drawer_logs_share_empty));
+                    return;
+                }
+                try (BufferedWriter out = new BufferedWriter(new FileWriter(shareFile))) {
+                    for (String line : lines) {
+                        out.write(line);
+                        out.write("\n");
+                    }
+                }
+            }
+
+            String authority = getPackageName() + ".tileprovider";
+            Uri uri = FileProvider.getUriForFile(this, authority, shareFile);
+            Intent shareIntent = new Intent(Intent.ACTION_SEND);
+            shareIntent.setType("text/plain");
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+            shareIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.session_drawer_logs_share_subject));
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            startActivity(Intent.createChooser(shareIntent, getString(R.string.session_drawer_logs_share_chooser)));
+        } catch (Exception e) {
+            Log.w("XServerLogs", "Failed to share log stream", e);
+            showToast(this, getString(R.string.session_drawer_logs_share_failed));
+        }
+    }
+
+    private void cleanupDebugDialog(String trigger) {
+        Callback<String> sink = logStreamSink;
+        if (sink != null) {
+            try {
+                ProcessHelper.removeDebugCallback(sink);
+            } catch (Exception e) {
+                Log.w("XServerLeakCheck", "Failed to remove log sink during " + trigger, e);
+            }
+            logStreamSink = null;
+        }
+        BufferedWriter writer = logStreamWriter;
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (IOException ignored) {
+            } finally {
+                logStreamWriter = null;
+            }
+        }
+        logStreamFile = null;
     }
 
     private void stopXServer(String trigger) {
@@ -3185,6 +3290,26 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     public void onTaskManagerNewTask(String command) {
                         if (winHandler != null) winHandler.exec(command);
                     }
+
+                    @Override
+                    public void onLogsClear() {
+                        if (drawerStateHolder != null) drawerStateHolder.clearLogLines();
+                    }
+
+                    @Override
+                    public void onLogsPauseChanged(boolean paused) {
+                        if (drawerStateHolder != null) drawerStateHolder.setLogsPaused(paused);
+                    }
+
+                    @Override
+                    public void onLogsPaneVisibilityChanged(boolean visible) {
+                        if (drawerStateHolder != null) drawerStateHolder.setLogsPaneVisible(visible);
+                    }
+
+                    @Override
+                    public void onLogsShare() {
+                        shareLogStream();
+                    }
                 };
         }
 
@@ -3567,9 +3692,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     renderer.setMagnifierUIActive(true);
                 }
                 renderDrawerMenu();
-                break;
-            case R.id.main_menu_logs:
-                debugDialog.show();
                 break;
             case R.id.main_menu_native_rendering:
                 isNativeRenderingEnabled = !isNativeRenderingEnabled;

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -287,6 +287,7 @@ private fun XServerDisplayHost(
                     XServerDrawerContent(
                         state = stateHolder.state,
                         taskManagerState = stateHolder.taskManagerState,
+                        logsState = stateHolder.logsState,
                         openPane = stateHolder.openPane,
                         onOpenPaneChange = { stateHolder.setOpenPaneAndNotify(it) },
                         listener = listener,

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
@@ -48,6 +49,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -62,6 +66,7 @@ import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Fullscreen
 import androidx.compose.material.icons.outlined.Keyboard
@@ -73,6 +78,7 @@ import androidx.compose.material.icons.outlined.PictureInPictureAlt
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.ScreenRotation
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material.icons.outlined.Tune
@@ -121,6 +127,7 @@ import androidx.compose.ui.res.integerArrayResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.ImeAction
@@ -190,7 +197,14 @@ private enum class HUDMetricEditor(
     SCALE(minPercent = 50, maxPercent = 200),
 }
 
-internal enum class DrawerPane { INPUT_CONTROLS, HUD, GYROSCOPE, SCREEN_EFFECTS, TASK_MANAGER }
+internal enum class DrawerPane { INPUT_CONTROLS, HUD, GYROSCOPE, SCREEN_EFFECTS, TASK_MANAGER, LOGS }
+
+internal const val LogsPaneMaxLines = 2000
+
+data class LogsPaneState(
+    val lines: List<String> = emptyList(),
+    val paused: Boolean = false,
+)
 
 data class TaskManagerProcess(
     val pid: Int,
@@ -313,6 +327,17 @@ class XServerDrawerStateHolder(
 ) {
     var state by mutableStateOf(initialState, neverEqualPolicy())
     var taskManagerState by mutableStateOf(TaskManagerPaneState(), neverEqualPolicy())
+    var logsState by mutableStateOf(LogsPaneState(), neverEqualPolicy())
+        private set
+    private val logsBuffer = java.util.Collections.synchronizedList(ArrayList<String>(LogsPaneMaxLines))
+    @Volatile private var logsPausedFlag = false
+    @Volatile private var logsPaneVisibleFlag = false
+    private val logsMainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private val logsFlushPending = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val logsFlushRunnable = Runnable {
+        logsFlushPending.set(false)
+        flushLogsBufferToState()
+    }
     private var drawerOpen by mutableStateOf(false)
     internal var openPane by mutableStateOf<DrawerPane?>(null)
     private var paneVisibilityListener: ((Boolean) -> Unit)? = null
@@ -353,6 +378,59 @@ class XServerDrawerStateHolder(
         if (wasVisible != nowVisible) paneVisibilityListener?.invoke(nowVisible)
     }
 
+    fun openLogsPane() {
+        setOpenPaneAndNotify(DrawerPane.LOGS)
+    }
+
+    /**
+     * Append a log line. Safe to call from any thread. When the logs pane is not
+     * visible, this only stores the line in an off-thread ring buffer — no
+     * recomposition or main-thread work is scheduled. The buffer is flushed into
+     * observable state when the pane becomes visible (and live while visible,
+     * coalesced through a single posted runnable).
+     */
+    fun appendLogLine(line: String) {
+        if (logsPausedFlag) return
+        synchronized(logsBuffer) {
+            logsBuffer.add(line)
+            while (logsBuffer.size > LogsPaneMaxLines) logsBuffer.removeAt(0)
+        }
+        if (logsPaneVisibleFlag && logsFlushPending.compareAndSet(false, true)) {
+            logsMainHandler.post(logsFlushRunnable)
+        }
+    }
+
+    private fun flushLogsBufferToState() {
+        val snapshot = synchronized(logsBuffer) { ArrayList(logsBuffer) }
+        logsState = logsState.copy(lines = snapshot)
+    }
+
+    fun clearLogLines() {
+        synchronized(logsBuffer) { logsBuffer.clear() }
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            logsState = logsState.copy(lines = emptyList())
+        } else {
+            logsMainHandler.post { logsState = logsState.copy(lines = emptyList()) }
+        }
+    }
+
+    fun setLogsPaused(paused: Boolean) {
+        if (logsPausedFlag == paused) return
+        logsPausedFlag = paused
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            logsState = logsState.copy(paused = paused)
+        } else {
+            logsMainHandler.post { logsState = logsState.copy(paused = paused) }
+        }
+    }
+
+    fun setLogsPaneVisible(visible: Boolean) {
+        if (logsPaneVisibleFlag == visible) return
+        logsPaneVisibleFlag = visible
+        if (visible) flushLogsBufferToState()
+    }
+
+    fun snapshotLogLines(): List<String> = synchronized(logsBuffer) { ArrayList(logsBuffer) }
 }
 
 interface XServerDrawerActionListener {
@@ -432,6 +510,14 @@ interface XServerDrawerActionListener {
     fun onTaskManagerSetAffinity(pid: Int, affinityMask: Int)
 
     fun onTaskManagerNewTask(command: String)
+
+    fun onLogsClear()
+
+    fun onLogsPauseChanged(paused: Boolean)
+
+    fun onLogsPaneVisibilityChanged(visible: Boolean)
+
+    fun onLogsShare()
 }
 
 fun buildXServerDrawerState(
@@ -650,6 +736,7 @@ fun setupXServerDrawerComposeView(
             XServerDrawerContent(
                 state = stateHolder.state,
                 taskManagerState = stateHolder.taskManagerState,
+                logsState = stateHolder.logsState,
                 openPane = stateHolder.openPane,
                 onOpenPaneChange = { stateHolder.setOpenPaneAndNotify(it) },
                 listener = listener,
@@ -663,6 +750,7 @@ fun setupXServerDrawerComposeView(
 internal fun XServerDrawerContent(
     state: XServerDrawerState,
     taskManagerState: TaskManagerPaneState,
+    logsState: LogsPaneState,
     openPane: DrawerPane?,
     onOpenPaneChange: (DrawerPane?) -> Unit,
     listener: XServerDrawerActionListener,
@@ -683,7 +771,7 @@ internal fun XServerDrawerContent(
             val paneScale = computePaneScale(maxHeight)
             CompositionLocalProvider(LocalPaneScale provides paneScale) {
                 Column(modifier = Modifier.fillMaxSize()) {
-                    val railVisible = openPane != DrawerPane.TASK_MANAGER
+                    val railVisible = openPane != DrawerPane.TASK_MANAGER && openPane != DrawerPane.LOGS
                     val chromeEnter =
                         expandVertically(
                             animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
@@ -722,8 +810,9 @@ internal fun XServerDrawerContent(
                             targetState = openPane,
                             transitionSpec = {
                                 val enteringTaskManager = targetState == DrawerPane.TASK_MANAGER
+                                val enteringLogs = targetState == DrawerPane.LOGS
                                 val returningToMenu = targetState == null
-                                if (enteringTaskManager) {
+                                if (enteringTaskManager || enteringLogs) {
                                     (
                                         slideInVertically(
                                             initialOffsetY = { it / 3 },
@@ -751,12 +840,19 @@ internal fun XServerDrawerContent(
                                         listener = listener,
                                         onClose = { onOpenPaneChange(null) },
                                     )
+                                DrawerPane.LOGS ->
+                                    LogsPaneContent(
+                                        logsState = logsState,
+                                        listener = listener,
+                                        onClose = { onOpenPaneChange(null) },
+                                    )
                                 null ->
                                     ActionCardGrid(
                                         state = state,
                                         listener = listener,
                                         cardsRevealed = cardsRevealed.value,
                                         onOpenTaskManager = { onOpenPaneChange(DrawerPane.TASK_MANAGER) },
+                                        onOpenLogs = { onOpenPaneChange(DrawerPane.LOGS) },
                                     )
                             }
                         }
@@ -997,6 +1093,7 @@ private fun ActionCardGrid(
     listener: XServerDrawerActionListener,
     cardsRevealed: Boolean,
     onOpenTaskManager: () -> Unit,
+    onOpenLogs: () -> Unit,
 ) {
     val paneScale = LocalPaneScale.current
     val cards =
@@ -1031,6 +1128,7 @@ private fun ActionCardGrid(
                     onClick = {
                         when (item.itemId) {
                             R.id.main_menu_task_manager -> onOpenTaskManager()
+                            R.id.main_menu_logs -> onOpenLogs()
                             R.id.main_menu_relative_mouse_movement,
                             R.id.main_menu_disable_mouse,
                             R.id.main_menu_toggle_fullscreen -> listener.onActionSelected(item.itemId)
@@ -2056,6 +2154,205 @@ private fun TaskManagerPaneContent(
                 listener.onTaskManagerEndProcess(process.name)
             },
         )
+    }
+}
+
+@Composable
+private fun LogsPaneContent(
+    logsState: LogsPaneState,
+    listener: XServerDrawerActionListener,
+    onClose: () -> Unit,
+) {
+    DisposableEffect(Unit) {
+        listener.onLogsPaneVisibilityChanged(true)
+        onDispose { listener.onLogsPaneVisibilityChanged(false) }
+    }
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val paneScale = computePaneScale(maxHeight)
+        CompositionLocalProvider(LocalPaneScale provides paneScale) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = (12f * paneScale).dp, vertical = (10f * paneScale).dp),
+                verticalArrangement = Arrangement.spacedBy((10f * paneScale).dp),
+            ) {
+                LogsPaneHeader(
+                    paused = logsState.paused,
+                    lineCount = logsState.lines.size,
+                    onClear = { listener.onLogsClear() },
+                    onTogglePause = { listener.onLogsPauseChanged(!logsState.paused) },
+                    onShare = { listener.onLogsShare() },
+                    onClose = onClose,
+                )
+
+                LogsPaneList(
+                    lines = logsState.lines,
+                    paused = logsState.paused,
+                    modifier = Modifier.weight(1f, fill = true).fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogsPaneHeader(
+    paused: Boolean,
+    lineCount: Int,
+    onClear: () -> Unit,
+    onTogglePause: () -> Unit,
+    onShare: () -> Unit,
+    onClose: () -> Unit,
+) {
+    val paneScale = LocalPaneScale.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy((8f * paneScale).dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.session_drawer_logs),
+                color = DrawerTextPrimary,
+                fontSize = (16f * paneScale).sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text =
+                    if (paused) {
+                        stringResource(R.string.session_drawer_logs_paused_indicator) +
+                            " · " +
+                            stringResource(R.string.session_drawer_logs_line_count, lineCount)
+                    } else {
+                        stringResource(R.string.session_drawer_logs_line_count, lineCount)
+                    },
+                color = if (paused) DrawerAccent else DrawerTextSecondary,
+                fontSize = (11f * paneScale).sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        LogsPaneActionTile(
+            icon = if (paused) Icons.Outlined.PlayArrow else Icons.Outlined.Pause,
+            contentDescription =
+                if (paused) {
+                    stringResource(R.string.session_drawer_logs_resume)
+                } else {
+                    stringResource(R.string.session_drawer_logs_pause)
+                },
+            onClick = onTogglePause,
+        )
+        LogsPaneActionTile(
+            icon = Icons.Outlined.DeleteSweep,
+            contentDescription = stringResource(R.string.session_drawer_logs_clear),
+            onClick = onClear,
+        )
+        LogsPaneActionTile(
+            icon = Icons.Outlined.Share,
+            contentDescription = stringResource(R.string.session_drawer_logs_share),
+            onClick = onShare,
+        )
+
+        Spacer(Modifier.width((16f * paneScale).dp))
+
+        TaskManagerCloseButton(onClick = onClose)
+    }
+}
+
+@Composable
+private fun LogsPaneActionTile(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    val paneScale = LocalPaneScale.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val tint by animateColorAsState(
+        targetValue = if (pressed) DrawerAccent else DrawerTextPrimary,
+        animationSpec = tween(120),
+        label = "logsActionTileTint",
+    )
+    Box(
+        modifier =
+            Modifier
+                .size((38f * paneScale).dp)
+                .clip(CircleShape)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier.size((24f * paneScale).dp),
+        )
+    }
+}
+
+@Composable
+private fun LogsPaneList(
+    lines: List<String>,
+    paused: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val paneScale = LocalPaneScale.current
+    val shape = RoundedCornerShape((10f * paneScale).dp)
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(lines.size, paused) {
+        if (!paused && lines.isNotEmpty()) {
+            listState.scrollToItem((lines.size - 1).coerceAtLeast(0))
+        }
+    }
+
+    Box(
+        modifier =
+            modifier
+                .clip(shape)
+                .background(PaneInnerResting)
+                .border(1.dp, RestingCardBorder, shape),
+    ) {
+        if (lines.isEmpty()) {
+            Text(
+                text = stringResource(R.string.common_ui_no_items_to_display),
+                color = DrawerTextSecondary,
+                fontSize = (12f * paneScale).sp,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = (24f * paneScale).dp),
+                textAlign = TextAlign.Center,
+            )
+        } else {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding =
+                    PaddingValues(
+                        horizontal = (10f * paneScale).dp,
+                        vertical = (8f * paneScale).dp,
+                    ),
+                verticalArrangement = Arrangement.spacedBy((1f * paneScale).dp),
+            ) {
+                items(lines) { line ->
+                    Text(
+                        text = line,
+                        color = DrawerTextPrimary,
+                        fontSize = (11f * paneScale).sp,
+                        fontFamily = FontFamily.Monospace,
+                        lineHeight = (14f * paneScale).sp,
+                        letterSpacing = 0.sp,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds an in-drawer session logs pane with clear, pause, and share actions.

Replaces the separate debug dialog path with streamed drawer state and a shareable log file.