### PR TITLE
fix: keep controller services running in Aggressive and Essential modes

### DIFF
--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -1371,6 +1371,12 @@ public abstract class WineUtils {
       "Winmgmt:3",
       "wuauserv:3"
     };
+    // Services that MUST stay enabled in every startup mode so controllers keep
+    // working. PlugPlay enumerates devices, winebus is the HID bus driver,
+    // winehid is the HID protocol driver, and RpcSs is PlugPlay's RPC backbone —
+    // disabling any of them breaks gamepad input on launch.
+    final List<String> controllerCriticalServices =
+        Arrays.asList("winebus", "winehid", "PlugPlay", "RpcSs");
     File systemRegFile = new File(container.getRootDir(), ".wine/system.reg");
     byte selection = 0;
     try {
@@ -1384,17 +1390,13 @@ public abstract class WineUtils {
       for (String service : aggressiveServices) {
         String name = service.substring(0, service.indexOf(":"));
         int value = Character.getNumericValue(service.charAt(service.length() - 1));
-        if (selection == 1) {
-          if (servicesList.contains(service)
-              && !name.equals("winebus")
-              && !name.equals("winehid")
-              && !name.equals("PlugPlay")) {
+        if (controllerCriticalServices.contains(name)) {
+          value = 2;
+        } else if (selection == 1) {
+          if (servicesList.contains(service)) {
             value = 4;
           }
-        } else if (selection == 2
-            && !name.equals("winebus")
-            && !name.equals("winehid")
-            && !name.equals("PlugPlay")) {
+        } else if (selection == 2) {
           value = 4;
         }
         registryEditor.setDwordValue(


### PR DESCRIPTION
Aggressive and Essential startup modes were disabling RpcSs in the Wine service registry. PlugPlay relies on RpcSs as its RPC backbone, so even though winebus, winehid and PlugPlay were exempted from being disabled, the underlying dependency was being killed and controllers broke on launch.

changeServicesStatus() now treats winebus, winehid, PlugPlay and RpcSs as a single controller-critical set and forces them to AUTO_START in every mode. The exemption list is consolidated in one place instead of duplicated as inline string compares.