### PR TITLE
chore: Reset app build number

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
         applicationId "com.winnative.cmod"
         minSdk 26
         targetSdk 28
-        versionCode 21
+        versionCode 1
         versionName appVersionName
 
         externalNativeBuild {


### PR DESCRIPTION
## What changed
Reset the Android app `versionCode` from 21 to 1 in `app/build.gradle`.

## Why
This resets the app build number to 1 for the next build series.

## Validation
- `./gradlew.bat :app:tasks --all`
- `./gradlew.bat :app:processStandardDebugMainManifest`