### PR TITLE
Fix HyperOS Vulkan ICD dependency preload

### DIFF
--- a/app/src/main/cpp/winlator/vulkan.c
+++ b/app/src/main/cpp/winlator/vulkan.c
@@ -169,20 +169,29 @@ static char *get_library_name(JNIEnv *env, jobject context,
   return library_name;
 }
 
+static void preload_first_existing(const char **candidates) {
+  for (int i = 0; candidates[i]; i++) {
+    if (dlopen(candidates[i], RTLD_GLOBAL | RTLD_NOW))
+      return;
+  }
+}
+
 static void preload_vendor_icd_deps() {
-  // Some OEM Vulkan ICDs (e.g. Samsung's /system_ext/lib64/libvendorutils.so)
-  // declare unresolved refs to OpenSSL symbols like BIO_flush. When the Android
-  // Vulkan loader pulls in the vendor ICD via dlopen, those symbols must already
-  // be visible in a preceding RTLD_GLOBAL library or the dlopen fails with
-  // "cannot locate symbol BIO_flush", and vkCreateInstance returns -9.
-  const char *candidates[] = {
+  // Keep OEM Vulkan ICD dependencies globally visible before the loader pulls
+  // them in, or DXVK can misreport missing VK_KHR_surface.
+  const char *jpeg_candidates[] = {
+      "/system/lib64/libjpeg.so",
+      "/system_ext/lib64/libjpeg.so",
+      "libjpeg.so",
+      NULL,
+  };
+  preload_first_existing(jpeg_candidates);
+
+  const char *crypto_candidates[] = {
       "libcrypto.so",
       NULL,
   };
-  for (int i = 0; candidates[i]; i++) {
-    if (dlopen(candidates[i], RTLD_GLOBAL | RTLD_NOW))
-      break;
-  }
+  preload_first_existing(crypto_candidates);
 }
 
 static void init_original_vulkan() {
@@ -194,6 +203,8 @@ static void init_vulkan(JNIEnv *env, jobject context, const char *driver_name) {
   char *tmpdir = NULL;
   char *library_name = NULL;
   char *native_library_dir = NULL;
+
+  preload_vendor_icd_deps();
 
   const char *driver_path = get_driver_path(env, context, driver_name);
 

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -624,6 +624,15 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     return baseValue + ":" + overrideValue;
   }
 
+  private static String appendFirstExistingPreload(String ldPreload, File[] candidates) {
+    for (File candidate : candidates) {
+      if (candidate.exists()) {
+        return mergePreloadValue(ldPreload, candidate.getAbsolutePath());
+      }
+    }
+    return ldPreload;
+  }
+
   private void mergeExternalEnvVars(
       EnvVars envVars,
       String protectedLdPreload,
@@ -943,27 +952,20 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
       ld_preload = ld_preload + fakeinputDest.getAbsolutePath();
     }
 
-    // Samsung and some other OEMs ship a Vulkan ICD dep chain ending in
-    // /system_ext/lib64/libvendorutils.so that references OpenSSL's BIO_flush.
-    // Without libcrypto already mapped, vkCreateInstance fails with res=-9 and
-    // DXVK aborts with "Required Vulkan extension VK_KHR_surface not supported".
-    //
-    // Only /system and /system_ext are in the default linker namespace's
-    // permitted_paths; the conscrypt APEX is not, so preloading from it
-    // blocks the whole execve with a linker namespace error. Fall back to
-    // the imagefs copy as a last resort.
+    // Preload OEM Vulkan ICD deps that otherwise fail lazy symbol resolution.
+    // Keep paths within default linker namespace permitted_paths.
+    File[] jpegCandidates = new File[] {
+        new File("/system/lib64/libjpeg.so"),
+        new File("/system_ext/lib64/libjpeg.so"),
+    };
+    ld_preload = appendFirstExistingPreload(ld_preload, jpegCandidates);
+
     File[] cryptoCandidates = new File[] {
         new File("/system/lib64/libcrypto.so"),
         new File("/system_ext/lib64/libcrypto.so"),
         new File(imageFs.getLibDir(), "libcrypto.so.3"),
     };
-    for (File c : cryptoCandidates) {
-      if (c.exists()) {
-        if (!ld_preload.isEmpty()) ld_preload = ld_preload + ":";
-        ld_preload = ld_preload + c.getAbsolutePath();
-        break;
-      }
-    }
+    ld_preload = appendFirstExistingPreload(ld_preload, cryptoCandidates);
 
     File devInputDir = new File(imageFs.getRootDir(), "dev/input");
     devInputDir.mkdirs();


### PR DESCRIPTION
Preloads system libjpeg before Vulkan ICD loading so HyperOS 3's libjpeg-hyper dependency can resolve jsimd symbols when using AdrenoTools/Turnip.

Keeps the existing libcrypto preload behavior through the same first-existing helper for app-side Vulkan probing and guest launch.

Validation: git diff --check passes. Full Android build could not run locally because no Android SDK path is configured.