### PR TITLE
fix: Show full EXE paths in game settings

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -10373,23 +10373,16 @@ class UnifiedActivity :
                                 Icon(Icons.Outlined.FolderOpen, contentDescription = null, tint = Accent, modifier = Modifier.size(16.dp))
                                 Spacer(Modifier.width(8.dp))
                                 Text(
-                                    if (selectedExePath == null) "Select Executable (.exe)" else java.io.File(selectedExePath!!).name,
+                                    selectedExePath ?: "Select Executable (.exe)",
                                     color = if (selectedExePath == null) TextSecondary else TextPrimary,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    fontSize = 12.sp,
+                                    maxLines = if (selectedExePath == null) 1 else Int.MAX_VALUE,
+                                    overflow = if (selectedExePath == null) TextOverflow.Ellipsis else TextOverflow.Visible,
+                                    fontSize = if (selectedExePath == null) 12.sp else 10.sp,
+                                    modifier = Modifier.weight(1f),
                                 )
                             }
 
                             if (selectedExePath != null) {
-                                Spacer(Modifier.height(4.dp))
-                                Text(
-                                    selectedExePath!!,
-                                    color = TextSecondary.copy(alpha = 0.6f),
-                                    fontSize = 9.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
 
                                 Spacer(Modifier.height(8.dp))
 

--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -195,6 +195,7 @@ class GameSettingsStateHolder {
     // General
     val name = mutableStateOf("")
     val launchExePath = mutableStateOf("")
+    val launchExeDisplayPath = mutableStateOf("")
     val containerEntries = mutableStateOf<List<String>>(emptyList())
     val selectedContainer = mutableIntStateOf(0)
     val screenSizeEntries = mutableStateOf<List<String>>(emptyList())
@@ -864,6 +865,8 @@ private fun GeneralSection(
         )
 
         if (!isContainer) {
+            val launchExeDisplayText = state.launchExeDisplayPath.value.ifBlank { state.launchExePath.value }
+            val hasLaunchExePath = launchExeDisplayText.isNotEmpty()
             Spacer(Modifier.height(SettingItemGap))
             Text(
                 stringResource(R.string.common_ui_select_exe),
@@ -882,10 +885,11 @@ private fun GeneralSection(
                     .padding(horizontal = SettingFieldHorizontalPadding, vertical = SettingFieldVerticalPadding)
             ) {
                 Text(
-                    text = state.launchExePath.value.ifEmpty { stringResource(R.string.common_ui_select_exe) },
-                    color = if (state.launchExePath.value.isEmpty()) TextDim else TextPrimary,
-                    fontSize = SettingValueSize,
-                    maxLines = 1
+                    text = launchExeDisplayText.ifEmpty { stringResource(R.string.common_ui_select_exe) },
+                    color = if (hasLaunchExePath) TextPrimary else TextDim,
+                    fontSize = if (hasLaunchExePath) 10.sp else SettingValueSize,
+                    maxLines = if (hasLaunchExePath) Int.MAX_VALUE else 1,
+                    overflow = if (hasLaunchExePath) TextOverflow.Visible else TextOverflow.Ellipsis
                 )
             }
         }

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -346,6 +346,7 @@ class ShortcutSettingsComposeDialog private constructor(
         // General
         state.name.value = shortcut.name
         state.launchExePath.value = resolveInitialLaunchExePath()
+        state.launchExeDisplayPath.value = resolveLaunchExeDisplayPath(state.launchExePath.value)
         syncLibraryArtworkState()
 
         // Input
@@ -1363,20 +1364,27 @@ class ShortcutSettingsComposeDialog private constructor(
     }
 
     private fun resolveInitialLaunchExePath(): String {
-        val storedPath = shortcut.getExtra("launch_exe_path")
-        if (storedPath.isNotEmpty()) return storedPath
-
         val gameSource = shortcut.getExtra("game_source", "")
         if (gameSource == "CUSTOM") {
             val customExe = shortcut.getExtra("custom_exe")
             if (customExe.isNotEmpty()) return customExe
         }
 
+        val storedPath = shortcut.getExtra("launch_exe_path")
+        if (storedPath.isNotEmpty()) return storedPath
+
         return ""
     }
 
     private fun resolveExePickerInitialPath(): String? {
-        val currentPath = state.launchExePath.value.ifBlank { shortcut.getExtra("launch_exe_path") }
+        val currentPath =
+            state.launchExePath.value.ifBlank {
+                if (shortcut.getExtra("game_source", "") == "CUSTOM") {
+                    shortcut.getExtra("custom_exe").ifBlank { shortcut.getExtra("launch_exe_path") }
+                } else {
+                    shortcut.getExtra("launch_exe_path")
+                }
+            }
         if (currentPath.isBlank()) {
             return shortcut.getExtra("game_install_path")
                 .takeIf { it.isNotBlank() && File(it).isDirectory }
@@ -1404,6 +1412,7 @@ class ShortcutSettingsComposeDialog private constructor(
             } else {
                 exeFile.absolutePath
             }
+        state.launchExeDisplayPath.value = exeFile.absolutePath
     }
 
     private fun normalizeLaunchExeForShortcut(path: String): String {
@@ -1433,6 +1442,20 @@ class ShortcutSettingsComposeDialog private constructor(
         }
 
         return directFile
+    }
+
+    private fun resolveLaunchExeDisplayPath(path: String): String {
+        if (path.isBlank()) return ""
+
+        val directFile = File(path)
+        if (directFile.isAbsolute) return directFile.absolutePath
+
+        val installPath = shortcut.getExtra("game_install_path")
+        if (installPath.isNotBlank()) {
+            return File(installPath, path.replace("\\", File.separator)).absolutePath
+        }
+
+        return path
     }
 
     private fun relativePathWithinGameInstall(file: File): String? {


### PR DESCRIPTION
- Show selected custom game EXE paths as full paths in the add custom game picker.
- Display resolved full EXE paths in game settings without changing saved launch path values.
- Prefer custom game executable metadata when showing custom game EXE selections.
- Validated with `./gradlew.bat :app:compileStandardDebugKotlin`.