### PR TITLE
Upload tag APKs to existing releases

### DIFF
--- a/.github/workflows/tag-apk-artifacts.yml
+++ b/.github/workflows/tag-apk-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -121,3 +121,15 @@ jobs:
           path: artifacts/apk/*.apk
           retention-days: 30
           if-no-files-found: error
+
+      - name: Upload APK to existing release
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" artifacts/apk/*.apk --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            echo "No release exists for $TAG_NAME; skipping release asset upload."
+          fi


### PR DESCRIPTION
Uploads tag-built APKs to an existing release for the same tag without creating a release when one is missing.

Validation:
- `git diff --check upstream/main..HEAD`