### PR TITLE
fix: Update store game UI and steam dlc downloading

### DIFF
--- a/app/src/main/app/db/PluviaDatabase.kt
+++ b/app/src/main/app/db/PluviaDatabase.kt
@@ -43,7 +43,7 @@ const val DATABASE_NAME = "pluvia_database"
         DownloadingAppInfo::class,
         DownloadRecord::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/app/db/download/DownloadRecord.kt
+++ b/app/src/main/app/db/download/DownloadRecord.kt
@@ -32,6 +32,9 @@ data class DownloadRecord(
     val selectedDlcs: String = "",
     @ColumnInfo("language")
     val language: String = "",
+    /** One of: INSTALL, UPDATE, VERIFY. */
+    @ColumnInfo("task_type")
+    val taskType: String = TASK_INSTALL,
     /** One of: QUEUED, DOWNLOADING, PAUSED, COMPLETE, CANCELLED, FAILED. */
     @ColumnInfo("status")
     val status: String = STATUS_QUEUED,
@@ -50,6 +53,10 @@ data class DownloadRecord(
         const val STORE_STEAM = "STEAM"
         const val STORE_EPIC = "EPIC"
         const val STORE_GOG = "GOG"
+
+        const val TASK_INSTALL = "INSTALL"
+        const val TASK_UPDATE = "UPDATE"
+        const val TASK_VERIFY = "VERIFY"
 
         const val STATUS_QUEUED = "QUEUED"
         const val STATUS_DOWNLOADING = "DOWNLOADING"

--- a/app/src/main/app/service/DownloadService.kt
+++ b/app/src/main/app/service/DownloadService.kt
@@ -116,9 +116,22 @@ object DownloadService {
         // (PAUSED or QUEUED) for which no store has yet created an in-memory DownloadInfo.
         // Fabricate stub DownloadInfos for those so the Downloads tab shows them and the user
         // can Resume / Cancel them.
-        val knownIds = list.map { it.first }.toSet()
         val coord = com.winlator.cmod.app.service.download.DownloadCoordinator
-        coord.snapshotRecords().forEach { record ->
+        val records = coord.snapshotRecords()
+        val recordsByUiId = records.associateBy { "${it.store}_${it.storeGameId}" }
+        list.forEach { (id, info) ->
+            val record = recordsByUiId[id] ?: return@forEach
+            if (record.bytesTotal > 0L) {
+                info.setDisplayTotalExpectedBytes(record.bytesTotal)
+                if (info.getTotalExpectedBytes() <= 0L) {
+                    info.setTotalExpectedBytes(record.bytesTotal)
+                    info.initializeBytesDownloaded(record.bytesDownloaded)
+                }
+            }
+        }
+
+        val knownIds = list.map { it.first }.toSet()
+        records.forEach { record ->
             val id = "${record.store}_${record.storeGameId}"
             if (id in knownIds) return@forEach
             val phase = mapRecordStatusToPhase(record.status)
@@ -138,6 +151,7 @@ object DownloadService {
                     )
                     if (record.bytesTotal > 0L) {
                         setTotalExpectedBytes(record.bytesTotal)
+                        setDisplayTotalExpectedBytes(record.bytesTotal)
                         initializeBytesDownloaded(record.bytesDownloaded)
                     }
                 }

--- a/app/src/main/app/service/download/DownloadCoordinator.kt
+++ b/app/src/main/app/service/download/DownloadCoordinator.kt
@@ -118,6 +118,7 @@ object DownloadCoordinator {
         installPath: String = "",
         selectedDlcs: String = "",
         language: String = "",
+        taskType: String = DownloadRecord.TASK_INSTALL,
         bytesTotal: Long = 0L,
     ): Decision {
         val daoRef = dao ?: throw IllegalStateException("DownloadCoordinator not initialised")
@@ -157,6 +158,7 @@ object DownloadCoordinator {
                             installPath = installPath,
                             selectedDlcs = selectedDlcs,
                             language = language,
+                            taskType = taskType,
                             bytesTotal = bytesTotal,
                             status = status,
                             createdAt = now,
@@ -180,6 +182,7 @@ object DownloadCoordinator {
                             installPath = installPath,
                             selectedDlcs = selectedDlcs,
                             language = language,
+                            taskType = taskType,
                             bytesTotal = if (bytesTotal > 0L) bytesTotal else existing.bytesTotal,
                             status = status,
                             errorMessage = null,

--- a/app/src/main/app/shell/LibraryGameLaunchScreen.kt
+++ b/app/src/main/app/shell/LibraryGameLaunchScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -66,11 +67,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
 import coil.compose.AsyncImage
@@ -449,6 +453,26 @@ private fun LaunchUninstallMenu(
             appName,
         )
 
+    LaunchDangerConfirmMenu(
+        expanded = expanded,
+        title = title,
+        message = message,
+        confirmLabel = confirmLabel,
+        onDismissRequest = onDismissRequest,
+        onConfirm = onConfirm,
+    )
+}
+
+@Composable
+internal fun LaunchDangerConfirmMenu(
+    expanded: Boolean,
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+    icon: ImageVector = Icons.Outlined.Delete,
+) {
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismissRequest,
@@ -472,7 +496,7 @@ private fun LaunchUninstallMenu(
                 horizontalArrangement = Arrangement.spacedBy(9.dp),
             ) {
                 Icon(
-                    Icons.Outlined.Delete,
+                    icon,
                     contentDescription = null,
                     tint = LaunchDanger,
                     modifier = Modifier.size(18.dp),
@@ -508,6 +532,160 @@ private fun LaunchUninstallMenu(
                     onClick = onConfirm,
                 )
             }
+        }
+    }
+}
+
+@Composable
+internal fun LaunchDangerConfirmDialog(
+    visible: Boolean,
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+    icon: ImageVector = Icons.Outlined.Warning,
+    titleTextAlign: TextAlign = TextAlign.Start,
+    messageTextAlign: TextAlign = TextAlign.Start,
+) {
+    if (!visible) return
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(LaunchBlack.copy(alpha = 0.46f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onDismissRequest,
+                    ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier =
+                    Modifier
+                        .width(286.dp)
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { },
+                        ),
+                shape = RoundedCornerShape(12.dp),
+                color = LaunchCard,
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.14f)),
+                shadowElevation = 14.dp,
+                tonalElevation = 0.dp,
+            ) {
+                LaunchDangerConfirmContent(
+                    title = title,
+                    message = message,
+                    confirmLabel = confirmLabel,
+                    onDismissRequest = onDismissRequest,
+                    onConfirm = onConfirm,
+                    icon = icon,
+                    titleTextAlign = titleTextAlign,
+                    messageTextAlign = messageTextAlign,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LaunchDangerConfirmContent(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+    icon: ImageVector,
+    titleTextAlign: TextAlign,
+    messageTextAlign: TextAlign,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (titleTextAlign == TextAlign.Center) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = LaunchDanger,
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterStart)
+                            .size(18.dp),
+                )
+                Text(
+                    title,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 28.dp),
+                    color = LaunchTextPrimary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(9.dp),
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = LaunchDanger,
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    title,
+                    color = LaunchTextPrimary,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        Text(
+            message,
+            modifier = Modifier.fillMaxWidth(),
+            color = LaunchTextSecondary,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+            textAlign = messageTextAlign,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            LaunchMenuTextAction(
+                label = stringResource(R.string.common_ui_cancel),
+                textColor = LaunchTextSecondary,
+                onClick = onDismissRequest,
+            )
+            LaunchMenuTextAction(
+                label = confirmLabel,
+                textColor = LaunchDanger,
+                onClick = onConfirm,
+            )
         }
     }
 }

--- a/app/src/main/app/shell/StoreGameDetailScreen.kt
+++ b/app/src/main/app/shell/StoreGameDetailScreen.kt
@@ -116,6 +116,7 @@ internal fun StoreGameDetailScreen(
     installSize: Long,
     availableBytes: Long,
     isInstallEnabled: Boolean,
+    isDownloadActionEnabled: Boolean = isInstallEnabled,
     customPathLabel: String,
     showCustomPath: Boolean = true,
     showCloudSync: Boolean = false,
@@ -129,6 +130,7 @@ internal fun StoreGameDetailScreen(
     isUpdateCheckCoolingDown: Boolean = false,
     dlcs: List<StoreDlcItem> = emptyList(),
     selectedDlcIds: Set<Int> = emptySet(),
+    isDlcSelectionEnabled: Boolean = true,
     onBack: () -> Unit,
     onInstall: () -> Unit = {},
     onCheckForUpdate: () -> Unit = {},
@@ -371,7 +373,7 @@ internal fun StoreGameDetailScreen(
                                     height = ctaHeight,
                                     icon = Icons.Outlined.Download,
                                     label = stringResource(R.string.common_ui_download),
-                                    enabled = !isLoading && isInstallEnabled,
+                                    enabled = !isLoading && isDownloadActionEnabled,
                                     loading = isLoading,
                                     onClick = onInstall,
                                 )
@@ -482,6 +484,7 @@ internal fun StoreGameDetailScreen(
                 StoreDlcCard(
                     dlcs = dlcs,
                     selectedDlcIds = selectedDlcIds,
+                    selectionEnabled = isDlcSelectionEnabled,
                     expanded = dlcExpanded,
                     onToggleExpanded = { dlcExpanded = !dlcExpanded },
                     onToggleDlc = onToggleDlc,
@@ -496,6 +499,7 @@ internal fun StoreGameDetailScreen(
 private fun StoreDlcCard(
     dlcs: List<StoreDlcItem>,
     selectedDlcIds: Set<Int>,
+    selectionEnabled: Boolean,
     expanded: Boolean,
     onToggleExpanded: () -> Unit,
     onToggleDlc: (Int) -> Unit,
@@ -578,13 +582,14 @@ private fun StoreDlcCard(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable(onClick = onToggleSelectAll)
+                                    .clickable(enabled = selectionEnabled, onClick = onToggleSelectAll)
                                     .padding(horizontal = 8.dp, vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Checkbox(
                                 checked = allSelected,
                                 onCheckedChange = { onToggleSelectAll() },
+                                enabled = selectionEnabled,
                                 colors =
                                     CheckboxDefaults.colors(
                                         checkedColor = StoreAccent,
@@ -626,6 +631,8 @@ private fun StoreDlcCard(
                                         .then(
                                             if (dlc.isInstalled) {
                                                 Modifier
+                                            } else if (!selectionEnabled) {
+                                                Modifier
                                             } else {
                                                 Modifier.clickable { onToggleDlc(dlc.id) }
                                             },
@@ -650,6 +657,7 @@ private fun StoreDlcCard(
                                     Checkbox(
                                         checked = dlc.id in selectedDlcIds,
                                         onCheckedChange = { onToggleDlc(dlc.id) },
+                                        enabled = selectionEnabled,
                                         colors =
                                             CheckboxDefaults.colors(
                                                 checkedColor = StoreAccent,

--- a/app/src/main/app/shell/StoreGameDetailScreen.kt
+++ b/app/src/main/app/shell/StoreGameDetailScreen.kt
@@ -1,0 +1,837 @@
+package com.winlator.cmod.app.shell
+
+import android.os.Build
+import android.view.WindowManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.CloudSync
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Extension
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.SportsEsports
+import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import com.winlator.cmod.R
+import com.winlator.cmod.shared.io.StorageUtils
+
+internal data class StoreDlcItem(
+    val id: Int,
+    val name: String,
+    val downloadSize: Long,
+)
+
+private val StoreBlack = Color.Black
+private val StoreCard = Color(0xFF12121B)
+private val StoreAccent = Color(0xFF1A9FFF)
+private val StoreAccentGlow = Color(0xFF58A6FF)
+private val StoreTextPrimary = Color(0xFFF0F4FF)
+private val StoreTextSecondary = Color(0xFF93A6BC)
+private val StoreDanger = Color(0xFFFF6B6B)
+
+@Composable
+internal fun StoreGameDetailScreen(
+    title: String,
+    subtitle: String,
+    sourceLabel: String,
+    heroImageUrl: Any?,
+    isLoading: Boolean,
+    isInstalled: Boolean,
+    installPathDisplay: String,
+    downloadSize: Long,
+    installSize: Long,
+    availableBytes: Long,
+    isInstallEnabled: Boolean,
+    customPathLabel: String,
+    showCustomPath: Boolean = true,
+    showCloudSync: Boolean = false,
+    showUninstall: Boolean = true,
+    dlcs: List<StoreDlcItem> = emptyList(),
+    selectedDlcIds: Set<Int> = emptySet(),
+    onBack: () -> Unit,
+    onPlay: () -> Unit = {},
+    onInstall: () -> Unit = {},
+    onUninstall: () -> Unit = {},
+    onCloudSync: () -> Unit = {},
+    onCustomPath: () -> Unit = {},
+    onToggleDlc: (Int) -> Unit = {},
+    onToggleSelectAllDlcs: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    var dlcExpanded by remember { mutableStateOf(false) }
+
+    StoreScreenCutoutMode()
+
+    Box(Modifier.fillMaxSize()) {
+        val edgePadding = 22.dp
+        val bottomPadding = 20.dp
+        val actionIconSize = 48.dp
+        val actionIconSpacing = 8.dp
+        val actionWidth = actionIconSize * 5 + actionIconSpacing * 4
+        val ctaHeight = 56.dp
+        val contentGap = 18.dp
+        val horizontalNavInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
+
+        if (heroImageUrl != null) {
+            val heroRequest =
+                remember(heroImageUrl, context) {
+                    ImageRequest
+                        .Builder(context)
+                        .data(heroImageUrl)
+                        .crossfade(150)
+                        .memoryCachePolicy(CachePolicy.ENABLED)
+                        .diskCachePolicy(CachePolicy.ENABLED)
+                        .build()
+                }
+            AsyncImage(
+                model = heroRequest,
+                contentDescription = "$title artwork",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.Center,
+            )
+        } else {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.radialGradient(
+                            colors = listOf(StoreAccent.copy(alpha = 0.34f), StoreCard, StoreBlack),
+                            radius = 980f,
+                        ),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Outlined.SportsEsports,
+                    contentDescription = null,
+                    tint = StoreTextPrimary.copy(alpha = 0.18f),
+                    modifier = Modifier.size(132.dp),
+                )
+            }
+        }
+
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.horizontalGradient(
+                        colorStops =
+                            arrayOf(
+                                0.0f to StoreBlack.copy(alpha = 0.9f),
+                                0.36f to StoreBlack.copy(alpha = 0.58f),
+                                0.72f to StoreBlack.copy(alpha = 0.18f),
+                                1.0f to StoreBlack.copy(alpha = 0.62f),
+                            ),
+                    ),
+                ),
+        )
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops =
+                            arrayOf(
+                                0.0f to StoreBlack.copy(alpha = 0.54f),
+                                0.36f to Color.Transparent,
+                                0.72f to StoreBlack.copy(alpha = 0.32f),
+                                1.0f to StoreBlack.copy(alpha = 0.94f),
+                            ),
+                    ),
+                ),
+        )
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(horizontalNavInsets)
+                    .padding(start = edgePadding, top = 12.dp, end = edgePadding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = onBack,
+                modifier =
+                    Modifier
+                        .size(54.dp)
+                        .clip(CircleShape)
+                        .background(StoreBlack.copy(alpha = 0.5f))
+                        .border(1.dp, Color.White.copy(alpha = 0.18f), CircleShape),
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = stringResource(R.string.common_ui_back),
+                    tint = StoreTextPrimary,
+                    modifier = Modifier.size(30.dp),
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            StoreSourceTag(sourceLabel = sourceLabel)
+        }
+
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .padding(start = edgePadding, top = 68.dp, end = edgePadding, bottom = bottomPadding),
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Column(
+                    modifier = Modifier.widthIn(max = 640.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        title,
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = StoreTextPrimary,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (subtitle.isNotBlank()) {
+                        Text(
+                            subtitle,
+                            style = MaterialTheme.typography.titleSmall,
+                            color = StoreTextPrimary.copy(alpha = 0.72f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(contentGap))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(contentGap),
+                    verticalAlignment = Alignment.Bottom,
+                ) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        if (isLoading) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    color = StoreAccent,
+                                    strokeWidth = 2.dp,
+                                )
+                                Text(
+                                    stringResource(R.string.common_ui_loading),
+                                    color = StoreTextSecondary,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                        } else if (isInstalled) {
+                            StoreStatChip(
+                                icon = Icons.Outlined.Storage,
+                                label = stringResource(R.string.library_games_install_path),
+                                value = installPathDisplay,
+                            )
+                        } else {
+                            if (downloadSize > 0L) {
+                                StoreStatChip(
+                                    icon = Icons.Outlined.Download,
+                                    label = stringResource(R.string.common_ui_download),
+                                    value = StorageUtils.formatBinarySize(downloadSize),
+                                )
+                            }
+                            if (installSize > 0L) {
+                                StoreStatChip(
+                                    icon = Icons.Outlined.Storage,
+                                    label = stringResource(R.string.common_ui_size),
+                                    value = StorageUtils.formatBinarySize(installSize),
+                                    valueColor = if (!isInstallEnabled) StoreDanger else null,
+                                )
+                            }
+                            if (availableBytes > 0L) {
+                                StoreStatChip(
+                                    icon = Icons.Outlined.Folder,
+                                    label = stringResource(R.string.common_ui_available),
+                                    value = StorageUtils.formatBinarySize(availableBytes),
+                                    valueColor = if (!isInstallEnabled) StoreDanger else null,
+                                )
+                            }
+                        }
+                    }
+
+                    Column(
+                        modifier = Modifier.width(actionWidth),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        if (isInstalled) {
+                            StoreCtaButton(
+                                height = ctaHeight,
+                                icon = Icons.Outlined.PlayArrow,
+                                label = stringResource(R.string.library_games_play),
+                                enabled = true,
+                                loading = false,
+                                onClick = onPlay,
+                            )
+                        } else {
+                            StoreCtaButton(
+                                height = ctaHeight,
+                                icon = Icons.Outlined.Download,
+                                label = stringResource(R.string.common_ui_download),
+                                enabled = !isLoading && isInstallEnabled,
+                                loading = isLoading,
+                                onClick = onInstall,
+                            )
+                        }
+
+                        if (!isInstalled && !isLoading && !isInstallEnabled && installSize > 0L) {
+                            val deficit = (installSize - availableBytes).coerceAtLeast(0L)
+                            if (deficit > 0L) {
+                                Text(
+                                    stringResource(
+                                        R.string.library_games_not_enough_space,
+                                        StorageUtils.formatBinarySize(deficit),
+                                    ),
+                                    color = StoreDanger,
+                                    fontSize = 11.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
+                            verticalAlignment = Alignment.Top,
+                        ) {
+                            if (showCustomPath && !isInstalled) {
+                                StoreIconActionButton(
+                                    icon = Icons.Outlined.Folder,
+                                    contentDescription = customPathLabel,
+                                    size = actionIconSize,
+                                    onClick = onCustomPath,
+                                )
+                            }
+                            if (showCloudSync && isInstalled) {
+                                StoreIconActionButton(
+                                    icon = Icons.Outlined.CloudSync,
+                                    contentDescription = stringResource(R.string.cloud_saves_title),
+                                    size = actionIconSize,
+                                    onClick = onCloudSync,
+                                )
+                            }
+                            if (showUninstall && isInstalled) {
+                                StoreIconActionButton(
+                                    icon = Icons.Outlined.Delete,
+                                    contentDescription = stringResource(R.string.common_ui_uninstall),
+                                    size = actionIconSize,
+                                    onClick = onUninstall,
+                                    tint = StoreDanger,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!isInstalled && dlcs.isNotEmpty()) {
+                Spacer(Modifier.height(12.dp))
+                StoreDlcCard(
+                    dlcs = dlcs,
+                    selectedDlcIds = selectedDlcIds,
+                    expanded = dlcExpanded,
+                    onToggleExpanded = { dlcExpanded = !dlcExpanded },
+                    onToggleDlc = onToggleDlc,
+                    onToggleSelectAll = onToggleSelectAllDlcs,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreDlcCard(
+    dlcs: List<StoreDlcItem>,
+    selectedDlcIds: Set<Int>,
+    expanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    onToggleDlc: (Int) -> Unit,
+    onToggleSelectAll: () -> Unit,
+) {
+    val totalSize = remember(dlcs) { dlcs.sumOf { it.downloadSize.coerceAtLeast(0L) } }
+    val selectedCount = dlcs.count { it.id in selectedDlcIds }
+    val selectedSize = remember(dlcs, selectedDlcIds) {
+        dlcs.filter { it.id in selectedDlcIds }.sumOf { it.downloadSize.coerceAtLeast(0L) }
+    }
+    val allSelected = dlcs.isNotEmpty() && selectedCount == dlcs.size
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = StoreBlack.copy(alpha = 0.62f),
+        shape = RoundedCornerShape(14.dp),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onToggleExpanded)
+                        .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    Icons.Outlined.Extension,
+                    contentDescription = null,
+                    tint = StoreAccentGlow,
+                    modifier = Modifier.size(20.dp),
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Text(
+                        stringResource(R.string.library_games_dlcs).uppercase(),
+                        color = StoreTextSecondary,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.8.sp,
+                    )
+                    Text(
+                        buildDlcSummary(
+                            selectedCount = selectedCount,
+                            totalCount = dlcs.size,
+                            selectedSize = selectedSize,
+                            totalSize = totalSize,
+                        ),
+                        color = StoreTextPrimary,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Icon(
+                    if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                    contentDescription = null,
+                    tint = StoreTextPrimary,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Column {
+                    HorizontalDivider(color = Color.White.copy(alpha = 0.08f), thickness = 0.5.dp)
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable(onClick = onToggleSelectAll)
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = allSelected,
+                            onCheckedChange = { onToggleSelectAll() },
+                            colors =
+                                CheckboxDefaults.colors(
+                                    checkedColor = StoreAccent,
+                                    uncheckedColor = StoreTextSecondary,
+                                    checkmarkColor = Color.White,
+                                ),
+                        )
+                        Text(
+                            stringResource(
+                                if (allSelected) R.string.common_ui_deselect_all else R.string.common_ui_select_all,
+                            ),
+                            color = StoreTextPrimary,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    HorizontalDivider(color = Color.White.copy(alpha = 0.08f), thickness = 0.5.dp)
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 280.dp)
+                                .verticalScroll(rememberScrollState()),
+                    ) {
+                        dlcs.forEachIndexed { index, dlc ->
+                            if (index > 0) {
+                                HorizontalDivider(
+                                    color = Color.White.copy(alpha = 0.06f),
+                                    thickness = 0.5.dp,
+                                    modifier = Modifier.padding(horizontal = 12.dp),
+                                )
+                            }
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable { onToggleDlc(dlc.id) }
+                                        .padding(horizontal = 8.dp, vertical = 2.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Checkbox(
+                                    checked = dlc.id in selectedDlcIds,
+                                    onCheckedChange = { onToggleDlc(dlc.id) },
+                                    colors =
+                                        CheckboxDefaults.colors(
+                                            checkedColor = StoreAccent,
+                                            uncheckedColor = StoreTextSecondary,
+                                            checkmarkColor = Color.White,
+                                        ),
+                                )
+                                Text(
+                                    dlc.name,
+                                    color = StoreTextPrimary,
+                                    fontSize = 13.sp,
+                                    modifier = Modifier.weight(1f),
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Text(
+                                    if (dlc.downloadSize > 0L) StorageUtils.formatBinarySize(dlc.downloadSize) else "—",
+                                    color = StoreTextSecondary,
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier.padding(horizontal = 10.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun buildDlcSummary(
+    selectedCount: Int,
+    totalCount: Int,
+    selectedSize: Long,
+    totalSize: Long,
+): String {
+    val totalSizeStr = if (totalSize > 0L) StorageUtils.formatBinarySize(totalSize) else null
+    val selectedSizeStr = if (selectedSize > 0L) StorageUtils.formatBinarySize(selectedSize) else null
+    return when {
+        selectedCount == 0 && totalSizeStr != null -> "$totalCount available · $totalSizeStr total"
+        selectedCount == 0 -> "$totalCount available"
+        selectedSizeStr != null && totalSizeStr != null ->
+            "$selectedCount of $totalCount · $selectedSizeStr / $totalSizeStr"
+        else -> "$selectedCount of $totalCount selected"
+    }
+}
+
+@Composable
+private fun StoreSourceTag(sourceLabel: String) {
+    Surface(
+        color = Color.White.copy(alpha = 0.1f),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.14f)),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(StoreAccent),
+            )
+            Text(
+                sourceLabel.uppercase(),
+                color = StoreTextPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StoreStatChip(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    valueColor: Color? = null,
+) {
+    Surface(
+        color = StoreBlack.copy(alpha = 0.44f),
+        shape = RoundedCornerShape(12.dp),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.11f)),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp),
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(16.dp), tint = StoreAccentGlow)
+            Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                Text(
+                    label.uppercase(),
+                    color = StoreTextSecondary,
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    value,
+                    color = valueColor ?: StoreTextPrimary,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreCtaButton(
+    height: Dp,
+    icon: ImageVector,
+    label: String,
+    enabled: Boolean,
+    loading: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed && enabled) 0.96f else 1f,
+        animationSpec = spring(dampingRatio = 0.5f, stiffness = 600f),
+        label = "storeCtaScale",
+    )
+    val shape = remember { RoundedCornerShape(12.dp) }
+    val activeBrush =
+        Brush.horizontalGradient(
+            colors = listOf(Color(0xFF00B4D8), StoreAccent, Color(0xFF7B2FF7)),
+        )
+    val disabledBrush =
+        Brush.horizontalGradient(
+            colors = listOf(Color(0xFF3A3A4A), Color(0xFF2A2A36)),
+        )
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(height)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }.clip(shape)
+                .background(if (enabled) activeBrush else disabledBrush)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = { if (enabled && !loading) onClick() },
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(26.dp),
+                color = Color.White,
+                strokeWidth = 2.dp,
+            )
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = Color.White,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    label,
+                    color = Color.White,
+                    fontSize = 19.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreIconActionButton(
+    icon: ImageVector,
+    contentDescription: String,
+    size: Dp,
+    onClick: () -> Unit,
+    tint: Color = Color.White,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Surface(
+            modifier =
+                Modifier
+                    .size(size)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(onClick = onClick),
+            color = StoreBlack.copy(alpha = 0.46f),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, tint.copy(alpha = 0.18f)),
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Icon(
+                    icon,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(28.dp),
+                    tint = tint,
+                )
+            }
+        }
+        Text(
+            contentDescription,
+            color = tint.copy(alpha = 0.85f),
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = size + 12.dp),
+        )
+    }
+}
+
+@Composable
+private fun StoreScreenCutoutMode() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val window =
+            (view.parent as? DialogWindowProvider)?.window
+                ?: return@DisposableEffect onDispose { }
+
+        val originalCutoutMode = window.attributes.layoutInDisplayCutoutMode
+        val originalWidth = window.attributes.width
+        val originalHeight = window.attributes.height
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.setLayout(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+        )
+        window.attributes =
+            window.attributes.apply {
+                layoutInDisplayCutoutMode = storeCutoutMode()
+            }
+
+        onDispose {
+            window.attributes =
+                window.attributes.apply {
+                    layoutInDisplayCutoutMode = originalCutoutMode
+                }
+            WindowCompat.setDecorFitsSystemWindows(window, true)
+            window.setLayout(originalWidth, originalHeight)
+        }
+    }
+}
+
+private fun storeCutoutMode(): Int =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+    } else {
+        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+    }

--- a/app/src/main/app/shell/StoreGameDetailScreen.kt
+++ b/app/src/main/app/shell/StoreGameDetailScreen.kt
@@ -45,8 +45,10 @@ import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.SystemUpdate
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -118,10 +120,19 @@ internal fun StoreGameDetailScreen(
     showCustomPath: Boolean = true,
     showCloudSync: Boolean = false,
     showUninstall: Boolean = true,
+    showUpdateCheck: Boolean = false,
+    isCheckingForUpdate: Boolean = false,
+    isUpdateAvailable: Boolean = false,
+    updateDownloadSize: Long = 0L,
+    updateStatusText: String? = null,
+    isUpdateActionEnabled: Boolean = true,
+    isUpdateCheckCoolingDown: Boolean = false,
     dlcs: List<StoreDlcItem> = emptyList(),
     selectedDlcIds: Set<Int> = emptySet(),
     onBack: () -> Unit,
     onInstall: () -> Unit = {},
+    onCheckForUpdate: () -> Unit = {},
+    onDownloadUpdate: () -> Unit = {},
     onUninstall: () -> Unit = {},
     onCloudSync: () -> Unit = {},
     onCustomPath: () -> Unit = {},
@@ -144,8 +155,10 @@ internal fun StoreGameDetailScreen(
         val horizontalNavInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
         val hasSelectedInstallableDlc = dlcs.any { !it.isInstalled && it.id in selectedDlcIds }
         val showDownloadCta = !isInstalled || hasSelectedInstallableDlc
+        val showUpdateCheckButton = showUpdateCheck && isInstalled
+        val showUpdateCta = showUpdateCheckButton && isUpdateAvailable
         val showDlcCard = dlcs.isNotEmpty() && (!isInstalled || dlcs.any { !it.isInstalled })
-        val showActionColumn = showDownloadCta || (showCloudSync || showUninstall)
+        val showActionColumn = showDownloadCta || showUpdateCheckButton || (showCloudSync || showUninstall)
 
         if (heroImageUrl != null) {
             val heroRequest =
@@ -313,6 +326,13 @@ internal fun StoreGameDetailScreen(
                                 label = stringResource(R.string.library_games_install_path),
                                 value = installPathDisplay,
                             )
+                            if (isUpdateAvailable && updateDownloadSize > 0L) {
+                                StoreStatChip(
+                                    icon = Icons.Outlined.SystemUpdate,
+                                    label = stringResource(R.string.store_game_update),
+                                    value = StorageUtils.formatBinarySize(updateDownloadSize),
+                                )
+                            }
                         } else {
                             if (downloadSize > 0L) {
                                 StoreStatChip(
@@ -357,6 +377,54 @@ internal fun StoreGameDetailScreen(
                                 )
                             }
 
+                            if (showUpdateCta) {
+                                StoreCtaButton(
+                                    height = ctaHeight,
+                                    icon = Icons.Outlined.SystemUpdate,
+                                    label = stringResource(R.string.store_game_download_update),
+                                    enabled =
+                                        !isLoading &&
+                                            isUpdateActionEnabled &&
+                                            !isCheckingForUpdate,
+                                    loading = false,
+                                    onClick = onDownloadUpdate,
+                                )
+                            }
+
+                            if (showUpdateCheckButton) {
+                                StoreSecondaryActionButton(
+                                    icon = Icons.Outlined.Refresh,
+                                    label =
+                                        if (isCheckingForUpdate) {
+                                            stringResource(R.string.store_game_checking_for_update)
+                                        } else {
+                                            stringResource(R.string.store_game_check_for_update)
+                                        },
+                                    enabled =
+                                        !isLoading &&
+                                            !isCheckingForUpdate &&
+                                            !isUpdateCheckCoolingDown &&
+                                            isUpdateActionEnabled,
+                                    loading = isCheckingForUpdate,
+                                    onClick = onCheckForUpdate,
+                                )
+                                if (!updateStatusText.isNullOrBlank()) {
+                                    Text(
+                                        updateStatusText,
+                                        color =
+                                            if (updateStatusText == stringResource(R.string.store_game_update_check_failed)) {
+                                                StoreDanger
+                                            } else {
+                                                StoreTextSecondary
+                                            },
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+
                             if (showDownloadCta && !isLoading && !isInstallEnabled && installSize > 0L) {
                                 val deficit = (installSize - availableBytes).coerceAtLeast(0L)
                                 if (deficit > 0L) {
@@ -378,7 +446,7 @@ internal fun StoreGameDetailScreen(
                                 horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
                                 verticalAlignment = Alignment.Top,
                             ) {
-                                if (showCustomPath && !isInstalled) {
+                                if (showCustomPath && !isInstalled && !isLoading) {
                                     StoreIconActionButton(
                                         icon = Icons.Outlined.Folder,
                                         contentDescription = customPathLabel,
@@ -778,6 +846,74 @@ private fun StoreCtaButton(
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreSecondaryActionButton(
+    icon: ImageVector,
+    label: String,
+    enabled: Boolean,
+    loading: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed && enabled) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = 0.6f, stiffness = 620f),
+        label = "storeSecondaryActionScale",
+    )
+    val shape = remember { RoundedCornerShape(8.dp) }
+    val contentColor = if (enabled) StoreTextPrimary else StoreTextSecondary.copy(alpha = 0.58f)
+    Surface(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }.clip(shape)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = { if (enabled && !loading) onClick() },
+                ),
+        color = StoreBlack.copy(alpha = if (enabled) 0.52f else 0.34f),
+        shape = shape,
+        border = BorderStroke(1.dp, StoreAccentGlow.copy(alpha = if (enabled) 0.36f else 0.14f)),
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            if (loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    color = StoreAccentGlow,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = contentColor,
+                    )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        label,
+                        color = contentColor,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/app/shell/StoreGameDetailScreen.kt
+++ b/app/src/main/app/shell/StoreGameDetailScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Folder
-import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.Checkbox
@@ -91,6 +90,7 @@ internal data class StoreDlcItem(
     val id: Int,
     val name: String,
     val downloadSize: Long,
+    val isInstalled: Boolean = false,
 )
 
 private val StoreBlack = Color.Black
@@ -121,7 +121,6 @@ internal fun StoreGameDetailScreen(
     dlcs: List<StoreDlcItem> = emptyList(),
     selectedDlcIds: Set<Int> = emptySet(),
     onBack: () -> Unit,
-    onPlay: () -> Unit = {},
     onInstall: () -> Unit = {},
     onUninstall: () -> Unit = {},
     onCloudSync: () -> Unit = {},
@@ -143,6 +142,10 @@ internal fun StoreGameDetailScreen(
         val ctaHeight = 56.dp
         val contentGap = 18.dp
         val horizontalNavInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
+        val hasSelectedInstallableDlc = dlcs.any { !it.isInstalled && it.id in selectedDlcIds }
+        val showDownloadCta = !isInstalled || hasSelectedInstallableDlc
+        val showDlcCard = dlcs.isNotEmpty() && (!isInstalled || dlcs.any { !it.isInstalled })
+        val showActionColumn = showDownloadCta || (showCloudSync || showUninstall)
 
         if (heroImageUrl != null) {
             val heroRequest =
@@ -337,83 +340,76 @@ internal fun StoreGameDetailScreen(
                         }
                     }
 
-                    Column(
-                        modifier = Modifier.width(actionWidth),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        if (isInstalled) {
-                            StoreCtaButton(
-                                height = ctaHeight,
-                                icon = Icons.Outlined.PlayArrow,
-                                label = stringResource(R.string.library_games_play),
-                                enabled = true,
-                                loading = false,
-                                onClick = onPlay,
-                            )
-                        } else {
-                            StoreCtaButton(
-                                height = ctaHeight,
-                                icon = Icons.Outlined.Download,
-                                label = stringResource(R.string.common_ui_download),
-                                enabled = !isLoading && isInstallEnabled,
-                                loading = isLoading,
-                                onClick = onInstall,
-                            )
-                        }
-
-                        if (!isInstalled && !isLoading && !isInstallEnabled && installSize > 0L) {
-                            val deficit = (installSize - availableBytes).coerceAtLeast(0L)
-                            if (deficit > 0L) {
-                                Text(
-                                    stringResource(
-                                        R.string.library_games_not_enough_space,
-                                        StorageUtils.formatBinarySize(deficit),
-                                    ),
-                                    color = StoreDanger,
-                                    fontSize = 11.sp,
-                                    fontWeight = FontWeight.SemiBold,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
-
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
-                            verticalAlignment = Alignment.Top,
+                    if (showActionColumn) {
+                        Column(
+                            modifier = Modifier.width(actionWidth),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
-                            if (showCustomPath && !isInstalled) {
-                                StoreIconActionButton(
-                                    icon = Icons.Outlined.Folder,
-                                    contentDescription = customPathLabel,
-                                    size = actionIconSize,
-                                    onClick = onCustomPath,
+                            if (showDownloadCta) {
+                                StoreCtaButton(
+                                    height = ctaHeight,
+                                    icon = Icons.Outlined.Download,
+                                    label = stringResource(R.string.common_ui_download),
+                                    enabled = !isLoading && isInstallEnabled,
+                                    loading = isLoading,
+                                    onClick = onInstall,
                                 )
                             }
-                            if (showCloudSync && isInstalled) {
-                                StoreIconActionButton(
-                                    icon = Icons.Outlined.CloudSync,
-                                    contentDescription = stringResource(R.string.cloud_saves_title),
-                                    size = actionIconSize,
-                                    onClick = onCloudSync,
-                                )
+
+                            if (showDownloadCta && !isLoading && !isInstallEnabled && installSize > 0L) {
+                                val deficit = (installSize - availableBytes).coerceAtLeast(0L)
+                                if (deficit > 0L) {
+                                    Text(
+                                        stringResource(
+                                            R.string.library_games_not_enough_space,
+                                            StorageUtils.formatBinarySize(deficit),
+                                        ),
+                                        color = StoreDanger,
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
                             }
-                            if (showUninstall && isInstalled) {
-                                StoreIconActionButton(
-                                    icon = Icons.Outlined.Delete,
-                                    contentDescription = stringResource(R.string.common_ui_uninstall),
-                                    size = actionIconSize,
-                                    onClick = onUninstall,
-                                    tint = StoreDanger,
-                                )
+
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
+                                verticalAlignment = Alignment.Top,
+                            ) {
+                                if (showCustomPath && !isInstalled) {
+                                    StoreIconActionButton(
+                                        icon = Icons.Outlined.Folder,
+                                        contentDescription = customPathLabel,
+                                        size = actionIconSize,
+                                        onClick = onCustomPath,
+                                    )
+                                }
+                                if (showCloudSync && isInstalled) {
+                                    StoreIconActionButton(
+                                        icon = Icons.Outlined.CloudSync,
+                                        contentDescription = stringResource(R.string.cloud_saves_title),
+                                        size = actionIconSize,
+                                        onClick = onCloudSync,
+                                    )
+                                }
+                                if (showUninstall && isInstalled) {
+                                    StoreIconActionButton(
+                                        icon = Icons.Outlined.Delete,
+                                        contentDescription = stringResource(R.string.common_ui_uninstall),
+                                        size = actionIconSize,
+                                        onClick = onUninstall,
+                                        tint = StoreDanger,
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
 
-            if (!isInstalled && dlcs.isNotEmpty()) {
+            if (showDlcCard) {
                 Spacer(Modifier.height(12.dp))
                 StoreDlcCard(
                     dlcs = dlcs,
@@ -437,12 +433,14 @@ private fun StoreDlcCard(
     onToggleDlc: (Int) -> Unit,
     onToggleSelectAll: () -> Unit,
 ) {
-    val totalSize = remember(dlcs) { dlcs.sumOf { it.downloadSize.coerceAtLeast(0L) } }
-    val selectedCount = dlcs.count { it.id in selectedDlcIds }
+    val selectableDlcs = remember(dlcs) { dlcs.filterNot { it.isInstalled } }
+    val totalSize = remember(selectableDlcs) { selectableDlcs.sumOf { it.downloadSize.coerceAtLeast(0L) } }
+    val selectedCount = selectableDlcs.count { it.id in selectedDlcIds }
+    val installedCount = dlcs.count { it.isInstalled }
     val selectedSize = remember(dlcs, selectedDlcIds) {
-        dlcs.filter { it.id in selectedDlcIds }.sumOf { it.downloadSize.coerceAtLeast(0L) }
+        dlcs.filter { !it.isInstalled && it.id in selectedDlcIds }.sumOf { it.downloadSize.coerceAtLeast(0L) }
     }
-    val allSelected = dlcs.isNotEmpty() && selectedCount == dlcs.size
+    val allSelected = selectableDlcs.isNotEmpty() && selectedCount == selectableDlcs.size
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -480,7 +478,8 @@ private fun StoreDlcCard(
                     Text(
                         buildDlcSummary(
                             selectedCount = selectedCount,
-                            totalCount = dlcs.size,
+                            totalCount = selectableDlcs.size,
+                            installedCount = installedCount,
                             selectedSize = selectedSize,
                             totalSize = totalSize,
                         ),
@@ -506,35 +505,37 @@ private fun StoreDlcCard(
             ) {
                 Column {
                     HorizontalDivider(color = Color.White.copy(alpha = 0.08f), thickness = 0.5.dp)
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable(onClick = onToggleSelectAll)
-                                .padding(horizontal = 8.dp, vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = allSelected,
-                            onCheckedChange = { onToggleSelectAll() },
-                            colors =
-                                CheckboxDefaults.colors(
-                                    checkedColor = StoreAccent,
-                                    uncheckedColor = StoreTextSecondary,
-                                    checkmarkColor = Color.White,
+                    if (selectableDlcs.isNotEmpty()) {
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable(onClick = onToggleSelectAll)
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                checked = allSelected,
+                                onCheckedChange = { onToggleSelectAll() },
+                                colors =
+                                    CheckboxDefaults.colors(
+                                        checkedColor = StoreAccent,
+                                        uncheckedColor = StoreTextSecondary,
+                                        checkmarkColor = Color.White,
+                                    ),
+                            )
+                            Text(
+                                stringResource(
+                                    if (allSelected) R.string.common_ui_deselect_all else R.string.common_ui_select_all,
                                 ),
-                        )
-                        Text(
-                            stringResource(
-                                if (allSelected) R.string.common_ui_deselect_all else R.string.common_ui_select_all,
-                            ),
-                            color = StoreTextPrimary,
-                            fontSize = 13.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.weight(1f),
-                        )
+                                color = StoreTextPrimary,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        HorizontalDivider(color = Color.White.copy(alpha = 0.08f), thickness = 0.5.dp)
                     }
-                    HorizontalDivider(color = Color.White.copy(alpha = 0.08f), thickness = 0.5.dp)
                     Column(
                         modifier =
                             Modifier
@@ -554,23 +555,44 @@ private fun StoreDlcCard(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onToggleDlc(dlc.id) }
+                                        .then(
+                                            if (dlc.isInstalled) {
+                                                Modifier
+                                            } else {
+                                                Modifier.clickable { onToggleDlc(dlc.id) }
+                                            },
+                                        )
                                         .padding(horizontal = 8.dp, vertical = 2.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                Checkbox(
-                                    checked = dlc.id in selectedDlcIds,
-                                    onCheckedChange = { onToggleDlc(dlc.id) },
-                                    colors =
-                                        CheckboxDefaults.colors(
-                                            checkedColor = StoreAccent,
-                                            uncheckedColor = StoreTextSecondary,
-                                            checkmarkColor = Color.White,
-                                        ),
-                                )
+                                if (dlc.isInstalled) {
+                                    Box(
+                                        modifier = Modifier.width(76.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        Text(
+                                            stringResource(R.string.common_ui_installed),
+                                            color = Color(0xFF38D77A),
+                                            fontSize = 10.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            maxLines = 1,
+                                        )
+                                    }
+                                } else {
+                                    Checkbox(
+                                        checked = dlc.id in selectedDlcIds,
+                                        onCheckedChange = { onToggleDlc(dlc.id) },
+                                        colors =
+                                            CheckboxDefaults.colors(
+                                                checkedColor = StoreAccent,
+                                                uncheckedColor = StoreTextSecondary,
+                                                checkmarkColor = Color.White,
+                                            ),
+                                    )
+                                }
                                 Text(
                                     dlc.name,
-                                    color = StoreTextPrimary,
+                                    color = if (dlc.isInstalled) Color(0xFFB7F8CE) else StoreTextPrimary,
                                     fontSize = 13.sp,
                                     modifier = Modifier.weight(1f),
                                     maxLines = 2,
@@ -595,17 +617,27 @@ private fun StoreDlcCard(
 private fun buildDlcSummary(
     selectedCount: Int,
     totalCount: Int,
+    installedCount: Int,
     selectedSize: Long,
     totalSize: Long,
 ): String {
     val totalSizeStr = if (totalSize > 0L) StorageUtils.formatBinarySize(totalSize) else null
     val selectedSizeStr = if (selectedSize > 0L) StorageUtils.formatBinarySize(selectedSize) else null
+    val selectionText =
+        when {
+            totalCount == 0 -> null
+            selectedCount == 0 && totalSizeStr != null -> "$totalCount available · $totalSizeStr total"
+            selectedCount == 0 -> "$totalCount available"
+            selectedSizeStr != null && totalSizeStr != null ->
+                "$selectedCount of $totalCount · $selectedSizeStr / $totalSizeStr"
+            else -> "$selectedCount of $totalCount selected"
+        }
+    val installedText = if (installedCount > 0) "$installedCount installed" else null
     return when {
-        selectedCount == 0 && totalSizeStr != null -> "$totalCount available · $totalSizeStr total"
-        selectedCount == 0 -> "$totalCount available"
-        selectedSizeStr != null && totalSizeStr != null ->
-            "$selectedCount of $totalCount · $selectedSizeStr / $totalSizeStr"
-        else -> "$selectedCount of $totalCount selected"
+        selectionText != null && installedText != null -> "$selectionText · $installedText"
+        selectionText != null -> selectionText
+        installedText != null -> installedText
+        else -> ""
     }
 }
 

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -145,6 +145,7 @@ import com.winlator.cmod.R
 import com.winlator.cmod.app.PluviaApp
 import com.winlator.cmod.app.db.PluviaDatabase
 import com.winlator.cmod.app.service.DownloadService
+import com.winlator.cmod.app.service.download.DownloadCoordinator
 import com.winlator.cmod.app.update.UpdateChecker
 import com.winlator.cmod.feature.settings.InputControlsFragment
 import com.winlator.cmod.feature.settings.SettingsHost
@@ -5722,6 +5723,32 @@ class UnifiedActivity :
     }
 
     @Composable
+    private fun StoreInstalledBadge(
+        modifier: Modifier = Modifier,
+        compact: Boolean = false,
+    ) {
+        val shape = RoundedCornerShape(4.dp)
+        Box(
+            modifier =
+                modifier
+                    .background(StatusOnline.copy(alpha = 0.94f), shape)
+                    .border(1.dp, Color.White.copy(alpha = 0.28f), shape)
+                    .padding(
+                        horizontal = if (compact) 5.dp else 7.dp,
+                        vertical = if (compact) 2.dp else 3.dp,
+                    ),
+        ) {
+            Text(
+                stringResource(R.string.library_games_installed_badge),
+                color = Color(0xFF07120A),
+                fontSize = if (compact) 8.sp else 10.sp,
+                fontWeight = FontWeight.Black,
+                maxLines = 1,
+            )
+        }
+    }
+
+    @Composable
     fun EpicStoreCapsule(
         app: com.winlator.cmod.feature.stores.epic.data.EpicGame,
         isInstalled: Boolean,
@@ -5787,21 +5814,10 @@ class UnifiedActivity :
                         contentScale = ContentScale.Crop,
                     )
                     if (isInstalled) {
-                        Box(
-                            Modifier
-                                .align(
-                                    Alignment.BottomEnd,
-                                ).padding(4.dp)
-                                .background(SurfaceDark.copy(alpha = 0.7f), RoundedCornerShape(6.dp))
-                                .padding(3.dp),
-                        ) {
-                            Text(
-                                stringResource(R.string.library_games_installed_badge),
-                                color = StatusOnline,
-                                fontSize = 8.sp,
-                                fontWeight = FontWeight.Bold,
-                            )
-                        }
+                        StoreInstalledBadge(
+                            modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp),
+                            compact = true,
+                        )
                     }
                 }
                 Spacer(Modifier.width(14.dp))
@@ -5859,21 +5875,9 @@ class UnifiedActivity :
                     )
 
                     if (isInstalled) {
-                        Box(
-                            Modifier
-                                .align(
-                                    Alignment.BottomEnd,
-                                ).padding(8.dp)
-                                .background(SurfaceDark.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
-                                .padding(4.dp),
-                        ) {
-                            Text(
-                                stringResource(R.string.library_games_installed_badge),
-                                color = StatusOnline,
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Bold,
-                            )
-                        }
+                        StoreInstalledBadge(
+                            modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
+                        )
                     }
                 }
 
@@ -6172,11 +6176,9 @@ class UnifiedActivity :
                             contentScale = ContentScale.Crop,
                         )
                         if (isInstalled) {
-                            Icon(
-                                Icons.Outlined.CheckCircle,
-                                contentDescription = "Installed",
-                                tint = StatusOnline,
-                                modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp).size(18.dp),
+                            StoreInstalledBadge(
+                                modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp),
+                                compact = true,
                             )
                         }
                     }
@@ -6250,11 +6252,8 @@ class UnifiedActivity :
                             contentScale = ContentScale.Crop,
                         )
                         if (isInstalled) {
-                            Icon(
-                                Icons.Outlined.CheckCircle,
-                                contentDescription = "Installed",
-                                tint = StatusOnline,
-                                modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp).size(24.dp),
+                            StoreInstalledBadge(
+                                modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
                             )
                         }
                     }
@@ -6643,11 +6642,9 @@ class UnifiedActivity :
                             contentScale = ContentScale.Crop,
                         )
                         if (isInstalled) {
-                            Icon(
-                                Icons.Outlined.CheckCircle,
-                                contentDescription = "Installed",
-                                tint = StatusOnline,
-                                modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp).size(18.dp),
+                            StoreInstalledBadge(
+                                modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp),
+                                compact = true,
                             )
                         }
                     }
@@ -6709,11 +6706,8 @@ class UnifiedActivity :
                     )
 
                     if (isInstalled) {
-                        Icon(
-                            Icons.Outlined.CheckCircle,
-                            contentDescription = "Installed",
-                            tint = StatusOnline,
-                            modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp).size(24.dp),
+                        StoreInstalledBadge(
+                            modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
                         )
                     }
                 }
@@ -6735,6 +6729,11 @@ class UnifiedActivity :
         }
     }
 
+    private data class DownloadCancelRequest(
+        val ids: List<String>,
+        val isCancelAll: Boolean,
+    )
+
     // Downloads Tab
     @Composable
     fun DownloadsTab(
@@ -6745,6 +6744,7 @@ class UnifiedActivity :
         val downloads = remember { mutableStateListOf<Pair<String, DownloadInfo>>() }
         var tick by remember { mutableIntStateOf(0) }
         val scope = rememberCoroutineScope()
+        var cancelWarningRequest by remember { mutableStateOf<DownloadCancelRequest?>(null) }
 
         val syncDownloads =
             remember(selectedId, onSelectDownload) {
@@ -6784,7 +6784,7 @@ class UnifiedActivity :
         // is what makes PAUSED records (loaded from DB after app restart) appear in the tab,
         // and what removes COMPLETE/CANCELLED/FAILED rows after Clear.
         LaunchedEffect(syncDownloads) {
-            com.winlator.cmod.app.service.download.DownloadCoordinator.changes.collect {
+            DownloadCoordinator.changes.collect {
                 latestSyncDownloads()
             }
         }
@@ -6884,20 +6884,46 @@ class UnifiedActivity :
                     enabled = pauseResumeEnabled,
                 )
 
-                DownloadsQueueButton(
-                    label = cancelLabel,
-                    accentColor = DangerRed,
-                    onClick = {
-                        if (selectedId == null) {
-                            DownloadService.cancelAll()
-                            onSelectDownload(null)
-                        } else {
-                            DownloadService.cancelDownload(selectedId)
-                            onSelectDownload(null)
-                        }
-                    },
-                    enabled = cancelEnabled,
-                )
+                Box {
+                    DownloadsQueueButton(
+                        label = cancelLabel,
+                        accentColor = DangerRed,
+                        onClick = {
+                            if (selectedId == null) {
+                                cancelWarningRequest =
+                                    DownloadCancelRequest(
+                                        ids = pausableDownloads.map { it.first },
+                                        isCancelAll = true,
+                                    )
+                            } else {
+                                cancelWarningRequest =
+                                    DownloadCancelRequest(
+                                        ids = listOf(selectedId),
+                                        isCancelAll = false,
+                                    )
+                            }
+                        },
+                        enabled = cancelEnabled,
+                    )
+
+                    cancelWarningRequest?.let { request ->
+                        DownloadCancelWarningMenu(
+                            expanded = true,
+                            onDismissRequest = { cancelWarningRequest = null },
+                            onConfirm = {
+                                val activeRequest = cancelWarningRequest
+                                cancelWarningRequest = null
+                                val ids = activeRequest?.ids.orEmpty()
+                                if (activeRequest?.isCancelAll == true) {
+                                    DownloadService.cancelAll()
+                                } else {
+                                    ids.forEach(DownloadService::cancelDownload)
+                                }
+                                onSelectDownload(null)
+                            },
+                        )
+                    }
+                }
 
                 // Clear button - clears completed, cancelled, and failed downloads
                 val hasCompletedOrCancelled =
@@ -7131,6 +7157,25 @@ class UnifiedActivity :
                 }
             }
         }
+    }
+
+    @Composable
+    private fun DownloadCancelWarningMenu(
+        expanded: Boolean,
+        onDismissRequest: () -> Unit,
+        onConfirm: () -> Unit,
+    ) {
+        LaunchDangerConfirmDialog(
+            visible = expanded,
+            title = stringResource(R.string.downloads_queue_cancel_download_title),
+            message = stringResource(R.string.downloads_queue_cancel_download_warning),
+            confirmLabel = stringResource(R.string.downloads_queue_cancel_download),
+            onDismissRequest = onDismissRequest,
+            onConfirm = onConfirm,
+            icon = Icons.Outlined.Warning,
+            titleTextAlign = TextAlign.Center,
+            messageTextAlign = TextAlign.Center,
+        )
     }
 
     @Composable
@@ -7428,74 +7473,40 @@ class UnifiedActivity :
                     }
                 }
 
-                IconButton(
-                    onClick = { showDeleteDialog = true },
-                    enabled = status != DownloadPhase.COMPLETE && status != DownloadPhase.CANCELLED,
-                ) {
-                    Icon(
-                        Icons.Outlined.Close,
-                        contentDescription = stringResource(R.string.downloads_queue_cancel_download),
-                        tint =
-                            if (status != DownloadPhase.COMPLETE &&
-                                status != DownloadPhase.CANCELLED
-                            ) {
-                                Color(0xFFFF6B6B)
-                            } else {
-                                TextSecondary
+                Box(contentAlignment = Alignment.Center) {
+                    IconButton(
+                        onClick = { showDeleteDialog = true },
+                        enabled = status != DownloadPhase.COMPLETE && status != DownloadPhase.CANCELLED,
+                    ) {
+                        Icon(
+                            Icons.Outlined.Close,
+                            contentDescription = stringResource(R.string.downloads_queue_cancel_download),
+                            tint =
+                                if (status != DownloadPhase.COMPLETE &&
+                                    status != DownloadPhase.CANCELLED
+                                ) {
+                                    Color(0xFFFF6B6B)
+                                } else {
+                                    TextSecondary
+                                },
+                        )
+                    }
+                    if (showDeleteDialog) {
+                        DownloadCancelWarningMenu(
+                            expanded = true,
+                            onDismissRequest = { showDeleteDialog = false },
+                            onConfirm = {
+                                showDeleteDialog = false
+                                DownloadService.cancelDownload(id)
                             },
-                    )
+                        )
+                    }
                 }
                 if (ControllerHelper.isControllerConnected()) {
                     Spacer(Modifier.width(8.dp))
                     ControllerBadge(if (ControllerHelper.isPlayStationController()) "\u2715" else "A")
                 }
             }
-        }
-
-        if (showDeleteDialog) {
-            val gameName =
-                if (id.startsWith("STEAM_")) {
-                    steamApp?.name
-                } else if (id.startsWith("EPIC_")) {
-                    epicGame?.title
-                } else if (id.startsWith("GOG_")) {
-                    gogGame?.title
-                } else {
-                    null
-                }
-            AlertDialog(
-                onDismissRequest = { showDeleteDialog = false },
-                containerColor = SurfaceDark,
-                title = { Text(stringResource(R.string.downloads_queue_cancel_download), color = TextPrimary) },
-                text = {
-                    Text(
-                        stringResource(
-                            R.string.downloads_queue_cancel_download_confirm,
-                            gameName ?: stringResource(R.string.downloads_queue_this_game),
-                        ),
-                        color = TextSecondary,
-                    )
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            showDeleteDialog = false
-                            DownloadService.cancelDownload(id)
-                        },
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF6B6B)),
-                    ) {
-                        Text(stringResource(R.string.downloads_queue_cancel_download), color = Color.White)
-                    }
-                },
-                dismissButton = {
-                    Button(
-                        onClick = { showDeleteDialog = false },
-                        colors = ButtonDefaults.buttonColors(containerColor = CardDark),
-                    ) {
-                        Text(stringResource(R.string.common_ui_cancel), color = TextPrimary)
-                    }
-                },
-            )
         }
     }
 
@@ -7515,6 +7526,13 @@ class UnifiedActivity :
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
         var showCustomPathWarning by remember { mutableStateOf(false) }
+        var isCheckingForUpdate by remember(app.id) { mutableStateOf(false) }
+        var isUpdateCheckCoolingDown by remember(app.id) { mutableStateOf(false) }
+        var updateInfo by remember(app.id) { mutableStateOf<SteamService.SteamUpdateInfo?>(null) }
+        var updateStatusText by remember(app.id) { mutableStateOf<String?>(null) }
+        val downloadRecords by com.winlator.cmod.app.service.download.DownloadCoordinator.records.collectAsState(
+            initial = com.winlator.cmod.app.service.download.DownloadCoordinator.snapshotRecords(),
+        )
         val scope = rememberCoroutineScope()
 
         if (showCustomPathWarning) {
@@ -7539,7 +7557,7 @@ class UnifiedActivity :
             val installed: Boolean,
         )
 
-        LaunchedEffect(app.id) {
+        LaunchedEffect(app.id, downloadRecords) {
             val loadData =
                 withContext(Dispatchers.IO) {
                     val selectableDlcApps = SteamService.getSelectableDlcAppsOf(app.id)
@@ -7619,6 +7637,20 @@ class UnifiedActivity :
                 else -> stringResource(R.string.common_ui_custom)
             }
         val isReallyInstalled = installed == true
+        val steamDownloadRecord =
+            downloadRecords.firstOrNull {
+                it.store == com.winlator.cmod.app.db.download.DownloadRecord.STORE_STEAM &&
+                    it.storeGameId == app.id.toString() &&
+                    it.status in setOf(
+                        com.winlator.cmod.app.db.download.DownloadRecord.STATUS_QUEUED,
+                        com.winlator.cmod.app.db.download.DownloadRecord.STATUS_DOWNLOADING,
+                        com.winlator.cmod.app.db.download.DownloadRecord.STATUS_PAUSED,
+                    )
+        }
+        val updateActionEnabled = steamDownloadRecord == null
+        val noUpdateAvailableText = stringResource(R.string.store_game_no_update_available)
+        val updateAvailableText = stringResource(R.string.store_game_update_available)
+        val updateFailedText = stringResource(R.string.store_game_update_check_failed)
 
         Dialog(
             onDismissRequest = onDismissRequest,
@@ -7653,6 +7685,13 @@ class UnifiedActivity :
                     showCustomPath = true,
                     showCloudSync = false,
                     showUninstall = false,
+                    showUpdateCheck = true,
+                    isCheckingForUpdate = isCheckingForUpdate,
+                    isUpdateAvailable = updateInfo?.hasUpdate == true,
+                    updateDownloadSize = updateInfo?.downloadSize ?: 0L,
+                    updateStatusText = updateStatusText,
+                    isUpdateActionEnabled = updateActionEnabled,
+                    isUpdateCheckCoolingDown = isUpdateCheckCoolingDown,
                     dlcs = dlcItems,
                     selectedDlcIds = selectedDlcIds.toSet(),
                     onBack = onDismissRequest,
@@ -7663,6 +7702,77 @@ class UnifiedActivity :
                                 .map { it.id }
                             SteamService.downloadApp(app.id, installableDlcIds, false, customPath)
                             withContext(Dispatchers.Main) { onDismissRequest() }
+                        }
+                    },
+                    onCheckForUpdate = {
+                        if (isCheckingForUpdate || isUpdateCheckCoolingDown) return@StoreGameDetailScreen
+                        scope.launch {
+                            try {
+                                isCheckingForUpdate = true
+                                updateStatusText = null
+                                val result =
+                                    withContext(Dispatchers.IO) {
+                                        SteamService.checkForAppUpdate(app.id)
+                                    }
+                                updateInfo = result
+                                updateStatusText =
+                                    when {
+                                        result.hasUpdate -> updateAvailableText
+                                        result.message != null -> updateFailedText
+                                        else -> null
+                                    }
+                                if (!result.hasUpdate && result.message == null) {
+                                    com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                        context,
+                                        noUpdateAvailableText,
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    )
+                                }
+                                isUpdateCheckCoolingDown = true
+                                kotlinx.coroutines.delay(5_000L)
+                            } catch (e: Exception) {
+                                Log.w("UnifiedActivity", "Steam update check failed for appId=${app.id}", e)
+                                updateInfo = null
+                                updateStatusText = updateFailedText
+                            } finally {
+                                isCheckingForUpdate = false
+                                isUpdateCheckCoolingDown = false
+                            }
+                        }
+                    },
+                    onDownloadUpdate = {
+                        if (!updateActionEnabled || updateInfo?.hasUpdate != true) return@StoreGameDetailScreen
+                        scope.launch(Dispatchers.IO) {
+                            try {
+                                val latest = SteamService.checkForAppUpdate(app.id)
+                                withContext(Dispatchers.Main) {
+                                    updateInfo = latest
+                                    updateStatusText =
+                                        when {
+                                            latest.hasUpdate -> updateAvailableText
+                                            latest.message != null -> updateFailedText
+                                            else -> null
+                                        }
+                                }
+                                if (!latest.hasUpdate) {
+                                    withContext(Dispatchers.Main) {
+                                        com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                            context,
+                                            noUpdateAvailableText,
+                                            android.widget.Toast.LENGTH_SHORT,
+                                        )
+                                    }
+                                    return@launch
+                                }
+
+                                SteamService.downloadAppForUpdate(app.id, latest.depotIds)
+                                withContext(Dispatchers.Main) { onDismissRequest() }
+                            } catch (e: Exception) {
+                                Log.w("UnifiedActivity", "Steam update download failed to start for appId=${app.id}", e)
+                                withContext(Dispatchers.Main) {
+                                    updateStatusText = updateFailedText
+                                }
+                            }
                         }
                     },
                     onCustomPath = {

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -5260,219 +5260,6 @@ class UnifiedActivity :
     }
 
     @Composable
-    private fun DetailCard(
-        label: String,
-        value: String,
-        modifier: Modifier = Modifier.fillMaxWidth(),
-        valueColor: Color? = null,
-        onClick: (() -> Unit)? = null,
-    ) {
-        Surface(
-            modifier =
-                modifier
-                    .then(if (onClick != null) Modifier.clip(RoundedCornerShape(10.dp)).clickable(onClick = onClick) else Modifier),
-            color = SurfaceDark,
-            shape = RoundedCornerShape(10.dp),
-            border = BorderStroke(1.dp, if (onClick != null) Accent.copy(alpha = 0.25f) else CardBorder),
-        ) {
-            Column(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(1.dp),
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        label.uppercase(),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = TextSecondary,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.8.sp,
-                        fontSize = 10.sp,
-                    )
-                    if (onClick != null) {
-                        Icon(
-                            Icons.AutoMirrored.Outlined.OpenInNew,
-                            contentDescription = null,
-                            modifier = Modifier.size(10.dp),
-                            tint = Accent.copy(alpha = 0.6f),
-                        )
-                    }
-                }
-                Text(
-                    value,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = valueColor ?: (if (onClick != null) Accent else TextPrimary),
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun PlayButton(
-        height: Dp = 44.dp,
-        onClick: () -> Unit,
-    ) {
-        val interactionSource = remember { MutableInteractionSource() }
-        val isPressed by interactionSource.collectIsPressedAsState()
-        val scale by animateFloatAsState(
-            targetValue = if (isPressed) 0.92f else 1f,
-            animationSpec = spring(dampingRatio = 0.5f, stiffness = 600f),
-            label = "playScale",
-        )
-
-        // Idle glow pulse
-        val infiniteTransition = rememberInfiniteTransition(label = "playGlow")
-        val glowPulse by infiniteTransition.animateFloat(
-            initialValue = 0.3f,
-            targetValue = 0.6f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation = tween<Float>(1200, easing = FastOutSlowInEasing),
-                    repeatMode = RepeatMode.Reverse,
-                ),
-            label = "playPulse",
-        )
-
-        val baseGradient =
-            Brush.horizontalGradient(
-                colors =
-                    listOf(
-                        Color(0xFF00B4D8),
-                        Accent,
-                        Color(0xFF7B2FF7),
-                    ),
-            )
-
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(height)
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                    }.shadow(
-                        elevation = 12.dp,
-                        shape = RoundedCornerShape(12.dp),
-                        ambientColor = Accent.copy(alpha = glowPulse),
-                        spotColor = Accent.copy(alpha = glowPulse),
-                    ).clip(RoundedCornerShape(12.dp))
-                    .background(baseGradient)
-                    .clickable(
-                        interactionSource = interactionSource,
-                        indication = null,
-                        onClick = onClick,
-                    ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                Icon(
-                    Icons.Outlined.PlayArrow,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = Color.White,
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    stringResource(R.string.library_games_play),
-                    color = Color.White,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 0.5.sp,
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun InstallButton(
-        loading: Boolean = false,
-        onClick: () -> Unit,
-    ) {
-        val interactionSource = remember { MutableInteractionSource() }
-        val isPressed by interactionSource.collectIsPressedAsState()
-        val scale by animateFloatAsState(
-            targetValue = if (isPressed && !loading) 0.92f else 1f,
-            animationSpec = spring(dampingRatio = 0.5f, stiffness = 600f),
-            label = "installScale",
-        )
-        val infiniteTransition = rememberInfiniteTransition(label = "installGlow")
-        val glowPulse by infiniteTransition.animateFloat(
-            initialValue = 0.3f,
-            targetValue = 0.6f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation = tween<Float>(1200, easing = FastOutSlowInEasing),
-                    repeatMode = RepeatMode.Reverse,
-                ),
-            label = "installPulse",
-        )
-        val baseGradient =
-            Brush.horizontalGradient(
-                colors =
-                    listOf(
-                        Color(0xFF00B4D8),
-                        Accent,
-                        Color(0xFF7B2FF7),
-                    ),
-            )
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(44.dp)
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                    }.shadow(
-                        elevation = 12.dp,
-                        shape = RoundedCornerShape(12.dp),
-                        ambientColor = Accent.copy(alpha = glowPulse),
-                        spotColor = Accent.copy(alpha = glowPulse),
-                    ).clip(RoundedCornerShape(12.dp))
-                    .background(baseGradient)
-                    .clickable(
-                        interactionSource = interactionSource,
-                        indication = null,
-                        onClick = { if (!loading) onClick() },
-                    ),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (loading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(22.dp),
-                    color = Color.White,
-                    strokeWidth = 2.dp,
-                )
-            } else {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    Icon(
-                        Icons.Outlined.Download,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                        tint = Color.White,
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        stringResource(R.string.common_ui_download),
-                        color = Color.White,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.5.sp,
-                    )
-                }
-            }
-        }
-    }
-
-    @Composable
     private fun CompactActionButton(
         icon: ImageVector,
         label: String,
@@ -6108,157 +5895,6 @@ class UnifiedActivity :
     }
 
     @Composable
-    private fun StoreInstallDialogShell(
-        title: String,
-        heroImageUrl: String?,
-        subtitle: String,
-        sourceLabel: String = "",
-        onDismissRequest: () -> Unit,
-        infoContent: @Composable ColumnScope.() -> Unit = {},
-        actionsContent: @Composable ColumnScope.() -> Unit,
-    ) {
-        Dialog(
-            onDismissRequest = onDismissRequest,
-            properties =
-                DialogProperties(
-                    usePlatformDefaultWidth = false,
-                    decorFitsSystemWindows = false,
-                ),
-        ) {
-            Surface(
-                modifier =
-                    Modifier
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .fillMaxWidth(0.864f)
-                        .fillMaxHeight(0.92f),
-                shape = RoundedCornerShape(20.dp),
-                color = CardDark,
-            ) {
-                Box(Modifier.fillMaxSize()) {
-                    Column(Modifier.fillMaxSize()) {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .fillMaxHeight(0.42f),
-                        ) {
-                            AsyncImage(
-                                model =
-                                    ImageRequest
-                                        .Builder(LocalContext.current)
-                                        .data(heroImageUrl)
-                                        .crossfade(150)
-                                        .memoryCachePolicy(coil.request.CachePolicy.ENABLED)
-                                        .diskCachePolicy(coil.request.CachePolicy.ENABLED)
-                                        .build(),
-                                contentDescription = "$title artwork",
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.FillWidth,
-                                alignment = Alignment.TopCenter,
-                            )
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .fillMaxSize()
-                                        .background(
-                                            Brush.verticalGradient(
-                                                colorStops =
-                                                    arrayOf(
-                                                        0.0f to Color.Transparent,
-                                                        0.45f to Color.Transparent,
-                                                        0.72f to CardDark.copy(alpha = 0.72f),
-                                                        1.0f to CardDark,
-                                                    ),
-                                            ),
-                                        ),
-                            )
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.BottomStart)
-                                        .padding(start = 24.dp, end = 80.dp, bottom = 24.dp),
-                            ) {
-                                Text(
-                                    title,
-                                    style = MaterialTheme.typography.headlineMedium,
-                                    color = TextPrimary,
-                                    fontWeight = FontWeight.Bold,
-                                )
-                                if (subtitle.isNotBlank()) {
-                                    Spacer(Modifier.height(8.dp))
-                                    Text(
-                                        subtitle,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = TextSecondary,
-                                        maxLines = 2,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                }
-                            }
-                        }
-
-                        Row(
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = 24.dp, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.spacedBy(14.dp),
-                        ) {
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .weight(1f)
-                                        .fillMaxHeight(),
-                                verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.Bottom),
-                            ) {
-                                if (sourceLabel.isNotBlank()) {
-                                    Surface(
-                                        color = Accent.copy(alpha = 0.15f),
-                                        shape = RoundedCornerShape(8.dp),
-                                    ) {
-                                        Text(
-                                            sourceLabel,
-                                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                                            color = Accent,
-                                            fontSize = 12.sp,
-                                            fontWeight = FontWeight.Bold,
-                                        )
-                                    }
-                                }
-                                infoContent()
-                            }
-
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .widthIn(min = 200.dp, max = 260.dp)
-                                        .fillMaxHeight(),
-                                verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.Bottom),
-                            ) {
-                                actionsContent()
-                            }
-                        }
-                    }
-
-                    IconButton(
-                        onClick = onDismissRequest,
-                        modifier =
-                            Modifier
-                                .align(Alignment.TopEnd)
-                                .padding(16.dp)
-                                .size(42.dp)
-                                .shadow(8.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.35f))
-                                .clip(CircleShape)
-                                .background(BgDark.copy(alpha = 0.7f)),
-                    ) {
-                        Icon(Icons.Outlined.Close, contentDescription = "Close", tint = TextPrimary)
-                    }
-                }
-            }
-        }
-    }
-
-    @Composable
     fun EpicGameManagerDialog(
         app: EpicGame,
         onDismissRequest: () -> Unit,
@@ -6273,7 +5909,6 @@ class UnifiedActivity :
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
         var showCustomPathWarning by remember { mutableStateOf(false) }
-        var showDlcDialog by remember { mutableStateOf(false) }
 
         if (showCustomPathWarning) {
             CustomPathWarningDialog(
@@ -6289,58 +5924,6 @@ class UnifiedActivity :
             )
         }
 
-        if (showDlcDialog && dlcApps.isNotEmpty()) {
-            GameSettingsDialogFrame(
-                title = stringResource(R.string.library_games_dlcs),
-                onDismissRequest = { showDlcDialog = false },
-            ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .heightIn(max = 300.dp)
-                            .verticalScroll(rememberScrollState()),
-                ) {
-                    dlcApps.forEachIndexed { index, dlc ->
-                        if (index > 0) {
-                            HorizontalDivider(
-                                color = CardBorder.copy(alpha = 0.5f),
-                                thickness = 0.5.dp,
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                            )
-                        }
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = null,
-                                    ) {
-                                        if (selectedDlcIds.contains(dlc.id)) {
-                                            selectedDlcIds.remove(dlc.id)
-                                        } else {
-                                            selectedDlcIds.add(dlc.id)
-                                        }
-                                    }.padding(horizontal = 16.dp, vertical = 2.dp),
-                        ) {
-                            Checkbox(
-                                checked = selectedDlcIds.contains(dlc.id),
-                                onCheckedChange = { if (it) selectedDlcIds.add(dlc.id) else selectedDlcIds.remove(dlc.id) },
-                                colors =
-                                    CheckboxDefaults.colors(
-                                        checkedColor = Accent,
-                                        uncheckedColor = TextSecondary,
-                                        checkmarkColor = Color.White,
-                                    ),
-                            )
-                            Text(dlc.title, color = TextPrimary, fontSize = 13.sp)
-                        }
-                    }
-                }
-            }
-        }
-
         LaunchedEffect(app.id, installed) {
             if (!installed) {
                 withContext(Dispatchers.IO) {
@@ -6351,8 +5934,14 @@ class UnifiedActivity :
             }
         }
 
-        val totalInstallSize = manifestSizes?.installSize ?: 0L
-        val totalDownloadSize = manifestSizes?.downloadSize ?: 0L
+        val baseDownloadSize = manifestSizes?.downloadSize ?: 0L
+        val baseInstallSize = manifestSizes?.installSize ?: 0L
+        val selectedDlcDownloadBytes =
+            dlcApps.filter { it.id in selectedDlcIds }.sumOf { it.downloadSize.coerceAtLeast(0L) }
+        val selectedDlcInstallBytes =
+            dlcApps.filter { it.id in selectedDlcIds }.sumOf { it.installSize.coerceAtLeast(0L) }
+        val totalDownloadSize = baseDownloadSize + selectedDlcDownloadBytes
+        val totalInstallSize = baseInstallSize + selectedDlcInstallBytes
         val defaultPathSet =
             if (PrefManager.useSingleDownloadFolder) {
                 PrefManager.defaultDownloadFolder.isNotEmpty()
@@ -6367,79 +5956,88 @@ class UnifiedActivity :
             } catch (e: Exception) {
                 0L
             }
-        val isInstallEnabled = installed || availableBytes >= totalInstallSize
-        val installPathDisplay = customPath ?: EpicConstants.defaultEpicGamesPath(context)
+        val isInstallEnabled = installed || totalInstallSize == 0L || availableBytes >= totalInstallSize
+        val installPathDisplay = if (installed) app.installPath else (customPath ?: EpicConstants.defaultEpicGamesPath(context))
 
-        StoreInstallDialogShell(
-            title = app.title,
-            heroImageUrl = app.artPortrait.ifEmpty { app.primaryImageUrl },
-            subtitle =
-                listOfNotNull(
-                    app.developer.takeIf { it.isNotBlank() },
-                    app.publisher.takeIf { it.isNotBlank() },
-                ).joinToString(" • "),
-            sourceLabel = "Epic Games",
+        val dlcItems =
+            remember(dlcApps) {
+                dlcApps.map { dlc ->
+                    val size =
+                        dlc.downloadSize.takeIf { it > 0L }
+                            ?: dlc.installSize
+                    StoreDlcItem(id = dlc.id, name = dlc.title, downloadSize = size)
+                }
+            }
+        val customPathLabel =
+            when {
+                customPath != null -> stringResource(R.string.common_ui_custom)
+                defaultPathSet -> stringResource(R.string.common_ui_already_set)
+                else -> stringResource(R.string.common_ui_custom)
+            }
+
+        Dialog(
             onDismissRequest = onDismissRequest,
-            infoContent = {
-                if (isLoading && !installed) {
-                    Spacer(Modifier.height(18.dp))
-                    CircularProgressIndicator(color = Accent)
-                } else if (installed) {
-                    DetailCard(
-                        label = stringResource(R.string.library_games_install_path),
-                        value = app.installPath,
-                    )
-                    DetailCard(
-                        label = stringResource(R.string.common_ui_status),
-                        value = stringResource(R.string.common_ui_installed),
-                        valueColor = StatusOnline,
-                    )
-                } else {
-                    DetailCard(
-                        label = stringResource(R.string.library_games_install_path),
-                        value = installPathDisplay,
-                    )
-                    DetailCard(
-                        stringResource(R.string.library_games_download_slash_install),
-                        stringResource(
-                            R.string.library_games_download_install_available,
-                            StorageUtils.formatBinarySize(totalDownloadSize),
-                            StorageUtils.formatBinarySize(totalInstallSize),
-                            StorageUtils.formatBinarySize(availableBytes),
-                        ),
-                        valueColor = if (!isInstallEnabled) DangerRed else null,
-                    )
-                }
-            },
+            properties =
+                DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
         ) {
-            if (installed) {
-                PlayButton(onClick = {
-                    launchEpicGame(context, ContainerManager(context), app)
-                    onDismissRequest()
-                })
-                if (app.cloudSaveEnabled) {
-                    CompactActionButton(
-                        icon = Icons.Outlined.CloudSync,
-                        label = stringResource(R.string.google_cloud_title),
-                        onClick = {
-                            scope.launch(Dispatchers.IO) {
-                                EpicCloudSavesManager.syncCloudSaves(context, app.id, "auto")
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                shape = RectangleShape,
+                color = Color.Black,
+            ) {
+                StoreGameDetailScreen(
+                    title = app.title,
+                    subtitle =
+                        listOfNotNull(
+                            app.developer.takeIf { it.isNotBlank() },
+                            app.publisher.takeIf { it.isNotBlank() },
+                        ).joinToString(" • "),
+                    sourceLabel = "Epic Games",
+                    heroImageUrl = app.artPortrait.ifEmpty { app.primaryImageUrl },
+                    isLoading = isLoading,
+                    isInstalled = installed,
+                    installPathDisplay = installPathDisplay,
+                    downloadSize = totalDownloadSize,
+                    installSize = totalInstallSize,
+                    availableBytes = availableBytes,
+                    isInstallEnabled = isInstallEnabled,
+                    customPathLabel = customPathLabel,
+                    showCustomPath = true,
+                    showCloudSync = app.cloudSaveEnabled,
+                    showUninstall = true,
+                    dlcs = dlcItems,
+                    selectedDlcIds = selectedDlcIds.toSet(),
+                    onBack = onDismissRequest,
+                    onPlay = {
+                        launchEpicGame(context, ContainerManager(context), app)
+                        onDismissRequest()
+                    },
+                    onInstall = {
+                        val installPath =
+                            if (customPath != null) {
+                                val sanitizedTitle = app.title.replace(Regex("[^a-zA-Z0-9 \\-_]"), "").trim()
+                                java.io.File(customPath!!, sanitizedTitle).absolutePath
+                            } else {
+                                EpicConstants.getGameInstallPath(context, app.title)
                             }
-                            onDismissRequest()
-                            com.winlator.cmod.shared.ui.toast.WinToast.show(
-                                context,
-                                context.getString(R.string.google_cloud_sync_started),
-                                android.widget.Toast.LENGTH_SHORT,
-                            )
-                        },
-                    )
-                }
-                CompactActionButton(
-                    icon = Icons.Outlined.Delete,
-                    label = stringResource(R.string.common_ui_uninstall),
-                    tint = DangerRed,
-                    bgColor = DangerRed.copy(alpha = 0.12f),
-                    onClick = {
+                        EpicService.downloadGame(context, app.id, selectedDlcIds.toList(), installPath, "en-US")
+                        onDismissRequest()
+                    },
+                    onCloudSync = {
+                        scope.launch(Dispatchers.IO) {
+                            EpicCloudSavesManager.syncCloudSaves(context, app.id, "auto")
+                        }
+                        onDismissRequest()
+                        com.winlator.cmod.shared.ui.toast.WinToast.show(
+                            context,
+                            context.getString(R.string.google_cloud_sync_started),
+                            android.widget.Toast.LENGTH_SHORT,
+                        )
+                    },
+                    onUninstall = {
                         scope.launch(Dispatchers.IO) {
                             val result = EpicService.deleteGame(context, app.id)
                             withContext(Dispatchers.Main) {
@@ -6458,60 +6056,33 @@ class UnifiedActivity :
                             }
                         }
                     },
-                )
-            } else {
-                InstallButton(
-                    loading = isLoading,
-                    onClick = {
-                        val installPath =
-                            if (customPath != null) {
-                                val sanitizedTitle = app.title.replace(Regex("[^a-zA-Z0-9 \\-_]"), "").trim()
-                                java.io.File(customPath!!, sanitizedTitle).absolutePath
-                            } else {
-                                EpicConstants.getGameInstallPath(context, app.title)
-                            }
-                        EpicService.downloadGame(context, app.id, selectedDlcIds.toList(), installPath, "en-US")
-                        onDismissRequest()
+                    onCustomPath = {
+                        if (customPath == null && defaultPathSet) {
+                            showCustomPathWarning = true
+                        } else {
+                            DirectoryPickerDialog.show(
+                                activity = this@UnifiedActivity,
+                                initialPath = customPath ?: EpicConstants.getGameInstallPath(context, app.appName),
+                                title = getString(R.string.settings_content_install_directory),
+                            ) { path -> customPath = path }
+                        }
+                    },
+                    onToggleDlc = { id ->
+                        if (selectedDlcIds.contains(id)) {
+                            selectedDlcIds.remove(id)
+                        } else {
+                            selectedDlcIds.add(id)
+                        }
+                    },
+                    onToggleSelectAllDlcs = {
+                        val all = dlcItems.isNotEmpty() && dlcItems.all { it.id in selectedDlcIds }
+                        if (all) {
+                            selectedDlcIds.clear()
+                        } else {
+                            dlcItems.forEach { if (it.id !in selectedDlcIds) selectedDlcIds.add(it.id) }
+                        }
                     },
                 )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    CompactActionButton(
-                        icon = Icons.Outlined.Folder,
-                        label =
-                            if (customPath !=
-                                null
-                            ) {
-                                stringResource(R.string.common_ui_custom)
-                            } else if (defaultPathSet) {
-                                stringResource(R.string.common_ui_already_set)
-                            } else {
-                                stringResource(R.string.common_ui_custom)
-                            },
-                        modifier = Modifier.weight(1f),
-                        onClick = {
-                            if (customPath == null && defaultPathSet) {
-                                showCustomPathWarning = true
-                            } else {
-                                DirectoryPickerDialog.show(
-                                    activity = this@UnifiedActivity,
-                                    initialPath = customPath ?: EpicConstants.getGameInstallPath(context, app.appName),
-                                    title = getString(R.string.settings_content_install_directory),
-                                ) { path -> customPath = path }
-                            }
-                        },
-                    )
-                    if (dlcApps.isNotEmpty()) {
-                        CompactActionButton(
-                            icon = Icons.Outlined.Extension,
-                            label = stringResource(R.string.library_games_dlcs),
-                            modifier = Modifier.weight(1f),
-                            onClick = { showDlcDialog = true },
-                        )
-                    }
-                }
             }
         }
     }
@@ -6747,7 +6318,9 @@ class UnifiedActivity :
             }
         val installRootPath = customPath ?: GOGConstants.defaultGOGGamesPath
         val installPathDisplay =
-            if (customPath != null) {
+            if (installed) {
+                app.installPath
+            } else if (customPath != null) {
                 java.io.File(customPath!!, GOGConstants.getSanitizedGameFolderName(app.title)).absolutePath
             } else {
                 GOGConstants.getGameInstallPath(app.title)
@@ -6759,56 +6332,59 @@ class UnifiedActivity :
             } catch (_: Exception) {
                 0L
             }
-        val isInstallEnabled = installed || availableBytes >= requiredBytes
+        val isInstallEnabled = installed || requiredBytes == 0L || availableBytes >= requiredBytes
+        val customPathLabel =
+            when {
+                customPath != null -> stringResource(R.string.common_ui_custom)
+                defaultPathSet -> stringResource(R.string.common_ui_already_set)
+                else -> stringResource(R.string.common_ui_custom)
+            }
 
-        StoreInstallDialogShell(
-            title = app.title,
-            heroImageUrl = app.imageUrl.ifEmpty { app.iconUrl },
-            subtitle =
-                listOfNotNull(
-                    app.developer.takeIf { it.isNotBlank() },
-                    app.publisher.takeIf { it.isNotBlank() },
-                ).joinToString(" • "),
-            sourceLabel = "GOG",
+        Dialog(
             onDismissRequest = onDismissRequest,
-            infoContent = {
-                if (installed) {
-                    DetailCard(
-                        label = stringResource(R.string.library_games_install_path),
-                        value = app.installPath,
-                    )
-                    DetailCard(
-                        label = stringResource(R.string.common_ui_status),
-                        value = stringResource(R.string.common_ui_installed),
-                        valueColor = StatusOnline,
-                    )
-                } else {
-                    DetailCard(
-                        label = stringResource(R.string.library_games_install_path),
-                        value = installPathDisplay,
-                    )
-                    DetailCard(
-                        stringResource(R.string.library_games_download_slash_install),
-                        stringResource(
-                            R.string.library_games_download_install_available,
-                            StorageUtils.formatBinarySize(app.downloadSize),
-                            StorageUtils.formatBinarySize(app.installSize),
-                            StorageUtils.formatBinarySize(availableBytes),
-                        ),
-                        valueColor = if (!isInstallEnabled) DangerRed else null,
-                    )
-                }
-            },
+            properties =
+                DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
         ) {
-            if (installed) {
-                PlayButton(onClick = {
-                    launchGogGame(context, ContainerManager(context), app)
-                    onDismissRequest()
-                })
-                CompactActionButton(
-                    icon = Icons.Outlined.CloudSync,
-                    label = stringResource(R.string.google_cloud_title),
-                    onClick = {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                shape = RectangleShape,
+                color = Color.Black,
+            ) {
+                StoreGameDetailScreen(
+                    title = app.title,
+                    subtitle =
+                        listOfNotNull(
+                            app.developer.takeIf { it.isNotBlank() },
+                            app.publisher.takeIf { it.isNotBlank() },
+                        ).joinToString(" • "),
+                    sourceLabel = "GOG",
+                    heroImageUrl = app.imageUrl.ifEmpty { app.iconUrl },
+                    isLoading = false,
+                    isInstalled = installed,
+                    installPathDisplay = installPathDisplay,
+                    downloadSize = app.downloadSize,
+                    installSize = app.installSize,
+                    availableBytes = availableBytes,
+                    isInstallEnabled = isInstallEnabled,
+                    customPathLabel = customPathLabel,
+                    showCustomPath = true,
+                    showCloudSync = true,
+                    showUninstall = true,
+                    dlcs = emptyList(),
+                    selectedDlcIds = emptySet(),
+                    onBack = onDismissRequest,
+                    onPlay = {
+                        launchGogGame(context, ContainerManager(context), app)
+                        onDismissRequest()
+                    },
+                    onInstall = {
+                        GOGService.downloadGame(context, app.id, installPathDisplay, PrefManager.containerLanguage)
+                        onDismissRequest()
+                    },
+                    onCloudSync = {
                         scope.launch(Dispatchers.IO) {
                             GOGService.syncCloudSaves(context, "GOG_${app.id}", "auto")
                         }
@@ -6819,18 +6395,17 @@ class UnifiedActivity :
                             android.widget.Toast.LENGTH_SHORT,
                         )
                     },
-                )
-                CompactActionButton(
-                    icon = Icons.Outlined.Delete,
-                    label = stringResource(R.string.common_ui_uninstall),
-                    tint = DangerRed,
-                    bgColor = DangerRed.copy(alpha = 0.12f),
-                    onClick = {
+                    onUninstall = {
                         scope.launch(Dispatchers.IO) {
-                            val result = GOGService.deleteGame(
-                                context,
-                                LibraryItem("GOG_${app.id}", app.title, com.winlator.cmod.feature.stores.steam.enums.GameSource.GOG),
-                            )
+                            val result =
+                                GOGService.deleteGame(
+                                    context,
+                                    LibraryItem(
+                                        "GOG_${app.id}",
+                                        app.title,
+                                        com.winlator.cmod.feature.stores.steam.enums.GameSource.GOG,
+                                    ),
+                                )
                             withContext(Dispatchers.Main) {
                                 if (!result.isSuccess) {
                                     com.winlator.cmod.shared.ui.toast.WinToast.show(
@@ -6847,27 +6422,7 @@ class UnifiedActivity :
                             }
                         }
                     },
-                )
-            } else {
-                InstallButton(
-                    onClick = {
-                        GOGService.downloadGame(context, app.id, installPathDisplay, PrefManager.containerLanguage)
-                        onDismissRequest()
-                    },
-                )
-                CompactActionButton(
-                    icon = Icons.Outlined.Folder,
-                    label =
-                        if (customPath !=
-                            null
-                        ) {
-                            stringResource(R.string.common_ui_custom)
-                        } else if (defaultPathSet) {
-                            stringResource(R.string.common_ui_already_set)
-                        } else {
-                            stringResource(R.string.common_ui_custom)
-                        },
-                    onClick = {
+                    onCustomPath = {
                         if (customPath == null && defaultPathSet) {
                             showCustomPathWarning = true
                         } else {
@@ -7716,7 +7271,7 @@ class UnifiedActivity :
 
                 Column(Modifier.weight(1f)) {
                     val currentFile by info.getCurrentFileNameFlow().collectAsState()
-                    val (downloadedBytes, totalBytes) = info.getBytesProgress()
+                    val (downloadedBytes, totalBytes) = info.getDisplayBytesProgress()
                     val speed = info.getCurrentDownloadSpeed() ?: 0L
                     val percentage = (animatedProgress * 100).roundToInt()
                     val showDownloadSpeed =
@@ -7960,14 +7515,13 @@ class UnifiedActivity :
     ) {
         val context = LocalContext.current
         var isLoading by remember { mutableStateOf(true) }
-        var manifestSizes by remember { mutableStateOf(SteamService.ManifestSizes()) }
+        var selectedManifestSizes by remember { mutableStateOf(SteamService.ManifestSizes()) }
         var dlcApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var dlcSizes by remember { mutableStateOf<Map<Int, SteamService.ManifestSizes>>(emptyMap()) }
         var installed by remember(app.id) { mutableStateOf<Boolean?>(null) }
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
         var showCustomPathWarning by remember { mutableStateOf(false) }
-        var showDlcDialog by remember { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
 
         if (showCustomPathWarning) {
@@ -7984,83 +7538,10 @@ class UnifiedActivity :
             )
         }
 
-        if (showDlcDialog && dlcApps.isNotEmpty()) {
-            GameSettingsDialogFrame(
-                title = stringResource(R.string.library_games_dlcs),
-                onDismissRequest = { showDlcDialog = false },
-            ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .heightIn(max = 300.dp)
-                            .verticalScroll(rememberScrollState()),
-                ) {
-                    dlcApps.forEachIndexed { index, dlc ->
-                        if (index > 0) {
-                            HorizontalDivider(
-                                color = CardBorder.copy(alpha = 0.5f),
-                                thickness = 0.5.dp,
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                            )
-                        }
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = null,
-                                    ) {
-                                        if (selectedDlcIds.contains(dlc.id)) {
-                                            selectedDlcIds.remove(dlc.id)
-                                        } else {
-                                            selectedDlcIds.add(dlc.id)
-                                        }
-                                    }.padding(horizontal = 16.dp, vertical = 2.dp),
-                        ) {
-                            Checkbox(
-                                checked = selectedDlcIds.contains(dlc.id),
-                                onCheckedChange = { if (it) selectedDlcIds.add(dlc.id) else selectedDlcIds.remove(dlc.id) },
-                                colors =
-                                    CheckboxDefaults.colors(
-                                        checkedColor = Accent,
-                                        uncheckedColor = TextSecondary,
-                                        checkmarkColor = Color.White,
-                                    ),
-                            )
-                            Text(
-                                dlc.name,
-                                color = TextPrimary,
-                                fontSize = 13.sp,
-                                modifier = Modifier.weight(1f),
-                            )
-                            val dlcManifestSizes = dlcSizes[dlc.id]
-                            val dlcSize =
-                                dlcManifestSizes
-                                    ?.downloadSize
-                                    ?.takeIf { it > 0L }
-                                    ?: dlcManifestSizes?.installSize
-                                    ?: 0L
-                            if (dlcSize > 0L) {
-                                Text(
-                                    StorageUtils.formatBinarySize(dlcSize),
-                                    color = TextSecondary,
-                                    fontSize = 12.sp,
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        val selectedDlcIdsKey = selectedDlcIds.toList().sorted().joinToString(",")
-
         data class SteamInstallLoadData(
             val dlcApps: List<SteamApp>,
             val dlcSizes: Map<Int, SteamService.ManifestSizes>,
-            val manifestSizes: SteamService.ManifestSizes,
+            val baseManifestSizes: SteamService.ManifestSizes,
             val installed: Boolean,
         )
 
@@ -8075,27 +7556,26 @@ class UnifiedActivity :
                     SteamInstallLoadData(
                         dlcApps = selectableDlcApps,
                         dlcSizes = perDlcSizes,
-                        manifestSizes = SteamService.getSelectedManifestSizes(app.id),
+                        baseManifestSizes = SteamService.getSelectedManifestSizes(app.id),
                         installed = SteamService.isAppInstalled(app.id),
                     )
                 }
             dlcApps = loadData.dlcApps
             dlcSizes = loadData.dlcSizes
-            manifestSizes = loadData.manifestSizes
+            selectedManifestSizes = loadData.baseManifestSizes
             installed = loadData.installed
             isLoading = false
         }
 
-        LaunchedEffect(app.id, selectedDlcIdsKey) {
-            if (isLoading) return@LaunchedEffect
-            manifestSizes =
+        LaunchedEffect(app.id, selectedDlcIds.toList()) {
+            selectedManifestSizes =
                 withContext(Dispatchers.IO) {
                     SteamService.getSelectedManifestSizes(app.id, selectedDlcIds.toList())
                 }
         }
 
-        val totalInstallSize = manifestSizes.installSize
-        val totalDownloadSize = manifestSizes.downloadSize
+        val totalDownloadSize = selectedManifestSizes.downloadSize
+        val totalInstallSize = selectedManifestSizes.installSize
         val defaultPathSet =
             if (PrefManager.useSingleDownloadFolder) {
                 PrefManager.defaultDownloadFolder.isNotEmpty()
@@ -8110,70 +7590,77 @@ class UnifiedActivity :
             } catch (e: Exception) {
                 0L
             }
-        val isInstallEnabled = availableBytes >= totalInstallSize
+        val isInstallEnabled = totalInstallSize == 0L || availableBytes >= totalInstallSize
         val installPathDisplay = customPath ?: SteamService.defaultAppInstallPath
 
-        StoreInstallDialogShell(
-            title = app.name,
-            heroImageUrl = app.getHeroUrl(),
-            subtitle =
-                listOfNotNull(
-                    app.developer.takeIf { it.isNotBlank() },
-                    app.publisher.takeIf { it.isNotBlank() },
-                ).joinToString(" • "),
-            sourceLabel = "Steam",
-            onDismissRequest = onDismissRequest,
-            infoContent = {
-                if (isLoading) {
-                    Spacer(Modifier.height(18.dp))
-                    CircularProgressIndicator(color = Accent)
-                } else {
-                    DetailCard(
-                        label = stringResource(R.string.library_games_install_path),
-                        value = installPathDisplay,
-                    )
-                    DetailCard(
-                        stringResource(R.string.library_games_download_slash_install),
-                        stringResource(
-                            R.string.library_games_download_install_available,
-                            StorageUtils.formatBinarySize(totalDownloadSize),
-                            StorageUtils.formatBinarySize(totalInstallSize),
-                            StorageUtils.formatBinarySize(availableBytes),
-                        ),
-                        valueColor = if (!isInstallEnabled) DangerRed else null,
-                    )
+        val dlcItems =
+            remember(dlcApps, dlcSizes) {
+                dlcApps.map { dlc ->
+                    val sizes = dlcSizes[dlc.id]
+                    val size =
+                        sizes
+                            ?.downloadSize
+                            ?.takeIf { it > 0L }
+                            ?: sizes?.installSize
+                            ?: 0L
+                    StoreDlcItem(id = dlc.id, name = dlc.name, downloadSize = size)
                 }
-            },
+            }
+        val customPathLabel =
+            when {
+                customPath != null -> stringResource(R.string.common_ui_custom)
+                defaultPathSet -> stringResource(R.string.common_ui_already_set)
+                else -> stringResource(R.string.common_ui_custom)
+            }
+        val isReallyInstalled = installed == true
+
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties =
+                DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
         ) {
-            if (installed == false) {
-                InstallButton(
-                    loading = isLoading,
-                    onClick = {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                shape = RectangleShape,
+                color = Color.Black,
+            ) {
+                StoreGameDetailScreen(
+                    title = app.name,
+                    subtitle =
+                        listOfNotNull(
+                            app.developer.takeIf { it.isNotBlank() },
+                            app.publisher.takeIf { it.isNotBlank() },
+                        ).joinToString(" • "),
+                    sourceLabel = "Steam",
+                    heroImageUrl = app.getHeroUrl(),
+                    isLoading = isLoading,
+                    isInstalled = isReallyInstalled,
+                    installPathDisplay = installPathDisplay,
+                    downloadSize = totalDownloadSize,
+                    installSize = totalInstallSize,
+                    availableBytes = availableBytes,
+                    isInstallEnabled = isInstallEnabled,
+                    customPathLabel = customPathLabel,
+                    showCustomPath = true,
+                    showCloudSync = false,
+                    showUninstall = false,
+                    dlcs = dlcItems,
+                    selectedDlcIds = selectedDlcIds.toSet(),
+                    onBack = onDismissRequest,
+                    onPlay = {
+                        launchSteamGame(context, ContainerManager(context), app)
+                        onDismissRequest()
+                    },
+                    onInstall = {
                         scope.launch(Dispatchers.IO) {
                             SteamService.downloadApp(app.id, selectedDlcIds.toList(), false, customPath)
                             withContext(Dispatchers.Main) { onDismissRequest() }
                         }
                     },
-                )
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                CompactActionButton(
-                    icon = Icons.Outlined.Folder,
-                    label =
-                        if (customPath !=
-                            null
-                        ) {
-                            stringResource(R.string.common_ui_custom)
-                        } else if (defaultPathSet) {
-                            stringResource(R.string.common_ui_already_set)
-                        } else {
-                            stringResource(R.string.common_ui_custom)
-                        },
-                    modifier = Modifier.weight(1f),
-                    onClick = {
+                    onCustomPath = {
                         if (customPath == null && defaultPathSet) {
                             showCustomPathWarning = true
                         } else {
@@ -8184,15 +7671,22 @@ class UnifiedActivity :
                             ) { path -> customPath = path }
                         }
                     },
+                    onToggleDlc = { id ->
+                        if (selectedDlcIds.contains(id)) {
+                            selectedDlcIds.remove(id)
+                        } else {
+                            selectedDlcIds.add(id)
+                        }
+                    },
+                    onToggleSelectAllDlcs = {
+                        val all = dlcItems.isNotEmpty() && dlcItems.all { it.id in selectedDlcIds }
+                        if (all) {
+                            selectedDlcIds.clear()
+                        } else {
+                            dlcItems.forEach { if (it.id !in selectedDlcIds) selectedDlcIds.add(it.id) }
+                        }
+                    },
                 )
-                if (dlcApps.isNotEmpty()) {
-                    CompactActionButton(
-                        icon = Icons.Outlined.Extension,
-                        label = stringResource(R.string.library_games_dlcs),
-                        modifier = Modifier.weight(1f),
-                        onClick = { showDlcDialog = true },
-                    )
-                }
             }
         }
     }

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -6011,10 +6011,6 @@ class UnifiedActivity :
                     dlcs = dlcItems,
                     selectedDlcIds = selectedDlcIds.toSet(),
                     onBack = onDismissRequest,
-                    onPlay = {
-                        launchEpicGame(context, ContainerManager(context), app)
-                        onDismissRequest()
-                    },
                     onInstall = {
                         val installPath =
                             if (customPath != null) {
@@ -6376,10 +6372,6 @@ class UnifiedActivity :
                     dlcs = emptyList(),
                     selectedDlcIds = emptySet(),
                     onBack = onDismissRequest,
-                    onPlay = {
-                        launchGogGame(context, ContainerManager(context), app)
-                        onDismissRequest()
-                    },
                     onInstall = {
                         GOGService.downloadGame(context, app.id, installPathDisplay, PrefManager.containerLanguage)
                         onDismissRequest()
@@ -7518,6 +7510,7 @@ class UnifiedActivity :
         var selectedManifestSizes by remember { mutableStateOf(SteamService.ManifestSizes()) }
         var dlcApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
         var dlcSizes by remember { mutableStateOf<Map<Int, SteamService.ManifestSizes>>(emptyMap()) }
+        var installedDlcIds by remember(app.id) { mutableStateOf<Set<Int>>(emptySet()) }
         var installed by remember(app.id) { mutableStateOf<Boolean?>(null) }
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
@@ -7541,6 +7534,7 @@ class UnifiedActivity :
         data class SteamInstallLoadData(
             val dlcApps: List<SteamApp>,
             val dlcSizes: Map<Int, SteamService.ManifestSizes>,
+            val installedDlcIds: Set<Int>,
             val baseManifestSizes: SteamService.ManifestSizes,
             val installed: Boolean,
         )
@@ -7553,15 +7547,22 @@ class UnifiedActivity :
                         selectableDlcApps.associate { dlc ->
                             dlc.id to SteamService.getDlcOnlyManifestSizes(app.id, dlc.id)
                         }
+                    val installedDlcIds =
+                        SteamService.getInstalledDlcDepotsOf(app.id)
+                            .orEmpty()
+                            .toSet()
                     SteamInstallLoadData(
                         dlcApps = selectableDlcApps,
                         dlcSizes = perDlcSizes,
-                        baseManifestSizes = SteamService.getSelectedManifestSizes(app.id),
+                        installedDlcIds = installedDlcIds,
+                        baseManifestSizes = SteamService.getInstallableSelectedManifestSizes(app.id),
                         installed = SteamService.isAppInstalled(app.id),
                     )
                 }
             dlcApps = loadData.dlcApps
             dlcSizes = loadData.dlcSizes
+            installedDlcIds = loadData.installedDlcIds
+            selectedDlcIds.removeAll(loadData.installedDlcIds)
             selectedManifestSizes = loadData.baseManifestSizes
             installed = loadData.installed
             isLoading = false
@@ -7570,7 +7571,7 @@ class UnifiedActivity :
         LaunchedEffect(app.id, selectedDlcIds.toList()) {
             selectedManifestSizes =
                 withContext(Dispatchers.IO) {
-                    SteamService.getSelectedManifestSizes(app.id, selectedDlcIds.toList())
+                    SteamService.getInstallableSelectedManifestSizes(app.id, selectedDlcIds.toList())
                 }
         }
 
@@ -7594,7 +7595,7 @@ class UnifiedActivity :
         val installPathDisplay = customPath ?: SteamService.defaultAppInstallPath
 
         val dlcItems =
-            remember(dlcApps, dlcSizes) {
+            remember(dlcApps, dlcSizes, installedDlcIds) {
                 dlcApps.map { dlc ->
                     val sizes = dlcSizes[dlc.id]
                     val size =
@@ -7603,7 +7604,12 @@ class UnifiedActivity :
                             ?.takeIf { it > 0L }
                             ?: sizes?.installSize
                             ?: 0L
-                    StoreDlcItem(id = dlc.id, name = dlc.name, downloadSize = size)
+                    StoreDlcItem(
+                        id = dlc.id,
+                        name = dlc.name,
+                        downloadSize = size,
+                        isInstalled = dlc.id in installedDlcIds,
+                    )
                 }
             }
         val customPathLabel =
@@ -7650,13 +7656,12 @@ class UnifiedActivity :
                     dlcs = dlcItems,
                     selectedDlcIds = selectedDlcIds.toSet(),
                     onBack = onDismissRequest,
-                    onPlay = {
-                        launchSteamGame(context, ContainerManager(context), app)
-                        onDismissRequest()
-                    },
                     onInstall = {
                         scope.launch(Dispatchers.IO) {
-                            SteamService.downloadApp(app.id, selectedDlcIds.toList(), false, customPath)
+                            val installableDlcIds = dlcItems
+                                .filter { !it.isInstalled && it.id in selectedDlcIds }
+                                .map { it.id }
+                            SteamService.downloadApp(app.id, installableDlcIds, false, customPath)
                             withContext(Dispatchers.Main) { onDismissRequest() }
                         }
                     },
@@ -7672,6 +7677,9 @@ class UnifiedActivity :
                         }
                     },
                     onToggleDlc = { id ->
+                        if (dlcItems.any { it.id == id && it.isInstalled }) {
+                            return@StoreGameDetailScreen
+                        }
                         if (selectedDlcIds.contains(id)) {
                             selectedDlcIds.remove(id)
                         } else {
@@ -7679,11 +7687,12 @@ class UnifiedActivity :
                         }
                     },
                     onToggleSelectAllDlcs = {
-                        val all = dlcItems.isNotEmpty() && dlcItems.all { it.id in selectedDlcIds }
+                        val selectableDlcItems = dlcItems.filterNot { it.isInstalled }
+                        val all = selectableDlcItems.isNotEmpty() && selectableDlcItems.all { it.id in selectedDlcIds }
                         if (all) {
-                            selectedDlcIds.clear()
+                            selectedDlcIds.removeAll(selectableDlcItems.map { it.id }.toSet())
                         } else {
-                            dlcItems.forEach { if (it.id !in selectedDlcIds) selectedDlcIds.add(it.id) }
+                            selectableDlcItems.forEach { if (it.id !in selectedDlcIds) selectedDlcIds.add(it.id) }
                         }
                     },
                 )

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -7962,6 +7962,7 @@ class UnifiedActivity :
         var isLoading by remember { mutableStateOf(true) }
         var manifestSizes by remember { mutableStateOf(SteamService.ManifestSizes()) }
         var dlcApps by remember { mutableStateOf<List<SteamApp>>(emptyList()) }
+        var dlcSizes by remember { mutableStateOf<Map<Int, SteamService.ManifestSizes>>(emptyMap()) }
         var installed by remember(app.id) { mutableStateOf<Boolean?>(null) }
         val selectedDlcIds = remember { mutableStateListOf<Int>() }
         var customPath by remember { mutableStateOf<String?>(null) }
@@ -8028,7 +8029,26 @@ class UnifiedActivity :
                                         checkmarkColor = Color.White,
                                     ),
                             )
-                            Text(dlc.name, color = TextPrimary, fontSize = 13.sp)
+                            Text(
+                                dlc.name,
+                                color = TextPrimary,
+                                fontSize = 13.sp,
+                                modifier = Modifier.weight(1f),
+                            )
+                            val dlcManifestSizes = dlcSizes[dlc.id]
+                            val dlcSize =
+                                dlcManifestSizes
+                                    ?.downloadSize
+                                    ?.takeIf { it > 0L }
+                                    ?: dlcManifestSizes?.installSize
+                                    ?: 0L
+                            if (dlcSize > 0L) {
+                                Text(
+                                    StorageUtils.formatBinarySize(dlcSize),
+                                    color = TextSecondary,
+                                    fontSize = 12.sp,
+                                )
+                            }
                         }
                     }
                 }
@@ -8037,18 +8057,32 @@ class UnifiedActivity :
 
         val selectedDlcIdsKey = selectedDlcIds.toList().sorted().joinToString(",")
 
+        data class SteamInstallLoadData(
+            val dlcApps: List<SteamApp>,
+            val dlcSizes: Map<Int, SteamService.ManifestSizes>,
+            val manifestSizes: SteamService.ManifestSizes,
+            val installed: Boolean,
+        )
+
         LaunchedEffect(app.id) {
-            val (downloadableDlcApps, sizes, isInstalled) =
+            val loadData =
                 withContext(Dispatchers.IO) {
-                    Triple(
-                        db.steamAppDao().findDownloadableDLCApps(app.id) ?: emptyList(),
-                        SteamService.getSelectedManifestSizes(app.id),
-                        SteamService.isAppInstalled(app.id),
+                    val selectableDlcApps = SteamService.getSelectableDlcAppsOf(app.id)
+                    val perDlcSizes =
+                        selectableDlcApps.associate { dlc ->
+                            dlc.id to SteamService.getDlcOnlyManifestSizes(app.id, dlc.id)
+                        }
+                    SteamInstallLoadData(
+                        dlcApps = selectableDlcApps,
+                        dlcSizes = perDlcSizes,
+                        manifestSizes = SteamService.getSelectedManifestSizes(app.id),
+                        installed = SteamService.isAppInstalled(app.id),
                     )
                 }
-            dlcApps = downloadableDlcApps
-            manifestSizes = sizes
-            installed = isInstalled
+            dlcApps = loadData.dlcApps
+            dlcSizes = loadData.dlcSizes
+            manifestSizes = loadData.manifestSizes
+            installed = loadData.installed
             isLoading = false
         }
 

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -7648,6 +7648,8 @@ class UnifiedActivity :
                     )
         }
         val updateActionEnabled = steamDownloadRecord == null
+        val installActionEnabled = isInstallEnabled && steamDownloadRecord == null
+        val activeSteamDownloadText = stringResource(R.string.store_game_download_already_active)
         val noUpdateAvailableText = stringResource(R.string.store_game_no_update_available)
         val updateAvailableText = stringResource(R.string.store_game_update_available)
         val updateFailedText = stringResource(R.string.store_game_update_check_failed)
@@ -7681,6 +7683,7 @@ class UnifiedActivity :
                     installSize = totalInstallSize,
                     availableBytes = availableBytes,
                     isInstallEnabled = isInstallEnabled,
+                    isDownloadActionEnabled = installActionEnabled,
                     customPathLabel = customPathLabel,
                     showCustomPath = true,
                     showCloudSync = false,
@@ -7694,8 +7697,17 @@ class UnifiedActivity :
                     isUpdateCheckCoolingDown = isUpdateCheckCoolingDown,
                     dlcs = dlcItems,
                     selectedDlcIds = selectedDlcIds.toSet(),
+                    isDlcSelectionEnabled = steamDownloadRecord == null,
                     onBack = onDismissRequest,
                     onInstall = {
+                        if (steamDownloadRecord != null) {
+                            com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                context,
+                                activeSteamDownloadText,
+                                android.widget.Toast.LENGTH_SHORT,
+                            )
+                            return@StoreGameDetailScreen
+                        }
                         scope.launch(Dispatchers.IO) {
                             val installableDlcIds = dlcItems
                                 .filter { !it.isInstalled && it.id in selectedDlcIds }
@@ -7787,6 +7799,9 @@ class UnifiedActivity :
                         }
                     },
                     onToggleDlc = { id ->
+                        if (steamDownloadRecord != null) {
+                            return@StoreGameDetailScreen
+                        }
                         if (dlcItems.any { it.id == id && it.isInstalled }) {
                             return@StoreGameDetailScreen
                         }
@@ -7797,6 +7812,9 @@ class UnifiedActivity :
                         }
                     },
                     onToggleSelectAllDlcs = {
+                        if (steamDownloadRecord != null) {
+                            return@StoreGameDetailScreen
+                        }
                         val selectableDlcItems = dlcItems.filterNot { it.isInstalled }
                         val all = selectableDlcItems.isNotEmpty() && selectableDlcItems.all { it.id in selectedDlcIds }
                         if (all) {

--- a/app/src/main/feature/stores/steam/data/DownloadInfo.kt
+++ b/app/src/main/feature/stores/steam/data/DownloadInfo.kt
@@ -36,6 +36,7 @@ class DownloadInfo(
     private var weightSum = jobCount.toFloat()
 
     private var totalExpectedBytes = AtomicLong(0L)
+    private var displayTotalExpectedBytes = AtomicLong(0L)
     private var bytesDownloaded = AtomicLong(0L)
 
     @Volatile private var persistencePath: String? = null
@@ -131,6 +132,10 @@ class DownloadInfo(
 
     fun setTotalExpectedBytes(bytes: Long) {
         totalExpectedBytes.set(if (bytes < 0L) 0L else bytes)
+    }
+
+    fun setDisplayTotalExpectedBytes(bytes: Long) {
+        displayTotalExpectedBytes.set(if (bytes < 0L) 0L else bytes)
     }
 
     fun initializeBytesDownloaded(value: Long) {
@@ -334,6 +339,14 @@ class DownloadInfo(
         } else {
             0L to 0L
         }
+    }
+
+    fun getDisplayBytesProgress(): Pair<Long, Long> {
+        val displayTotal = displayTotalExpectedBytes.get()
+        if (displayTotal <= 0L) return getBytesProgress()
+
+        val displayDownloaded = (getProgress().coerceIn(0f, 1f) * displayTotal.toFloat()).toLong()
+        return displayDownloaded.coerceIn(0L, displayTotal) to displayTotal
     }
 
     private fun getSpeedOverWindow(windowMs: Long): Double? {

--- a/app/src/main/feature/stores/steam/db/dao/SteamLicenseDao.kt
+++ b/app/src/main/feature/stores/steam/db/dao/SteamLicenseDao.kt
@@ -36,6 +36,13 @@ interface SteamLicenseDao {
     @Query("SELECT * FROM steam_license WHERE packageId = :packageId")
     suspend fun findLicense(packageId: Int): SteamLicense?
 
+    @Query(
+        "SELECT COUNT(*) FROM steam_license AS license " +
+            "WHERE license.license_type <> 0 AND " +
+            "REPLACE(REPLACE(license.app_ids, '[', ','), ']', ',') LIKE ('%,' || :appId || ',%')",
+    )
+    suspend fun countLicensesForApp(appId: Int): Int
+
     /* ----------------------------------------------------------
        INTERNAL queries that Room generates.  Keep them abstract.
        ---------------------------------------------------------- */

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -1009,18 +1009,26 @@ class SteamService :
                         }.map { it.dlcAppId }
 
                 val indirectDlcApps = service.appDao.findDownloadableDLCApps(appId).orEmpty()
-                val indirectDlcAppsById = indirectDlcApps.associateBy { it.id }
+                val hiddenDlcApps = service.appDao.findHiddenDLCApps(appId).orEmpty()
+                val dlcAppsById = (indirectDlcApps + hiddenDlcApps).associateBy { it.id }
                 val indirectDlcIds = indirectDlcApps.map { it.id }.asSequence()
+                val hiddenDlcIds = hiddenDlcApps.map { it.id }.asSequence()
+                val groupedBaseDlcIds =
+                    getGroupedBaseAppDlcIds(
+                        appInfo = appInfo,
+                        preferredLanguage = preferredLanguage,
+                        has64Bit = has64Bit,
+                    ).asSequence()
 
                 val declaredDlcIds = appInfo.dlcAppIds.asSequence()
 
-                val selectableDlcIds = (mainAppDlcIds + indirectDlcIds + declaredDlcIds).distinct().toList()
+                val selectableDlcIds = (mainAppDlcIds + groupedBaseDlcIds + indirectDlcIds + hiddenDlcIds + declaredDlcIds).distinct().toList()
 
                 if (selectableDlcIds.isEmpty()) return@runBlocking emptyList()
 
                 selectableDlcIds
                     .mapNotNull { dlcAppId ->
-                        val dlcApp = service.appDao.findApp(dlcAppId) ?: indirectDlcAppsById[dlcAppId]
+                        val dlcApp = service.appDao.findApp(dlcAppId) ?: dlcAppsById[dlcAppId]
                         dlcApp?.takeIf { it.name.isNotBlank() }
                     }
                     .sortedBy { it.name.lowercase() }
@@ -1463,6 +1471,7 @@ class SteamService :
             appId: Int,
             userSelectedDlcAppIds: Collection<Int>,
             preferredLanguage: String = PrefManager.containerLanguage,
+            branch: String = "public",
         ): Map<Int, DepotInfo> {
             val downloadableDepots = getDownloadableDepots(appId, preferredLanguage)
             if (downloadableDepots.isEmpty()) return emptyMap()
@@ -1470,22 +1479,146 @@ class SteamService :
             val selectedDlcIds = userSelectedDlcAppIds.toSet()
             val indirectDlcAppIds = getDownloadableDlcAppsOf(appId).orEmpty().map { it.id }.toSet()
             val mainDepots = getMainAppDepots(appId)
+            val groupedBaseDlcDepotIds =
+                getAppInfoOf(appId)
+                    ?.let { getGroupedBaseAppDlcContentDepotIds(it) }
+                    .orEmpty()
 
             val selectedMainDepots =
-                mainDepots.filter { (_, depot) ->
-                    depot.dlcAppId == INVALID_APP_ID ||
-                        (depot.dlcAppId in selectedDlcIds && depot.manifests.isNotEmpty())
-                }
+                mainDepots.filter { (depotId, depot) ->
+                    (depot.dlcAppId == INVALID_APP_ID && depotId !in groupedBaseDlcDepotIds) ||
+                        (depot.dlcAppId in selectedDlcIds && resolveDepotManifestInfo(depot, branch) != null)
+                } + getSelectedBaseAppDlcContentDepots(appId, selectedDlcIds, preferredLanguage, branch)
 
             val selectedDlcDepots =
                 downloadableDepots.filter { (depotId, depot) ->
                     depotId !in selectedMainDepots &&
                         depot.dlcAppId in selectedDlcIds &&
                         depot.dlcAppId in indirectDlcAppIds &&
-                        depot.manifests.isNotEmpty()
+                        resolveDepotManifestInfo(depot, branch) != null
                 }
 
             return selectedMainDepots + selectedDlcDepots
+        }
+
+        private fun getGroupedBaseAppDlcContentDepotIds(appInfo: SteamApp): Set<Int> {
+            return getGroupedBaseAppDlcDepots(appInfo).map { it.depotId }.toSet()
+        }
+
+        private fun getGroupedBaseAppDlcIds(
+            appInfo: SteamApp,
+            preferredLanguage: String = PrefManager.containerLanguage,
+            has64Bit: Boolean =
+                appInfo.depots.values.any {
+                    it.osArch == OSArch.Arch64 &&
+                        (it.osList.contains(OS.windows) || it.osList.isEmpty() || it.osList.contains(OS.none))
+                },
+        ): Set<Int> {
+            return getGroupedBaseAppDlcDepots(appInfo)
+                .filter { groupedDepot ->
+                    filterForDownloadableDepots(groupedDepot.depot, has64Bit, preferredLanguage, ownedDlc = null)
+                }.map { it.dlcAppId }
+                .toSet()
+        }
+
+        private data class GroupedBaseAppDlcDepot(
+            val depotId: Int,
+            val dlcAppId: Int,
+            val depot: DepotInfo,
+        )
+
+        private fun getGroupedBaseAppDlcDepots(appInfo: SteamApp): List<GroupedBaseAppDlcDepot> {
+            val declaredDlcIds =
+                (
+                    appInfo.dlcAppIds.asSequence() +
+                        appInfo.depots.values.asSequence()
+                            .map { it.dlcAppId }
+                            .filter { it != INVALID_APP_ID }
+                ).toSet()
+            if (declaredDlcIds.isEmpty()) return emptyList()
+
+            val depotIds = mutableListOf<GroupedBaseAppDlcDepot>()
+            var activeDlcAppId: Int? = null
+            for ((depotId, depot) in appInfo.depots) {
+                val isDlcMarkerDepot =
+                    depotId in declaredDlcIds &&
+                        depot.manifests.isEmpty()
+                if (isDlcMarkerDepot) {
+                    activeDlcAppId = depotId
+                    continue
+                }
+
+                val dlcAppId = activeDlcAppId
+                if (dlcAppId != null && depot.dlcAppId == INVALID_APP_ID) {
+                    depotIds += GroupedBaseAppDlcDepot(depotId, dlcAppId, depot)
+                }
+            }
+
+            return depotIds
+        }
+
+        private fun getSelectedBaseAppDlcContentDepots(
+            appId: Int,
+            selectedDlcAppIds: Collection<Int>,
+            preferredLanguage: String = PrefManager.containerLanguage,
+            branch: String = "public",
+        ): Map<Int, DepotInfo> {
+            if (selectedDlcAppIds.isEmpty()) return emptyMap()
+            val appInfo = getAppInfoOf(appId) ?: return emptyMap()
+            val selectedDlcIds = selectedDlcAppIds.toSet()
+            val declaredDlcIds =
+                (
+                    appInfo.dlcAppIds.asSequence() +
+                        appInfo.depots.values.asSequence()
+                            .map { it.dlcAppId }
+                            .filter { it != INVALID_APP_ID }
+                ).toSet()
+            if (declaredDlcIds.isEmpty()) return emptyMap()
+
+            val has64Bit =
+                appInfo.depots.values.any {
+                    it.osArch == OSArch.Arch64 &&
+                        (it.osList.contains(OS.windows) || it.osList.isEmpty() || it.osList.contains(OS.none))
+                }
+
+            val selectedDepots = linkedMapOf<Int, DepotInfo>()
+            var activeDlcAppId: Int? = null
+            for ((depotId, depot) in appInfo.depots) {
+                val isDlcMarkerDepot =
+                    depotId in declaredDlcIds &&
+                        depot.manifests.isEmpty()
+                if (isDlcMarkerDepot) {
+                    activeDlcAppId = depotId.takeIf { it in selectedDlcIds }
+                    continue
+                }
+
+                val selectedDlcAppId =
+                    when {
+                        depot.dlcAppId in selectedDlcIds -> depot.dlcAppId
+                        depot.dlcAppId == INVALID_APP_ID -> activeDlcAppId
+                        else -> null
+                    } ?: continue
+
+                val selectedDepot =
+                    if (depot.dlcAppId == selectedDlcAppId) {
+                        depot
+                    } else {
+                        depot.copy(dlcAppId = selectedDlcAppId)
+                    }
+
+                if (!filterForDownloadableDepots(selectedDepot, has64Bit, preferredLanguage, ownedDlc = null)) continue
+                if (resolveDepotManifestInfo(selectedDepot, branch) == null) continue
+                selectedDepots[depotId] = selectedDepot
+            }
+
+            if (selectedDepots.isNotEmpty()) {
+                Timber.i(
+                    "Recovered base-app DLC content depots for appId=$appId " +
+                        "selectedDlcAppIds=${selectedDlcIds.sorted()} " +
+                        "depotIdsByDlc=${selectedDepots.values.groupBy({ it.dlcAppId }, { it.depotId })}",
+                )
+            }
+            return selectedDepots
         }
 
         private fun resolveDepotManifestInfo(
@@ -1510,13 +1643,18 @@ class SteamService :
             return resolveDepotManifestInfo(sourceDepot, branch, visitedApps)
         }
 
+        private fun manifestDownloadBytes(manifest: ManifestInfo?): Long {
+            if (manifest == null) return 0L
+            return manifest.download.takeIf { it > 0L } ?: manifest.size.coerceAtLeast(0L)
+        }
+
         fun getSelectedManifestSizes(
             appId: Int,
             userSelectedDlcAppIds: Collection<Int> = emptyList(),
             preferredLanguage: String = PrefManager.containerLanguage,
             branch: String = "public",
         ): ManifestSizes {
-            val selectedDepots = getSelectedDownloadDepots(appId, userSelectedDlcAppIds, preferredLanguage)
+            val selectedDepots = getSelectedDownloadDepots(appId, userSelectedDlcAppIds, preferredLanguage, branch)
             if (selectedDepots.isEmpty()) return ManifestSizes()
 
             var totalInstallSize = 0L
@@ -1525,7 +1663,7 @@ class SteamService :
             selectedDepots.values.forEach { depot ->
                 val manifest = resolveDepotManifestInfo(depot, branch)
                 totalInstallSize += manifest?.size ?: 0L
-                totalDownloadSize += manifest?.download ?: 0L
+                totalDownloadSize += manifestDownloadBytes(manifest)
             }
 
             return ManifestSizes(
@@ -1540,22 +1678,34 @@ class SteamService :
             preferredLanguage: String = PrefManager.containerLanguage,
             branch: String = "public",
         ): ManifestSizes {
-            val dlcDepots =
-                getDownloadableDepots(appId, preferredLanguage)
-                    .values
-                    .filter { depot ->
-                        depot.dlcAppId == dlcAppId && depot.manifests.isNotEmpty()
-                    }
+            val service = instance ?: return ManifestSizes()
+            val mainAppInfo =
+                runBlocking(Dispatchers.IO) { service.appDao.findApp(appId) } ?: return ManifestSizes()
+            val has64Bit =
+                mainAppInfo.depots.values.any {
+                    it.osArch == OSArch.Arch64 &&
+                        (it.osList.contains(OS.windows) || (it.osList.isEmpty() || it.osList.contains(OS.none)))
+                }
 
-            if (dlcDepots.isEmpty()) return ManifestSizes()
+            val mainAppDlcDepots =
+                getSelectedBaseAppDlcContentDepots(appId, listOf(dlcAppId), preferredLanguage, branch).values
+
+            val dlcAppInfo = runBlocking(Dispatchers.IO) { service.appDao.findApp(dlcAppId) }
+            val dlcAppDepots =
+                dlcAppInfo?.depots?.values?.filter { depot ->
+                    filterForDownloadableDepots(depot, has64Bit, preferredLanguage, ownedDlc = null)
+                }.orEmpty()
+
+            val combined = (mainAppDlcDepots + dlcAppDepots).associateBy { it.depotId }.values
+            if (combined.isEmpty()) return ManifestSizes()
 
             var totalInstallSize = 0L
             var totalDownloadSize = 0L
 
-            dlcDepots.forEach { depot ->
+            combined.forEach { depot ->
                 val manifest = resolveDepotManifestInfo(depot, branch)
                 totalInstallSize += manifest?.size ?: 0L
-                totalDownloadSize += manifest?.download ?: 0L
+                totalDownloadSize += manifestDownloadBytes(manifest)
             }
 
             return ManifestSizes(
@@ -2566,6 +2716,10 @@ class SteamService :
         ): DownloadInfo? {
             var appDirPath = getAppDirPath(appId)
             Timber.i("downloadApp called for appId: $appId, customInstallPath: $customInstallPath")
+            Timber.i(
+                "Steam DLC selection: appId=$appId selectedDlcAppIds=${userSelectedDlcAppIds.sorted()} " +
+                    "includeInstalledDepots=$includeInstalledDepots verify=$enableVerify allowResume=$allowPersistedProgress",
+            )
 
             if (customInstallPath != null) {
                 // Determine if customInstallPath is the game folder itself or the parent
@@ -2655,25 +2809,94 @@ class SteamService :
 
             // Depots from Main game
             val mainDepots = getMainAppDepots(appId)
+            val groupedBaseDlcDepotIds =
+                getAppInfoOf(appId)
+                    ?.let { getGroupedBaseAppDlcContentDepotIds(it) }
+                    .orEmpty()
             Timber.d("Main app depots count: ${mainDepots.size}")
             val originalMainAppDepots =
-                mainDepots.filter { (_, depot) ->
-                    depot.dlcAppId == INVALID_APP_ID
+                mainDepots.filter { (depotId, depot) ->
+                    depot.dlcAppId == INVALID_APP_ID && depotId !in groupedBaseDlcDepotIds
                 } +
                     mainDepots.filter { (_, depot) ->
-                        userSelectedDlcAppIds.contains(depot.dlcAppId) && depot.manifests.isNotEmpty()
-                    }
+                        userSelectedDlcAppIds.contains(depot.dlcAppId) &&
+                            resolveDepotManifestInfo(depot, branch) != null
+                    } +
+                    getSelectedBaseAppDlcContentDepots(
+                        appId = appId,
+                        selectedDlcAppIds = userSelectedDlcAppIds,
+                        preferredLanguage = PrefManager.containerLanguage,
+                        branch = branch,
+                    )
             var mainAppDepots = originalMainAppDepots
             Timber.d("Filtered main app depots count: ${mainAppDepots.size}")
 
-            // Depots from DLC App
-            val dlcAppDepots =
+            // Depots from indirect DLC apps (those reachable via findDownloadableDLCApps, which
+            // requires a cached license row).
+            val indirectDlcAppDepots =
                 downloadableDepots.filter { (_, depot) ->
                     !mainAppDepots.map { it.key }.contains(depot.depotId) &&
-                        userSelectedDlcAppIds.contains(depot.dlcAppId) && indirectDlcAppIds.contains(depot.dlcAppId) &&
-                        depot.manifests.isNotEmpty()
+                        userSelectedDlcAppIds.contains(depot.dlcAppId) &&
+                        indirectDlcAppIds.contains(depot.dlcAppId) &&
+                        resolveDepotManifestInfo(depot, branch) != null
                 }
-            Timber.d("Filtered DLC app depots count: ${dlcAppDepots.size}")
+            Timber.d("Filtered indirect DLC app depots count: ${indirectDlcAppDepots.size}")
+
+            // Selected DLCs whose depots aren't reachable through `indirectDlcAppIds` (e.g. the
+            // license row is stale or the DLC is declared on the base game only). Look them up
+            // by appId so the download includes the same depots `getDlcOnlyManifestSizes` uses
+            // on the store screen — keeping the pre-download estimate and the downloads-tab
+            // total in sync.
+            val coveredDlcAppIds =
+                (originalMainAppDepots.values.asSequence() + indirectDlcAppDepots.values.asSequence())
+                    .mapNotNull { d -> d.dlcAppId.takeIf { it != INVALID_APP_ID } }
+                    .toSet()
+            val missingDlcAppIds = userSelectedDlcAppIds.filter { it !in coveredDlcAppIds }
+            val extraDlcAppDepots: Map<Int, DepotInfo> =
+                if (missingDlcAppIds.isEmpty()) {
+                    emptyMap()
+                } else {
+                    val appInfoForArch = getAppInfoOf(appId)
+                    val extraHas64Bit =
+                        appInfoForArch?.depots?.values?.any {
+                            it.osArch == OSArch.Arch64 &&
+                                (it.osList.contains(OS.windows) || it.osList.isEmpty() || it.osList.contains(OS.none))
+                        } ?: false
+                    val extraLanguage = PrefManager.containerLanguage
+                    val coveredDepotIds = originalMainAppDepots.keys + indirectDlcAppDepots.keys
+                    val collected = mutableMapOf<Int, DepotInfo>()
+                    for (dlcAppId in missingDlcAppIds) {
+                        val dlcAppInfo =
+                            runBlocking(Dispatchers.IO) { instance?.appDao?.findApp(dlcAppId) }
+                                ?: continue
+                        for ((depotId, depot) in dlcAppInfo.depots) {
+                            if (depotId in coveredDepotIds || depotId in collected) continue
+                            if (!filterForDownloadableDepots(depot, extraHas64Bit, extraLanguage, ownedDlc = null)) continue
+                            if (resolveDepotManifestInfo(depot, branch) == null) continue
+                            collected[depotId] =
+                                DepotInfo(
+                                    depotId = depot.depotId,
+                                    dlcAppId = dlcAppId,
+                                    optionalDlcId = depot.optionalDlcId,
+                                    depotFromApp = depot.depotFromApp,
+                                    sharedInstall = depot.sharedInstall,
+                                    osList = depot.osList,
+                                    osArch = depot.osArch,
+                                    language = depot.language,
+                                    manifests = depot.manifests,
+                                    encryptedManifests = depot.encryptedManifests,
+                                )
+                        }
+                    }
+                    collected
+                }
+            if (extraDlcAppDepots.isNotEmpty()) {
+                Timber.d("Recovered ${extraDlcAppDepots.size} extra DLC depots for selected DLCs ${missingDlcAppIds}")
+            }
+            // Single combined view of DLC depots used by the rest of the function. Downstream
+            // code groups by dlcAppId, computes totals, and persists DownloadingAppInfo from
+            // this map — the extras need to be visible everywhere.
+            val dlcAppDepots = indirectDlcAppDepots + extraDlcAppDepots
 
             // Remove depots that are already downloaded only when install metadata is trusted.
             // But if a custom path is provided, we want to check/download everything at the new location
@@ -2726,10 +2949,13 @@ class SteamService :
             }
 
             val allDepots = originalMainAppDepots + dlcAppDepots
-            // Use install (uncompressed) size for progress tracking
+            // Use install (uncompressed) size for progress tracking.
+            // resolveDepotManifestInfo follows depot.depotFromApp and falls back to the public
+            // branch, so shared/proxied DLC depots (whose real manifest lives on the base app)
+            // contribute their full size to the total instead of the 1L fallback.
             val depotSizeById =
                 allDepots.mapValues { (_, depot) ->
-                    val mInfo = depot.manifests[branch] ?: depot.encryptedManifests[branch]
+                    val mInfo = resolveDepotManifestInfo(depot, branch)
                     (mInfo?.size ?: 1L).coerceAtLeast(1L)
                 }
 
@@ -2918,8 +3144,8 @@ class SteamService :
                 dlcAppDepots.values
                     .groupBy(keySelector = { it.dlcAppId }, valueTransform = { it.depotId })
                     .mapValues { (_, depotIds) -> depotIds.sorted() }
-            val selectedDepotIdsByDlcAppId =
-                selectedDepots.values
+            val selectedDlcDepotIdsByDlcAppId =
+                filteredDlcAppDepots.values
                     .groupBy(keySelector = { it.dlcAppId }, valueTransform = { it.depotId })
                     .mapValues { (_, depotIds) -> depotIds.sorted() }
 
@@ -2935,13 +3161,34 @@ class SteamService :
                 downloadingAppIds.add(appId)
             }
 
-            // There are some apps, the dlc depots does not have dlcAppId in the data, need to set it back
-            val mainAppDlcIds = getMainAppDlcIdsWithoutProperDepotDlcIds(appId)
+            // There are some apps where DLC content lives under the base app without a
+            // dlcAppId on every content depot. Only persist DLC metadata that belongs to
+            // the current selected scope; otherwise marker-only DLCs can be falsely saved
+            // as installed when a sibling DLC is selected.
+            val selectedDlcAppIdSet = userSelectedDlcAppIds.toSet()
+            val mainAppDlcIds =
+                getMainAppDlcIdsWithoutProperDepotDlcIds(appId)
+                    .filterTo(mutableListOf()) { it in selectedDlcAppIdSet }
+            mainAppDlcIds.addAll(
+                mainAppDepots.values
+                    .map { it.dlcAppId }
+                    .filter { it != INVALID_APP_ID && it in selectedDlcAppIdSet }
+                    .distinct(),
+            )
 
             // If there are no DLC depots, download the main app only
             if (dlcAppDepots.isEmpty()) {
                 // Because all dlcIDs are coming from main depots, need to add the dlcID to main app in order to save it to db after finish download
-                mainAppDlcIds.addAll(mainAppDepots.filter { it.value.dlcAppId != INVALID_APP_ID }.map { it.value.dlcAppId }.distinct())
+                mainAppDlcIds.addAll(
+                    mainAppDepots
+                        .filter { it.value.dlcAppId != INVALID_APP_ID && it.value.dlcAppId in selectedDlcAppIdSet }
+                        .map { it.value.dlcAppId }
+                        .distinct(),
+                )
+                // Some Steam DLCs are entitlement/config DLC with no separate downloadable
+                // depot. They still need to be remembered as selected/installed so launch
+                // metadata can expose them later.
+                mainAppDlcIds.addAll(userSelectedDlcAppIds)
 
                 // Refresh id List, so only main app is downloaded
                 calculatedDlcAppIds.clear()
@@ -2960,6 +3207,24 @@ class SteamService :
                     return null
                 }
 
+            val selectedDepotSizes =
+                selectedDepots.mapValues { (depotId, _) ->
+                    depotSizeById[depotId] ?: 1L
+                }
+            val selectedTotalBytes = selectedDepotSizes.values.sum()
+            val totalBytes = selectedTotalBytes.coerceAtLeast(1L)
+            val selectedDisplayDownloadBytes =
+                selectedDepots.values
+                    .sumOf { depot -> manifestDownloadBytes(resolveDepotManifestInfo(depot, branch)) }
+                    .takeIf { it > 0L }
+                    ?: totalBytes
+            Timber.i(
+                "Steam DLC selected download scope: appId=$appId selectedDlcAppIds=${userSelectedDlcAppIds.sorted()} " +
+                    "calculatedDlcAppIds=${calculatedDlcAppIds.sorted()} mainDepotIds=${mainAppDepots.keys.sorted()} " +
+                    "dlcDepotIdsByApp=$selectedDlcDepotIdsByDlcAppId totalBytes=$totalBytes " +
+                    "displayDownloadBytes=$selectedDisplayDownloadBytes metadataDlcAppIds=${mainAppDlcIds.sorted()}",
+            )
+
             // Save downloading app info
             runBlocking {
                 service.downloadingAppInfoDao.insert(
@@ -2970,6 +3235,10 @@ class SteamService :
                 )
                 Unit
             }
+            Timber.i(
+                "Steam DLC selection persisted: appId=$appId selectedDlcAppIds=${userSelectedDlcAppIds.sorted()} " +
+                    "installPath=$appDirPath",
+            )
 
             // Ask the global coordinator whether this download can start now or must be queued
             // behind downloads from other stores too. The coordinator persists the decision in
@@ -2983,13 +3252,21 @@ class SteamService :
                         title = title,
                         installPath = appDirPath,
                         selectedDlcs = userSelectedDlcAppIds.joinToString(","),
+                        bytesTotal = selectedDisplayDownloadBytes,
                     )
                 }
+            Timber.i(
+                "Steam DLC coordinator record: appId=$appId selectedDlcAppIds=${userSelectedDlcAppIds.sorted()} " +
+                    "bytesTotal=$totalBytes displayDownloadBytes=$selectedDisplayDownloadBytes " +
+                    "decision=${coordDecision::class.simpleName}",
+            )
             if (coordDecision is DownloadCoordinator.Decision.Queue) {
                 Timber.i("Coordinator queued appId: $appId")
                 val info =
                     DownloadInfo(selectedDepots.size, appId, downloadingAppIds).also { di ->
                         di.setPersistencePath(appDirPath)
+                        di.setTotalExpectedBytes(totalBytes)
+                        di.setDisplayTotalExpectedBytes(selectedDisplayDownloadBytes)
                         di.updateStatus(DownloadPhase.QUEUED, "Queued...")
                         di.setActive(false)
                     }
@@ -3003,21 +3280,16 @@ class SteamService :
                     di.setPersistencePath(appDirPath)
 
                     // Set weights for each depot based on manifest sizes
-                    val selectedDepotSizes =
-                        selectedDepots.mapValues { (depotId, _) ->
-                            depotSizeById[depotId] ?: 1L
-                        }
                     selectedDepots.keys.forEachIndexed { index, depotId ->
                         di.setWeight(index, selectedDepotSizes[depotId] ?: 1L)
                     }
 
                     // Track progress only for depots in this active run so excluded/complete depots
                     // (including DLC already marked complete) cannot pre-fill progress at startup.
-                    val selectedTotalBytes = selectedDepotSizes.values.sum()
-                    val totalBytes = selectedTotalBytes.coerceAtLeast(1L)
 
                     // Total expected size (used for ETA based on recent download speed)
                     di.setTotalExpectedBytes(totalBytes)
+                    di.setDisplayTotalExpectedBytes(selectedDisplayDownloadBytes)
 
                     var resumedBytes = 0L
 
@@ -3205,8 +3477,12 @@ class SteamService :
                                         }
 
                                         calculatedDlcAppIds.forEach { dlcAppId ->
-                                            val dlcDepotIds = selectedDepotIdsByDlcAppId[dlcAppId].orEmpty()
+                                            val dlcDepotIds = selectedDlcDepotIdsByDlcAppId[dlcAppId].orEmpty()
                                             if (dlcDepotIds.isEmpty()) return@forEach
+                                            Timber.i(
+                                                "Steam DLC download item queued: baseAppId=$appId dlcAppId=$dlcAppId " +
+                                                    "depotIds=$dlcDepotIds",
+                                            )
 
                                             val dlcAppItem =
                                                 AppItem(
@@ -3369,7 +3645,7 @@ class SteamService :
                                     }
 
                                     calculatedDlcAppIds.forEach { dlcAppId ->
-                                        val dlcDepotIds = allDepotIdsByDlcAppId[dlcAppId].orEmpty()
+                                        val dlcDepotIds = selectedDlcDepotIdsByDlcAppId[dlcAppId].orEmpty()
                                         completeAppDownload(di, dlcAppId, dlcDepotIds, emptyList(), appDirPath)
                                     }
                                     Timber.i("Installation finalized for appId: $appId")
@@ -3549,9 +3825,23 @@ class SteamService :
             downloadJobs[appId] = info
             notifyDownloadStarted(appId)
 
-            val mainAppDlcIds = getMainAppDlcIdsWithoutProperDepotDlcIds(appId)
+            val selectedDlcAppIdSet = userSelectedDlcAppIds.toSet()
+            val mainAppDlcIds =
+                getMainAppDlcIdsWithoutProperDepotDlcIds(appId)
+                    .filterTo(mutableListOf()) { it in selectedDlcAppIdSet }
+            mainAppDlcIds.addAll(
+                mainAppDepots.values
+                    .map { it.dlcAppId }
+                    .filter { it != INVALID_APP_ID && it in selectedDlcAppIdSet }
+                    .distinct(),
+            )
             if (dlcAppDepots.isEmpty()) {
-                mainAppDlcIds.addAll(mainAppDepots.filter { it.value.dlcAppId != INVALID_APP_ID }.map { it.value.dlcAppId }.distinct())
+                mainAppDlcIds.addAll(
+                    mainAppDepots
+                        .filter { it.value.dlcAppId != INVALID_APP_ID && it.value.dlcAppId in selectedDlcAppIdSet }
+                        .map { it.value.dlcAppId }
+                        .distinct(),
+                )
             }
 
             runBlocking(Dispatchers.IO) {
@@ -3598,6 +3888,11 @@ class SteamService :
             appDirPath: String,
         ) {
             Timber.i("Item $downloadingAppId download completed, saving database")
+            Timber.i(
+                "Steam DLC downloaded item: baseAppId=${downloadInfo.gameId} completedAppId=$downloadingAppId " +
+                    "entitledDepotIds=${entitledDepotIds.sorted()} selectedDlcAppIds=${selectedDlcAppIds.sorted()} " +
+                    "remainingAppIds=${downloadInfo.downloadingAppIds.sorted()}",
+            )
 
             // Update database
             val appInfo = instance?.appInfoDao?.getInstalledApp(downloadingAppId)
@@ -3636,6 +3931,10 @@ class SteamService :
             // All downloading appIds are removed
             if (downloadInfo.downloadingAppIds.isEmpty()) {
                 Timber.i("All items for game ${downloadInfo.gameId} completed, running final completion logic.")
+                Timber.i(
+                    "Steam DLC download complete: appId=${downloadInfo.gameId} " +
+                        "downloadedBytes=${downloadInfo.getBytesDownloaded()} totalBytes=${downloadInfo.getTotalExpectedBytes()}",
+                )
                 // Settle the remaining bytes once at the end so the visible progress doesn't
                 // sit slightly under 100% when the game is actually complete (e.g. dedup
                 // skipped chunks that never reported via onChunkCompleted).
@@ -3646,6 +3945,7 @@ class SteamService :
                     if (remainingBytes > 0L) {
                         downloadInfo.updateBytesDownloaded(remainingBytes, System.currentTimeMillis())
                         downloadInfo.emitProgressChange()
+                        updateCoordinatorDownloadProgress(downloadInfo)
                     }
                 }
 
@@ -3701,6 +4001,16 @@ class SteamService :
                 checkQueue()
             }
             Unit
+        }
+
+        private fun updateCoordinatorDownloadProgress(downloadInfo: DownloadInfo) {
+            val (displayDownloadedBytes, displayTotalBytes) = downloadInfo.getDisplayBytesProgress()
+            DownloadCoordinator.updateProgress(
+                DownloadRecord.STORE_STEAM,
+                downloadInfo.gameId.toString(),
+                displayDownloadedBytes,
+                displayTotalBytes,
+            )
         }
 
         // CRITICAL: onChunkCompleted reports PER-DEPOT cumulative bytes, NOT global. The
@@ -3978,6 +4288,7 @@ class SteamService :
 
                     addDeltaToDepotBytes(depotId, deltaBytes)
                     downloadInfo.updateBytesDownloaded(deltaBytes, lastByteProgressAtMs)
+                    updateCoordinatorDownloadProgress(downloadInfo)
                     downloadInfo.markProgressSnapshotDirty()
 
                     // If resume verification/prepare phases already ran and bytes are now moving again,
@@ -4015,6 +4326,7 @@ class SteamService :
                     lastByteProgressAtMs = System.currentTimeMillis()
                     addDeltaToDepotBytes(depotId, sessionDelta)
                     downloadInfo.updateBytesDownloaded(sessionDelta, lastByteProgressAtMs)
+                    updateCoordinatorDownloadProgress(downloadInfo)
                     downloadInfo.markProgressSnapshotDirty()
                 }
 

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -40,7 +40,6 @@ import com.winlator.cmod.feature.stores.steam.db.dao.EncryptedAppTicketDao
 import com.winlator.cmod.feature.stores.steam.db.dao.FileChangeListsDao
 import com.winlator.cmod.feature.stores.steam.db.dao.SteamAppDao
 import com.winlator.cmod.feature.stores.steam.db.dao.SteamLicenseDao
-import com.winlator.cmod.feature.stores.steam.enums.AppType
 import com.winlator.cmod.feature.stores.steam.enums.ControllerSupport
 import com.winlator.cmod.feature.stores.steam.enums.DownloadPhase
 import com.winlator.cmod.feature.stores.steam.enums.GameSource
@@ -990,6 +989,43 @@ class SteamService :
         fun getDownloadableDlcAppsOf(appId: Int): List<SteamApp>? =
             runBlocking(Dispatchers.IO) { instance?.appDao?.findDownloadableDLCApps(appId) }
 
+        fun getSelectableDlcAppsOf(appId: Int): List<SteamApp> =
+            runBlocking(Dispatchers.IO) {
+                val service = instance ?: return@runBlocking emptyList()
+                val appInfo = service.appDao.findApp(appId) ?: return@runBlocking emptyList()
+                val preferredLanguage = PrefManager.containerLanguage
+                val has64Bit =
+                    appInfo.depots.values.any {
+                        it.osArch == OSArch.Arch64 &&
+                            (it.osList.contains(OS.windows) || (it.osList.isEmpty() || it.osList.contains(OS.none)))
+                    }
+
+                val mainAppDlcIds =
+                    appInfo.depots.values
+                        .asSequence()
+                        .filter { depot ->
+                            depot.dlcAppId != INVALID_APP_ID &&
+                                filterForDownloadableDepots(depot, has64Bit, preferredLanguage, ownedDlc = null)
+                        }.map { it.dlcAppId }
+
+                val indirectDlcApps = service.appDao.findDownloadableDLCApps(appId).orEmpty()
+                val indirectDlcAppsById = indirectDlcApps.associateBy { it.id }
+                val indirectDlcIds = indirectDlcApps.map { it.id }.asSequence()
+
+                val declaredDlcIds = appInfo.dlcAppIds.asSequence()
+
+                val selectableDlcIds = (mainAppDlcIds + indirectDlcIds + declaredDlcIds).distinct().toList()
+
+                if (selectableDlcIds.isEmpty()) return@runBlocking emptyList()
+
+                selectableDlcIds
+                    .mapNotNull { dlcAppId ->
+                        val dlcApp = service.appDao.findApp(dlcAppId) ?: indirectDlcAppsById[dlcAppId]
+                        dlcApp?.takeIf { it.name.isNotBlank() }
+                    }
+                    .sortedBy { it.name.lowercase() }
+            }
+
         fun getHiddenDlcAppsOf(appId: Int): List<SteamApp>? = runBlocking(Dispatchers.IO) { instance?.appDao?.findHiddenDLCApps(appId) }
 
         fun getInstalledApp(appId: Int): AppInfo? = runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledApp(appId) }
@@ -1179,9 +1215,11 @@ class SteamService :
                 }.orEmpty()
 
         suspend fun getOwnedAppDlc(appId: Int): Map<Int, DepotInfo> {
-            val client = instance?.steamClient ?: return emptyMap()
-            val accountId = client.steamID?.accountID?.toInt() ?: return emptyMap()
-            val ownedGameIds = getOwnedGames(userSteamId!!.convertToUInt64()).map { it.appId }.toHashSet()
+            val ownedGameIds =
+                runCatching {
+                    val steamId = userSteamId ?: return@runCatching emptySet<Int>()
+                    getOwnedGames(steamId.convertToUInt64()).map { it.appId }.toHashSet()
+                }.getOrDefault(emptySet())
 
             return getAppDlc(appId)
                 .filter { (_, depot) ->
@@ -1189,8 +1227,11 @@ class SteamService :
                         // Base-game depots always download
                         depot.dlcAppId == INVALID_APP_ID -> true
 
-                        // ① licence cache
-                        instance?.licenseDao?.findLicense(depot.dlcAppId) != null -> true
+                        // ① licence cache. DLC app IDs are stored inside package rows,
+                        // not as package IDs themselves.
+                        runBlocking(Dispatchers.IO) {
+                            instance?.licenseDao?.countLicensesForApp(depot.dlcAppId) ?: 0
+                        } > 0 -> true
 
                         // ② PICS row
                         instance?.appDao?.findApp(depot.dlcAppId) != null -> true
@@ -1482,6 +1523,36 @@ class SteamService :
             var totalDownloadSize = 0L
 
             selectedDepots.values.forEach { depot ->
+                val manifest = resolveDepotManifestInfo(depot, branch)
+                totalInstallSize += manifest?.size ?: 0L
+                totalDownloadSize += manifest?.download ?: 0L
+            }
+
+            return ManifestSizes(
+                installSize = totalInstallSize,
+                downloadSize = totalDownloadSize,
+            )
+        }
+
+        fun getDlcOnlyManifestSizes(
+            appId: Int,
+            dlcAppId: Int,
+            preferredLanguage: String = PrefManager.containerLanguage,
+            branch: String = "public",
+        ): ManifestSizes {
+            val dlcDepots =
+                getDownloadableDepots(appId, preferredLanguage)
+                    .values
+                    .filter { depot ->
+                        depot.dlcAppId == dlcAppId && depot.manifests.isNotEmpty()
+                    }
+
+            if (dlcDepots.isEmpty()) return ManifestSizes()
+
+            var totalInstallSize = 0L
+            var totalDownloadSize = 0L
+
+            dlcDepots.forEach { depot ->
                 val manifest = resolveDepotManifestInfo(depot, branch)
                 totalInstallSize += manifest?.size ?: 0L
                 totalDownloadSize += manifest?.download ?: 0L

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -1038,9 +1038,33 @@ class SteamService :
 
         fun getInstalledApp(appId: Int): AppInfo? = runBlocking(Dispatchers.IO) { instance?.appInfoDao?.getInstalledApp(appId) }
 
-        fun getInstalledDepotsOf(appId: Int): List<Int>? = getInstalledApp(appId)?.downloadedDepots
+        fun getInstalledDepotsOf(appId: Int): List<Int>? = getTrustedInstalledAppInfo(appId)?.downloadedDepots
 
-        fun getInstalledDlcDepotsOf(appId: Int): List<Int>? = getInstalledApp(appId)?.dlcDepots
+        fun getInstalledDlcDepotsOf(appId: Int): List<Int>? {
+            val installedApp = getTrustedInstalledAppInfo(appId) ?: return emptyList()
+            val installedDlcAppIds = installedApp.dlcDepots.toMutableSet()
+
+            getDownloadableDlcAppsOf(appId).orEmpty().forEach { dlcApp ->
+                val dlcInfo = getInstalledApp(dlcApp.id)
+                if (dlcInfo?.isDownloaded == true) {
+                    installedDlcAppIds.add(dlcApp.id)
+                }
+            }
+
+            return installedDlcAppIds.sorted()
+        }
+
+        private fun getTrustedInstalledAppInfo(appId: Int): AppInfo? {
+            val appInfo = getInstalledApp(appId) ?: tryRecoverInstalledAppInfo(appId)
+            if (appInfo?.isDownloaded != true) return null
+
+            val dirPath = getAppDirPath(appId)
+            val dir = File(dirPath)
+            if (!dir.isDirectory) return null
+            if (!MarkerUtils.hasMarker(dirPath, Marker.DOWNLOAD_COMPLETE_MARKER)) return null
+
+            return appInfo
+        }
 
         private fun tryRecoverInstalledAppInfo(appId: Int): AppInfo? {
             val dirPath = getAppDirPath(appId)
@@ -1158,10 +1182,7 @@ class SteamService :
         fun getAppDownloadInfo(appId: Int): DownloadInfo? = downloadJobs[appId]
 
         fun isAppInstalled(appId: Int): Boolean {
-            val appInfo = getInstalledApp(appId) ?: tryRecoverInstalledAppInfo(appId)
-            if (appInfo?.isDownloaded != true) return false
-            val dirPath = getAppDirPath(appId)
-            return MarkerUtils.hasMarker(dirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+            return getTrustedInstalledAppInfo(appId) != null
         }
 
         fun uninstallApp(
@@ -1648,19 +1669,14 @@ class SteamService :
             return manifest.download.takeIf { it > 0L } ?: manifest.size.coerceAtLeast(0L)
         }
 
-        fun getSelectedManifestSizes(
-            appId: Int,
-            userSelectedDlcAppIds: Collection<Int> = emptyList(),
-            preferredLanguage: String = PrefManager.containerLanguage,
-            branch: String = "public",
+        private fun calculateManifestSizes(
+            depots: Collection<DepotInfo>,
+            branch: String,
         ): ManifestSizes {
-            val selectedDepots = getSelectedDownloadDepots(appId, userSelectedDlcAppIds, preferredLanguage, branch)
-            if (selectedDepots.isEmpty()) return ManifestSizes()
-
             var totalInstallSize = 0L
             var totalDownloadSize = 0L
 
-            selectedDepots.values.forEach { depot ->
+            depots.forEach { depot ->
                 val manifest = resolveDepotManifestInfo(depot, branch)
                 totalInstallSize += manifest?.size ?: 0L
                 totalDownloadSize += manifestDownloadBytes(manifest)
@@ -1670,6 +1686,81 @@ class SteamService :
                 installSize = totalInstallSize,
                 downloadSize = totalDownloadSize,
             )
+        }
+
+        private fun filterAlreadyInstalledDepots(
+            appId: Int,
+            depots: Map<Int, DepotInfo>,
+            includeInstalledDepots: Boolean,
+        ): Map<Int, DepotInfo> {
+            if (includeInstalledDepots || depots.isEmpty()) return depots
+
+            val installedApp = getTrustedInstalledAppInfo(appId) ?: return depots
+            val installedDlcAppIds = getInstalledDlcDepotsOf(appId).orEmpty().toSet()
+
+            return depots.filter { (depotId, depot) ->
+                val isInstalledBaseDepot =
+                    depot.dlcAppId == INVALID_APP_ID ||
+                        depotId in installedApp.downloadedDepots
+                val isInstalledDlcDepot =
+                    depot.dlcAppId != INVALID_APP_ID &&
+                        depot.dlcAppId in installedDlcAppIds
+
+                !isInstalledBaseDepot && !isInstalledDlcDepot
+            }
+        }
+
+        private fun filterAlreadyInstalledDlcSelection(
+            appId: Int,
+            dlcAppIds: List<Int>,
+            includeInstalledDepots: Boolean,
+            customInstallPath: String?,
+        ): List<Int> {
+            val selected = dlcAppIds.distinct()
+            if (selected.isEmpty() || includeInstalledDepots || customInstallPath != null) return selected
+
+            val installedDlcAppIds = getInstalledDlcDepotsOf(appId).orEmpty().toSet()
+            if (installedDlcAppIds.isEmpty()) return selected
+
+            val filtered = selected.filterNot { it in installedDlcAppIds }
+            val skipped = selected - filtered.toSet()
+            if (skipped.isNotEmpty()) {
+                Timber.i(
+                    "Skipping already-installed Steam DLC selection for appId=$appId " +
+                        "dlcAppIds=${skipped.sorted()}",
+                )
+            }
+            return filtered
+        }
+
+        fun getSelectedManifestSizes(
+            appId: Int,
+            userSelectedDlcAppIds: Collection<Int> = emptyList(),
+            preferredLanguage: String = PrefManager.containerLanguage,
+            branch: String = "public",
+        ): ManifestSizes {
+            val selectedDepots = getSelectedDownloadDepots(appId, userSelectedDlcAppIds, preferredLanguage, branch)
+            if (selectedDepots.isEmpty()) return ManifestSizes()
+
+            return calculateManifestSizes(selectedDepots.values, branch)
+        }
+
+        fun getInstallableSelectedManifestSizes(
+            appId: Int,
+            userSelectedDlcAppIds: Collection<Int> = emptyList(),
+            preferredLanguage: String = PrefManager.containerLanguage,
+            branch: String = "public",
+        ): ManifestSizes {
+            val selectedDepots = getSelectedDownloadDepots(appId, userSelectedDlcAppIds, preferredLanguage, branch)
+            val installableDepots =
+                filterAlreadyInstalledDepots(
+                    appId = appId,
+                    depots = selectedDepots,
+                    includeInstalledDepots = false,
+                )
+            if (installableDepots.isEmpty()) return ManifestSizes()
+
+            return calculateManifestSizes(installableDepots.values, branch)
         }
 
         fun getDlcOnlyManifestSizes(
@@ -1699,19 +1790,7 @@ class SteamService :
             val combined = (mainAppDlcDepots + dlcAppDepots).associateBy { it.depotId }.values
             if (combined.isEmpty()) return ManifestSizes()
 
-            var totalInstallSize = 0L
-            var totalDownloadSize = 0L
-
-            combined.forEach { depot ->
-                val manifest = resolveDepotManifestInfo(depot, branch)
-                totalInstallSize += manifest?.size ?: 0L
-                totalDownloadSize += manifestDownloadBytes(manifest)
-            }
-
-            return ManifestSizes(
-                installSize = totalInstallSize,
-                downloadSize = totalDownloadSize,
-            )
+            return calculateManifestSizes(combined, branch)
         }
 
         fun getAppDirName(app: SteamApp?): String {
@@ -2328,6 +2407,14 @@ class SteamService :
                 return null
             }
 
+            val effectiveDlcAppIds =
+                filterAlreadyInstalledDlcSelection(
+                    appId = appId,
+                    dlcAppIds = dlcAppIds,
+                    includeInstalledDepots = includeInstalledDepots,
+                    customInstallPath = customInstallPath,
+                )
+
             val downloadableDepots = getDownloadableDepots(appId)
             if (downloadableDepots.isEmpty()) {
                 Timber.w("Download aborted: No downloadable depots found for appId: $appId")
@@ -2343,7 +2430,7 @@ class SteamService :
             return downloadApp(
                 appId = appId,
                 downloadableDepots = downloadableDepots,
-                userSelectedDlcAppIds = dlcAppIds,
+                userSelectedDlcAppIds = effectiveDlcAppIds,
                 branch = "public",
                 includeInstalledDepots = includeInstalledDepots,
                 enableVerify = enableVerify,
@@ -2750,6 +2837,14 @@ class SteamService :
                 }
             }
 
+            val hasTrustedInstallAtStart =
+                customInstallPath == null &&
+                    getTrustedInstalledAppInfo(appId) != null
+            val isAddingDlcToTrustedInstall =
+                hasTrustedInstallAtStart &&
+                    !includeInstalledDepots &&
+                    userSelectedDlcAppIds.isNotEmpty()
+
             // Ensure the download directory exists
             try {
                 val dir = File(appDirPath)
@@ -2776,8 +2871,10 @@ class SteamService :
                     Timber.e("Failed to add DOWNLOAD_IN_PROGRESS_MARKER at $appDirPath")
                 }
 
-                // If this is not an update/verify, remove the complete marker to reset state
-                if (!includeInstalledDepots) {
+                // Fresh installs should reset completion state. When the base game is already
+                // trusted, keep the marker while adding DLC so a cancelled DLC download does
+                // not make the whole base install look missing.
+                if (!includeInstalledDepots && !hasTrustedInstallAtStart) {
                     MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
                 }
             } catch (e: Exception) {
@@ -2814,10 +2911,20 @@ class SteamService :
                     ?.let { getGroupedBaseAppDlcContentDepotIds(it) }
                     .orEmpty()
             Timber.d("Main app depots count: ${mainDepots.size}")
+            val baseMainAppDepots =
+                if (isAddingDlcToTrustedInstall) {
+                    Timber.i(
+                        "Building DLC-only Steam download scope for installed appId=$appId " +
+                            "selectedDlcAppIds=${userSelectedDlcAppIds.sorted()}",
+                    )
+                    emptyMap()
+                } else {
+                    mainDepots.filter { (depotId, depot) ->
+                        depot.dlcAppId == INVALID_APP_ID && depotId !in groupedBaseDlcDepotIds
+                    }
+                }
             val originalMainAppDepots =
-                mainDepots.filter { (depotId, depot) ->
-                    depot.dlcAppId == INVALID_APP_ID && depotId !in groupedBaseDlcDepotIds
-                } +
+                baseMainAppDepots +
                     mainDepots.filter { (_, depot) ->
                         userSelectedDlcAppIds.contains(depot.dlcAppId) &&
                             resolveDepotManifestInfo(depot, branch) != null

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -313,6 +313,13 @@ class SteamService :
         val downloadSize: Long = 0L,
     )
 
+    data class SteamUpdateInfo(
+        val hasUpdate: Boolean = false,
+        val downloadSize: Long = 0L,
+        val depotIds: List<Int> = emptyList(),
+        val message: String? = null,
+    )
+
     companion object {
         const val MAX_PICS_BUFFER = 256
 
@@ -1041,18 +1048,25 @@ class SteamService :
         fun getInstalledDepotsOf(appId: Int): List<Int>? = getTrustedInstalledAppInfo(appId)?.downloadedDepots
 
         fun getInstalledDlcDepotsOf(appId: Int): List<Int>? {
-            val installedApp = getTrustedInstalledAppInfo(appId) ?: return emptyList()
-            val installedDlcAppIds = installedApp.dlcDepots.toMutableSet()
+            val installedApp = getTrustedInstalledAppInfo(appId)
+            val installedDlcAppIds = installedApp?.dlcDepots.orEmpty().toMutableSet()
+            installedDlcAppIds.addAll(getInstalledSelectableDlcAppIds(appId))
 
-            getDownloadableDlcAppsOf(appId).orEmpty().forEach { dlcApp ->
-                val dlcInfo = getInstalledApp(dlcApp.id)
-                if (dlcInfo?.isDownloaded == true) {
-                    installedDlcAppIds.add(dlcApp.id)
+            if (installedApp != null && installedDlcAppIds != installedApp.dlcDepots.toSet()) {
+                runBlocking(Dispatchers.IO) {
+                    instance?.appInfoDao?.update(installedApp.copy(dlcDepots = installedDlcAppIds.sorted()))
                 }
             }
 
             return installedDlcAppIds.sorted()
         }
+
+        private fun getInstalledSelectableDlcAppIds(appId: Int): Set<Int> =
+            getSelectableDlcAppsOf(appId)
+                .mapNotNull { dlcApp ->
+                    val dlcInfo = getInstalledApp(dlcApp.id)
+                    if (dlcInfo?.isDownloaded == true) dlcApp.id else null
+                }.toSet()
 
         private fun getTrustedInstalledAppInfo(appId: Int): AppInfo? {
             val appInfo = getInstalledApp(appId) ?: tryRecoverInstalledAppInfo(appId)
@@ -1076,12 +1090,13 @@ class SteamService :
             if (!dir.exists() || !dir.isDirectory) return null
 
             val downloadedDepotIds = runCatching { getMainAppDepots(appId).keys.sorted() }.getOrDefault(emptyList())
+            val installedDlcAppIds = getInstalledSelectableDlcAppIds(appId)
             val recovered =
                 AppInfo(
                     id = appId,
                     isDownloaded = true,
                     downloadedDepots = downloadedDepotIds,
-                    dlcDepots = emptyList(),
+                    dlcDepots = installedDlcAppIds.sorted(),
                 )
 
             runBlocking(Dispatchers.IO) {
@@ -2343,13 +2358,18 @@ class SteamService :
             )
         }
 
-        fun downloadAppForUpdate(appId: Int): DownloadInfo? =
+        fun downloadAppForUpdate(
+            appId: Int,
+            targetDepotIds: Collection<Int> = emptyList(),
+        ): DownloadInfo? =
             downloadApp(
                 appId,
                 resolveInstalledDlcIdsForUpdateOrVerify(appId),
                 includeInstalledDepots = true,
                 enableVerify = false,
                 allowPersistedProgress = false,
+                downloadTaskType = DownloadRecord.TASK_UPDATE,
+                targetDepotIds = targetDepotIds.toSet().takeIf { it.isNotEmpty() },
             )
 
         fun downloadAppForVerify(appId: Int): DownloadInfo? =
@@ -2359,6 +2379,7 @@ class SteamService :
                 includeInstalledDepots = true,
                 enableVerify = true,
                 allowPersistedProgress = false,
+                downloadTaskType = DownloadRecord.TASK_VERIFY,
             )
 
         private fun resolveInstalledDlcIdsForUpdateOrVerify(appId: Int): List<Int> {
@@ -2400,6 +2421,8 @@ class SteamService :
             allowPersistedProgress: Boolean = false,
             hasPersistedResumeRow: Boolean = false,
             customInstallPath: String? = null,
+            downloadTaskType: String = DownloadRecord.TASK_INSTALL,
+            targetDepotIds: Set<Int>? = null,
         ): DownloadInfo? {
             val appInfo = getAppInfoOf(appId)
             if (appInfo == null) {
@@ -2437,6 +2460,8 @@ class SteamService :
                 allowPersistedProgress = allowPersistedProgress,
                 hasPersistedResumeRow = hasPersistedResumeRow,
                 customInstallPath = customInstallPath,
+                downloadTaskType = downloadTaskType,
+                targetDepotIds = targetDepotIds,
             )
         }
 
@@ -2800,12 +2825,15 @@ class SteamService :
             allowPersistedProgress: Boolean = false,
             hasPersistedResumeRow: Boolean = false,
             customInstallPath: String? = null,
+            downloadTaskType: String = DownloadRecord.TASK_INSTALL,
+            targetDepotIds: Set<Int>? = null,
         ): DownloadInfo? {
             var appDirPath = getAppDirPath(appId)
             Timber.i("downloadApp called for appId: $appId, customInstallPath: $customInstallPath")
             Timber.i(
                 "Steam DLC selection: appId=$appId selectedDlcAppIds=${userSelectedDlcAppIds.sorted()} " +
-                    "includeInstalledDepots=$includeInstalledDepots verify=$enableVerify allowResume=$allowPersistedProgress",
+                    "includeInstalledDepots=$includeInstalledDepots verify=$enableVerify allowResume=$allowPersistedProgress " +
+                    "targetDepotIds=${targetDepotIds?.sorted().orEmpty()}",
             )
 
             if (customInstallPath != null) {
@@ -2874,7 +2902,9 @@ class SteamService :
                 // Fresh installs should reset completion state. When the base game is already
                 // trusted, keep the marker while adding DLC so a cancelled DLC download does
                 // not make the whole base install look missing.
-                if (!includeInstalledDepots && !hasTrustedInstallAtStart) {
+                if (downloadTaskType == DownloadRecord.TASK_UPDATE) {
+                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                } else if (!includeInstalledDepots && !hasTrustedInstallAtStart) {
                     MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
                 }
             } catch (e: Exception) {
@@ -2923,7 +2953,8 @@ class SteamService :
                         depot.dlcAppId == INVALID_APP_ID && depotId !in groupedBaseDlcDepotIds
                     }
                 }
-            val originalMainAppDepots =
+            val targetDepotIdSet = targetDepotIds?.takeIf { it.isNotEmpty() }
+            var originalMainAppDepots =
                 baseMainAppDepots +
                     mainDepots.filter { (_, depot) ->
                         userSelectedDlcAppIds.contains(depot.dlcAppId) &&
@@ -2935,6 +2966,9 @@ class SteamService :
                         preferredLanguage = PrefManager.containerLanguage,
                         branch = branch,
                     )
+            if (targetDepotIdSet != null) {
+                originalMainAppDepots = originalMainAppDepots.filterKeys { it in targetDepotIdSet }
+            }
             var mainAppDepots = originalMainAppDepots
             Timber.d("Filtered main app depots count: ${mainAppDepots.size}")
 
@@ -3003,7 +3037,10 @@ class SteamService :
             // Single combined view of DLC depots used by the rest of the function. Downstream
             // code groups by dlcAppId, computes totals, and persists DownloadingAppInfo from
             // this map — the extras need to be visible everywhere.
-            val dlcAppDepots = indirectDlcAppDepots + extraDlcAppDepots
+            val dlcAppDepots =
+                (indirectDlcAppDepots + extraDlcAppDepots).let { depots ->
+                    if (targetDepotIdSet == null) depots else depots.filterKeys { it in targetDepotIdSet }
+                }
 
             // Remove depots that are already downloaded only when install metadata is trusted.
             // But if a custom path is provided, we want to check/download everything at the new location
@@ -3353,12 +3390,19 @@ class SteamService :
             val coordDecision =
                 runBlocking {
                     val title = getAppInfoOf(appId)?.name.orEmpty()
+                    val persistedScope =
+                        if (downloadTaskType == DownloadRecord.TASK_UPDATE && targetDepotIdSet != null) {
+                            targetDepotIdSet.sorted().joinToString(",")
+                        } else {
+                            userSelectedDlcAppIds.joinToString(",")
+                        }
                     DownloadCoordinator.requestSlot(
                         store = DownloadRecord.STORE_STEAM,
                         storeGameId = appId.toString(),
                         title = title,
                         installPath = appDirPath,
-                        selectedDlcs = userSelectedDlcAppIds.joinToString(","),
+                        selectedDlcs = persistedScope,
+                        taskType = downloadTaskType,
                         bytesTotal = selectedDisplayDownloadBytes,
                     )
                 }
@@ -3369,6 +3413,10 @@ class SteamService :
             )
             if (coordDecision is DownloadCoordinator.Decision.Queue) {
                 Timber.i("Coordinator queued appId: $appId")
+                if (downloadTaskType == DownloadRecord.TASK_UPDATE) {
+                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                    MarkerUtils.addMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                }
                 val info =
                     DownloadInfo(selectedDepots.size, appId, downloadingAppIds).also { di ->
                         di.setPersistencePath(appDirPath)
@@ -3785,6 +3833,9 @@ class SteamService :
                                 di.setActive(false)
                                 // Clean up markers
                                 MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                                if (downloadTaskType == DownloadRecord.TASK_UPDATE) {
+                                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                                }
                                 runBlocking {
                                     DownloadCoordinator.notifyFinished(
                                         DownloadRecord.STORE_STEAM,
@@ -3844,6 +3895,9 @@ class SteamService :
                                 di.setActive(false)
                                 // Clean up markers and DB state
                                 MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                                if (downloadTaskType == DownloadRecord.TASK_UPDATE) {
+                                    MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                                }
                                 runBlocking {
                                     instance?.downloadingAppInfoDao?.deleteApp(appId)
                                     Unit
@@ -4071,13 +4125,25 @@ class SteamService :
                     if (service != null) {
                         val mainAppInfo = service.appInfoDao.getInstalledApp(mainAppId)
                         if (mainAppInfo != null) {
-                            if (!mainAppInfo.isDownloaded) {
-                                service.appInfoDao.update(mainAppInfo.copy(isDownloaded = true))
-                                Timber.i("Marked main app $mainAppId as downloaded in DB")
-                            }
+                            val updatedMainDlcDepots = (mainAppInfo.dlcDepots + selectedDlcAppIds).distinct().sorted()
+                            service.appInfoDao.update(
+                                mainAppInfo.copy(
+                                    isDownloaded = true,
+                                    dlcDepots = updatedMainDlcDepots,
+                                ),
+                            )
+                            Timber.i(
+                                "Marked main app $mainAppId as downloaded in DB with dlcDepots=$updatedMainDlcDepots",
+                            )
                         } else {
-                            service.appInfoDao.insert(AppInfo(mainAppId, isDownloaded = true))
-                            Timber.i("Inserted main app $mainAppId as downloaded in DB")
+                            service.appInfoDao.insert(
+                                AppInfo(
+                                    mainAppId,
+                                    isDownloaded = true,
+                                    dlcDepots = selectedDlcAppIds.distinct().sorted(),
+                                ),
+                            )
+                            Timber.i("Inserted main app $mainAppId as downloaded in DB with dlcDepots=${selectedDlcAppIds.distinct().sorted()}")
                         }
                     }
                     Unit
@@ -5748,41 +5814,180 @@ class SteamService :
         suspend fun isUpdatePending(
             appId: Int,
             branch: String = "public",
-        ): Boolean =
+        ): Boolean = checkForAppUpdate(appId, branch).hasUpdate
+
+        suspend fun checkForAppUpdate(
+            appId: Int,
+            branch: String = "public",
+        ): SteamUpdateInfo =
             withContext(Dispatchers.IO) {
-                // Don't try if there's no internet
-                if (!isConnected) return@withContext false
+                fun SteamUpdateInfo.logged(): SteamUpdateInfo {
+                    Timber.i(
+                        "Steam update check result: appId=$appId branch=$branch " +
+                            "hasUpdate=$hasUpdate downloadSize=$downloadSize depotIds=$depotIds message=$message",
+                    )
+                    return this
+                }
 
-                val steamApps = instance?._steamApps ?: return@withContext false
+                Timber.i("Steam update check started: appId=$appId branch=$branch")
+                if (!isConnected || !isLoggedIn) {
+                    return@withContext SteamUpdateInfo(message = "Steam is not connected").logged()
+                }
+                if (!isAppInstalled(appId)) {
+                    return@withContext SteamUpdateInfo(message = "Game is not installed").logged()
+                }
 
-                // ── 1. Fetch the latest app header from Steam (PICS).
-                val pics =
-                    steamApps
-                        .picsGetProductInfo(
-                            apps = listOf(PICSRequest(id = appId)),
-                            packages = emptyList(),
-                        ).await()
+                val remoteSteamApp = fetchLatestSteamAppInfo(appId)
+                    ?: return@withContext SteamUpdateInfo(message = "Could not fetch Steam metadata").logged()
+                persistLatestSteamAppInfo(appId, remoteSteamApp)
 
-                val remoteAppInfo =
-                    pics.results
-                        .firstOrNull()
-                        ?.apps
-                        ?.values
-                        ?.firstOrNull()
-                        ?: return@withContext false // nothing returned ⇒ treat as up-to-date
+                val appDirPath = getAppDirPath(appId)
+                val selectedDepots =
+                    getSelectedDownloadDepots(
+                        appId = appId,
+                        userSelectedDlcAppIds = resolveInstalledDlcIdsForUpdateOrVerify(appId),
+                        preferredLanguage = PrefManager.containerLanguage,
+                        branch = branch,
+                    )
+                if (selectedDepots.isEmpty()) {
+                    return@withContext SteamUpdateInfo(message = "No installed depots to update").logged()
+                }
 
-                val remoteSteamApp = remoteAppInfo.keyValues.generateSteamApp()
-                val localSteamApp = getAppInfoOf(appId) ?: return@withContext true // not cached yet
+                val installedManifestIds = readInstalledDepotManifestIds(appDirPath)
+                val updateDepots =
+                    selectedDepots.filter { (depotId, depot) ->
+                        val manifest = resolveDepotManifestInfo(depot, branch) ?: return@filter false
+                        val installedManifestId = installedManifestIds[depotId]
+                        if (installedManifestId != null) {
+                            installedManifestId != manifest.gid
+                        } else {
+                            !hasCachedDepotManifest(appDirPath, depotId, manifest.gid)
+                        }
+                    }
 
-                // ── 2. Compare manifest IDs of the depots we actually install.
-                getDownloadableDepots(appId).keys.any { depotId ->
-                    val remoteManifest = remoteSteamApp.depots[depotId]?.manifests?.get(branch)
-                    val localManifest = localSteamApp.depots[depotId]?.manifests?.get(branch)
-                    // If remote manifest is null, skip this depot (hack for Castle Crashers)
-                    if (remoteManifest == null) return@any false
-                    remoteManifest?.gid != localManifest?.gid
+                if (updateDepots.isEmpty()) {
+                    SteamUpdateInfo(hasUpdate = false).logged()
+                } else {
+                    SteamUpdateInfo(
+                        hasUpdate = true,
+                        downloadSize =
+                            updateDepots.values
+                                .sumOf { depot -> manifestDownloadBytes(resolveDepotManifestInfo(depot, branch)) }
+                                .coerceAtLeast(0L),
+                        depotIds = updateDepots.keys.sorted(),
+                    ).logged()
                 }
             }
+
+        private suspend fun fetchLatestSteamAppInfo(appId: Int): SteamApp? {
+            val steamApps = instance?._steamApps ?: return null
+            val pics =
+                steamApps
+                    .picsGetProductInfo(
+                        apps = listOf(PICSRequest(id = appId)),
+                        packages = emptyList(),
+                    ).await()
+
+            val remoteAppInfo =
+                pics.results
+                    .firstOrNull()
+                    ?.apps
+                    ?.values
+                    ?.firstOrNull()
+                    ?: return null
+
+            return remoteAppInfo.keyValues.generateSteamApp().copy(
+                receivedPICS = true,
+                lastChangeNumber = remoteAppInfo.changeNumber,
+            )
+        }
+
+        private suspend fun persistLatestSteamAppInfo(
+            appId: Int,
+            remoteSteamApp: SteamApp,
+        ) {
+            val service = instance ?: return
+            val appFromDb = service.appDao.findApp(appId)
+            val packageId = appFromDb?.packageId ?: remoteSteamApp.packageId
+            val packageFromDb = if (packageId != INVALID_PKG_ID) service.licenseDao.findLicense(packageId) else null
+            val existingInstallDir = appFromDb?.installDir.orEmpty()
+            val preserveInstallDir =
+                existingInstallDir.isNotEmpty() &&
+                    (existingInstallDir.startsWith("/") || existingInstallDir.contains(File.separator))
+
+            service.appDao.insert(
+                remoteSteamApp.copy(
+                    packageId = packageId,
+                    ownerAccountId = packageFromDb?.ownerAccountId ?: appFromDb?.ownerAccountId.orEmpty(),
+                    licenseFlags =
+                        packageFromDb?.licenseFlags
+                            ?: appFromDb?.licenseFlags
+                            ?: EnumSet.noneOf(ELicenseFlags::class.java),
+                    installDir = if (preserveInstallDir) existingInstallDir else remoteSteamApp.installDir,
+                ),
+            )
+        }
+
+        private fun readInstalledDepotManifestIds(appDirPath: String): Map<Int, Long> =
+            runCatching {
+                val configFile = File(File(appDirPath, ".DepotDownloader"), "depot.config")
+                if (!configFile.exists() || !configFile.canRead()) return@runCatching emptyMap()
+                val json = JSONObject(configFile.readText())
+                val manifests = json.optJSONObject("installedManifestIDs") ?: return@runCatching emptyMap()
+                val result = mutableMapOf<Int, Long>()
+                for (key in manifests.keys()) {
+                    val depotId = key.toIntOrNull() ?: continue
+                    result[depotId] = manifests.optLong(key, DepotDownloader.INVALID_MANIFEST_ID)
+                }
+                result
+            }.getOrElse {
+                Timber.w(it, "Failed to read Steam depot.config for $appDirPath")
+                emptyMap()
+            }
+
+        private fun hasCachedDepotManifest(
+            appDirPath: String,
+            depotId: Int,
+            manifestId: Long,
+        ): Boolean = File(File(appDirPath, ".DepotDownloader"), "${depotId}_${manifestId}.manifest").exists()
+
+        private fun cleanupCancelledUpdate(appDirPath: String) {
+            MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+            MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+            clearPersistedProgressSnapshot(appDirPath)
+
+            val stagingDir = File(File(appDirPath, ".DepotDownloader"), "staging")
+            if (!stagingDir.exists()) return
+
+            stagingDir
+                .walkBottomUp()
+                .forEach { staged ->
+                    if (staged == stagingDir) return@forEach
+                    if (staged.isDirectory) {
+                        if (staged.list().isNullOrEmpty()) staged.delete()
+                        return@forEach
+                    }
+
+                    val relative = staged.relativeTo(stagingDir)
+                    val finalFile = File(appDirPath, relative.path)
+                    runCatching {
+                        finalFile.parentFile?.mkdirs()
+                        if (finalFile.exists()) {
+                            finalFile.delete()
+                        }
+                        if (!staged.renameTo(finalFile)) {
+                            staged.copyTo(finalFile, overwrite = true)
+                            staged.delete()
+                        }
+                    }.onFailure {
+                        Timber.w(it, "Failed to restore staged Steam update file ${staged.absolutePath}")
+                    }
+                }
+
+            if (stagingDir.exists() && stagingDir.list().isNullOrEmpty()) {
+                stagingDir.delete()
+            }
+        }
 
         suspend fun checkDlcOwnershipViaPICSBatch(dlcAppIds: Set<Int>): Set<Int> {
             if (dlcAppIds.isEmpty()) return emptySet()
@@ -5870,17 +6075,20 @@ class SteamService :
                 // checkQueue() and an extra notify event), and only then proceeds to build
                 // a fresh DownloadInfo. Removing here directly avoids that duplicate path.
                 downloadJobs.remove(appId)
-                // CRITICAL: pass record.selectedDlcs as the authoritative DLC list. The
-                // legacy no-arg downloadApp(appId) reconstructs DLCs from a fragile chain
-                // (DownloadingAppInfo -> snapshot inference -> installed). Snapshot inference
-                // only sees DLCs that already had bytes downloaded, so DLCs the user selected
-                // but never started would silently disappear and the game would be marked
-                // COMPLETE after only downloading a partial scope.
-                val dlcAppIdsHint =
+                // For normal installs, selectedDlcs carries the authoritative DLC app IDs.
+                // For update tasks, the same persisted field carries the changed depot IDs
+                // reported by checkForAppUpdate(), so queued updates keep the narrowed scope.
+                val persistedIds =
                     record.selectedDlcs
                         .split(',')
                         .mapNotNull { it.trim().toIntOrNull() }
-                downloadApp(appId, dlcAppIdsHint)
+                if (record.taskType == DownloadRecord.TASK_UPDATE) {
+                    downloadAppForUpdate(appId, persistedIds)
+                } else if (record.taskType == DownloadRecord.TASK_VERIFY) {
+                    downloadAppForVerify(appId)
+                } else {
+                    downloadApp(appId, persistedIds)
+                }
             }
 
             override fun pauseRunning(record: DownloadRecord) {
@@ -5902,13 +6110,38 @@ class SteamService :
             override fun cancelRunning(record: DownloadRecord) {
                 val appId = record.storeGameId.toIntOrNull() ?: return
                 val info = downloadJobs[appId]
+                val statusAtCancel = info?.getStatusFlow()?.value
                 if (info != null) {
                     info.isCancelling = true
                     info.cancel("Cancelled by user")
                 }
                 kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
-                    info?.awaitCompletion(timeoutMs = 3000L)
+                    val isUpdateTask = record.taskType == DownloadRecord.TASK_UPDATE
+                    info?.awaitCompletion(timeoutMs = if (isUpdateTask) 10000L else 3000L)
                     val appDirPath = record.installPath.ifEmpty { getAppDirPath(appId) }
+                    if (isUpdateTask) {
+                        val updateNeverStarted =
+                            statusAtCancel == DownloadPhase.QUEUED ||
+                                (
+                                    statusAtCancel == DownloadPhase.PAUSED &&
+                                        MarkerUtils.hasMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER) &&
+                                        !MarkerUtils.hasMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                                )
+                        if (updateNeverStarted) {
+                            MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_IN_PROGRESS_MARKER)
+                            MarkerUtils.addMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
+                        } else {
+                            cleanupCancelledUpdate(appDirPath)
+                        }
+                        try {
+                            instance?.downloadingAppInfoDao?.deleteApp(appId)
+                        } catch (e: Exception) {
+                            Timber.w(e, "Failed to clear cancelled Steam update metadata for appId=$appId")
+                        }
+                        info?.updateStatus(DownloadPhase.CANCELLED)
+                        removeDownloadJob(appId, forceRemove = true)
+                        return@launch
+                    }
                     val dirFile = java.io.File(appDirPath)
                     if (dirFile.exists() && dirFile.isDirectory) {
                         val deleteCheck =

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -2395,6 +2395,46 @@ class SteamService :
             return dlcAppIds.distinct()
         }
 
+        private fun parseDownloadScopeIds(scope: String): Set<Int> =
+            scope
+                .split(',')
+                .mapNotNull { it.trim().toIntOrNull() }
+                .toSet()
+
+        private fun activeDownloadRecordFor(appId: Int): DownloadRecord? =
+            runCatching {
+                runBlocking(Dispatchers.IO) {
+                    DownloadCoordinator.findRecord(
+                        DownloadRecord.STORE_STEAM,
+                        appId.toString(),
+                    )
+                }
+            }.getOrNull()
+                ?.takeIf {
+                    it.status in setOf(
+                        DownloadRecord.STATUS_QUEUED,
+                        DownloadRecord.STATUS_DOWNLOADING,
+                        DownloadRecord.STATUS_PAUSED,
+                    )
+                }
+
+        private fun rejectConflictingDownloadRequest(appId: Int, record: DownloadRecord): DownloadInfo? {
+            Timber.i(
+                "Refusing Steam download request for appId=$appId because an active record already exists " +
+                    "status=${record.status} taskType=${record.taskType} selectedDlcs=${record.selectedDlcs}",
+            )
+            instance?.let { service ->
+                service.scope.launch(Dispatchers.Main) {
+                    WinToast.show(
+                        service.applicationContext,
+                        service.getString(R.string.store_game_download_already_active),
+                        Toast.LENGTH_SHORT,
+                    )
+                }
+            }
+            return downloadJobs[appId]
+        }
+
         fun downloadApp(
             appId: Int,
             dlcAppIds: List<Int>,
@@ -2835,6 +2875,22 @@ class SteamService :
                     "includeInstalledDepots=$includeInstalledDepots verify=$enableVerify allowResume=$allowPersistedProgress " +
                     "targetDepotIds=${targetDepotIds?.sorted().orEmpty()}",
             )
+
+            activeDownloadRecordFor(appId)?.let { activeRecord ->
+                val requestedScopeIds =
+                    if (downloadTaskType == DownloadRecord.TASK_UPDATE && targetDepotIds != null) {
+                        targetDepotIds
+                    } else {
+                        userSelectedDlcAppIds.toSet()
+                    }
+                val isSameCoordinatorDispatch =
+                    customInstallPath == null &&
+                        activeRecord.taskType == downloadTaskType &&
+                        parseDownloadScopeIds(activeRecord.selectedDlcs) == requestedScopeIds
+                if (!isSameCoordinatorDispatch) {
+                    return rejectConflictingDownloadRequest(appId, activeRecord)
+                }
+            }
 
             if (customInstallPath != null) {
                 // Determine if customInstallPath is the game folder itself or the parent

--- a/app/src/main/feature/stores/steam/utils/KeyValueUtils.kt
+++ b/app/src/main/feature/stores/steam/utils/KeyValueUtils.kt
@@ -165,8 +165,7 @@ fun KeyValue.generateSteamApp(): SteamApp =
         homepageUrl = this["extended"]["homepage"].value.orEmpty(),
         gameManualUrl = this["common"]["extended"]["gamemanualurl"].value.orEmpty(),
         loadAllBeforeLaunch = this["common"]["extended"]["loadallbeforelaunch"].asBoolean(),
-        // dlcAppIds = (this["common"]["extended"]["listofdlc"].value).Split(",").Select(uint.Parse).ToArray(),
-        dlcAppIds = emptyList(),
+        dlcAppIds = this["common"]["extended"]["listofdlc"].value.parseDlcAppIds(),
         isFreeApp = this["common"]["extended"]["isfreeapp"].asBoolean(),
         dlcForAppId = this["extended"]["dlcforappid"].asInteger(this["common"]["extended"]["dlcforappid"].asInteger()),
         mustOwnAppToPurchase = this["common"]["extended"]["mustownapptopurchase"].asInteger(),
@@ -278,6 +277,14 @@ fun List<KeyValue>.toLangImgMap(): Map<Language, String> =
             .takeIf { it != Language.unknown }
             ?.to(kv.value!!)
     }.toMap()
+
+private fun String?.parseDlcAppIds(): List<Int> =
+    this
+        .orEmpty()
+        .split(',', ';')
+        .mapNotNull { it.trim().toIntOrNull() }
+        .filter { it != INVALID_APP_ID }
+        .distinct()
 
 @Suppress("unused")
 fun KeyValue.printAllKeyValues(depth: Int = 0) {

--- a/app/src/main/feature/stores/steam/utils/SteamUtils.kt
+++ b/app/src/main/feature/stores/steam/utils/SteamUtils.kt
@@ -750,6 +750,10 @@ object SteamUtils {
             commonDir.mkdirs()
 
             val gameDir = File(SteamService.getAppDirPath(steamAppId))
+            if (!gameDir.isDirectory || !SteamService.isAppInstalled(steamAppId)) {
+                Timber.w("Skipping ACF manifest for appId=$steamAppId because the install is not trusted on disk")
+                return
+            }
             val gameName = gameDir.name
             val sizeOnDisk = calculateDirectorySize(gameDir)
 
@@ -766,11 +770,21 @@ object SteamUtils {
 
             val buildId = appInfo.branches["public"]?.buildId ?: 0L
             val downloadableDepots = SteamService.getDownloadableDepots(steamAppId)
+            val installedDepotIds = SteamService.getInstalledDepotsOf(steamAppId).orEmpty().toSet()
+            val installedDlcAppIds = SteamService.getInstalledDlcDepotsOf(steamAppId).orEmpty().toSet()
 
             val regularDepots = mutableMapOf<Int, DepotInfo>()
             val sharedDepots = mutableMapOf<Int, DepotInfo>()
 
             downloadableDepots.forEach { (depotId, depotInfo) ->
+                val isInstalledDepot =
+                    depotId in installedDepotIds ||
+                        (
+                            depotInfo.dlcAppId != SteamService.INVALID_APP_ID &&
+                                depotInfo.dlcAppId in installedDlcAppIds
+                        )
+                if (!isInstalledDepot) return@forEach
+
                 val manifest = depotInfo.manifests["public"]
                 if (manifest != null && manifest.gid != 0L) {
                     regularDepots[depotId] = depotInfo

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Installer</string>
     <string name="common_ui_application">Applikation</string>
     <string name="common_ui_check">Tjek</string>
+    <string name="store_game_check_for_update">Søg efter opdatering</string>
+    <string name="store_game_checking_for_update">Tjekker...</string>
+    <string name="store_game_download_update">Download opdatering</string>
+    <string name="store_game_no_update_available">Ingen opdatering tilgængelig</string>
+    <string name="store_game_update_available">Opdatering tilgængelig</string>
+    <string name="store_game_update_check_failed">Kunne ikke tjekke for opdatering</string>
+    <string name="store_game_update">Opdater</string>
     <string name="common_ui_select">Vælg</string>
     <string name="common_ui_select_folder">Vælg mappe</string>
     <string name="common_ui_current_folder">Nuværende mappe</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Annulleret</string>
     <string name="downloads_queue_phase_failed">Mislykkedes: %1$s</string>
     <string name="downloads_queue_cancel_download">Annuller download</string>
+    <string name="downloads_queue_cancel_download_title">Annuller download?</string>
+    <string name="downloads_queue_cancel_download_warning">Annullering af en DLC-, spil- eller opdateringsdownload kan potentielt beskadige din spilinstallation.\n\nEr du sikker på, at du vil annullere?</string>
     <string name="downloads_queue_empty">Ingen aktive downloads.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Indstillinger</string>
     <string name="common_ui_enable_all">Aktiver alle</string>
     <string name="common_ui_disable_all">Deaktiver alle</string>
+    <string name="common_ui_select_all">Vælg alle</string>
+    <string name="common_ui_deselect_all">Fravælg alle</string>
     <string name="common_ui_on">Til</string>
     <string name="common_ui_off">Fra</string>
     <string name="common_ui_already_set">Allerede indstillet</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Genvej oprettet</string>
     <string name="library_games_failed_to_create_shortcut">Kunne ikke oprette genvej: %s</string>
     <string name="library_games_install_path">Installationssti</string>
+    <string name="library_games_not_enough_space">Kræver %1$s mere plads</string>
     <string name="library_games_download_slash_install">Download / Installer</string>
     <string name="library_games_save_management">GEMMEDATA HÅNDTERING</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Tilgængelig: %3$s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Opdatering tilgængelig</string>
     <string name="store_game_update_check_failed">Kunne ikke tjekke for opdatering</string>
     <string name="store_game_update">Opdater</string>
+    <string name="store_game_download_already_active">Dette spil downloades allerede. Annuller den aktuelle download, før du tilføjer DLC.</string>
     <string name="common_ui_select">Vælg</string>
     <string name="common_ui_select_folder">Vælg mappe</string>
     <string name="common_ui_current_folder">Nuværende mappe</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Installieren</string>
     <string name="common_ui_application">Anwendung</string>
     <string name="common_ui_check">Prüfen</string>
+    <string name="store_game_check_for_update">Nach Update suchen</string>
+    <string name="store_game_checking_for_update">Suche...</string>
+    <string name="store_game_download_update">Update herunterladen</string>
+    <string name="store_game_no_update_available">Kein Update verfügbar</string>
+    <string name="store_game_update_available">Update verfügbar</string>
+    <string name="store_game_update_check_failed">Update-Prüfung fehlgeschlagen</string>
+    <string name="store_game_update">Aktualisieren</string>
     <string name="common_ui_select">Auswählen</string>
     <string name="common_ui_select_folder">Ordner auswählen</string>
     <string name="common_ui_current_folder">Aktueller Ordner</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Abgebrochen</string>
     <string name="downloads_queue_phase_failed">Fehlgeschlagen: %1$s</string>
     <string name="downloads_queue_cancel_download">Download abbrechen</string>
+    <string name="downloads_queue_cancel_download_title">Download abbrechen?</string>
+    <string name="downloads_queue_cancel_download_warning">Das Abbrechen eines DLC-, Spiel- oder Update-Downloads kann deine Spielinstallation möglicherweise beschädigen.\n\nMöchtest du wirklich abbrechen?</string>
     <string name="downloads_queue_empty">Keine aktiven Downloads.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Update verfügbar</string>
     <string name="store_game_update_check_failed">Update-Prüfung fehlgeschlagen</string>
     <string name="store_game_update">Aktualisieren</string>
+    <string name="store_game_download_already_active">Dieses Spiel wird bereits heruntergeladen. Brich den aktuellen Download ab, bevor du DLC hinzufügst.</string>
     <string name="common_ui_select">Auswählen</string>
     <string name="common_ui_select_folder">Ordner auswählen</string>
     <string name="common_ui_current_folder">Aktueller Ordner</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Einstellungen</string>
     <string name="common_ui_enable_all">Alle aktivieren</string>
     <string name="common_ui_disable_all">Alle deaktivieren</string>
+    <string name="common_ui_select_all">Alle auswählen</string>
+    <string name="common_ui_deselect_all">Alle abwählen</string>
     <string name="common_ui_on">Ein</string>
     <string name="common_ui_off">Aus</string>
     <string name="common_ui_already_set">Bereits festgelegt</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Verknüpfung erstellt</string>
     <string name="library_games_failed_to_create_shortcut">Verknüpfung konnte nicht erstellt werden: %s</string>
     <string name="library_games_install_path">Installationspfad</string>
+    <string name="library_games_not_enough_space">Benötigt %1$s mehr Speicherplatz</string>
     <string name="library_games_download_slash_install">Herunterladen / Installieren</string>
     <string name="library_games_save_management">SPEICHERVERWALTUNG</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Verfügbar: %3$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Instalar</string>
     <string name="common_ui_application">Aplicación</string>
     <string name="common_ui_check">Comprobar</string>
+    <string name="store_game_check_for_update">Buscar actualización</string>
+    <string name="store_game_checking_for_update">Comprobando...</string>
+    <string name="store_game_download_update">Descargar actualización</string>
+    <string name="store_game_no_update_available">No hay actualizaciones disponibles</string>
+    <string name="store_game_update_available">Actualización disponible</string>
+    <string name="store_game_update_check_failed">Error al comprobar actualizaciones</string>
+    <string name="store_game_update">Actualizar</string>
     <string name="common_ui_select">Seleccionar</string>
     <string name="common_ui_select_folder">Seleccionar carpeta</string>
     <string name="common_ui_current_folder">Carpeta actual</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Cancelado</string>
     <string name="downloads_queue_phase_failed">Error: %1$s</string>
     <string name="downloads_queue_cancel_download">Cancelar descarga</string>
+    <string name="downloads_queue_cancel_download_title">¿Cancelar descarga?</string>
+    <string name="downloads_queue_cancel_download_warning">Cancelar una descarga de DLC, juego o actualización puede dañar potencialmente la instalación del juego.\n\n¿Seguro que quieres cancelar?</string>
     <string name="downloads_queue_empty">No hay descargas activas.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Actualización disponible</string>
     <string name="store_game_update_check_failed">Error al comprobar actualizaciones</string>
     <string name="store_game_update">Actualizar</string>
+    <string name="store_game_download_already_active">Este juego ya se está descargando. Cancela la descarga actual antes de añadir DLC.</string>
     <string name="common_ui_select">Seleccionar</string>
     <string name="common_ui_select_folder">Seleccionar carpeta</string>
     <string name="common_ui_current_folder">Carpeta actual</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Ajustes</string>
     <string name="common_ui_enable_all">Activar todo</string>
     <string name="common_ui_disable_all">Desactivar todo</string>
+    <string name="common_ui_select_all">Seleccionar todo</string>
+    <string name="common_ui_deselect_all">Deseleccionar todo</string>
     <string name="common_ui_on">Activado</string>
     <string name="common_ui_off">Desactivado</string>
     <string name="common_ui_already_set">Ya configurado</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Acceso directo creado</string>
     <string name="library_games_failed_to_create_shortcut">Error al crear acceso directo: %s</string>
     <string name="library_games_install_path">Ruta de instalación</string>
+    <string name="library_games_not_enough_space">Se necesitan %1$s más de espacio</string>
     <string name="library_games_download_slash_install">Descargar / Instalar</string>
     <string name="library_games_save_management">GESTIÓN DE GUARDADOS</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Disponible: %3$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Installer</string>
     <string name="common_ui_application">Application</string>
     <string name="common_ui_check">Vérifier</string>
+    <string name="store_game_check_for_update">Rechercher une mise à jour</string>
+    <string name="store_game_checking_for_update">Vérification...</string>
+    <string name="store_game_download_update">Télécharger la mise à jour</string>
+    <string name="store_game_no_update_available">Aucune mise à jour disponible</string>
+    <string name="store_game_update_available">Mise à jour disponible</string>
+    <string name="store_game_update_check_failed">Échec de la vérification des mises à jour</string>
+    <string name="store_game_update">Mettre à jour</string>
     <string name="common_ui_select">Sélectionner</string>
     <string name="common_ui_select_folder">Sélectionner un dossier</string>
     <string name="common_ui_current_folder">Dossier actuel</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Annulé</string>
     <string name="downloads_queue_phase_failed">Échec : %1$s</string>
     <string name="downloads_queue_cancel_download">Annuler le téléchargement</string>
+    <string name="downloads_queue_cancel_download_title">Annuler le téléchargement ?</string>
+    <string name="downloads_queue_cancel_download_warning">Annuler le téléchargement d\'un DLC, d\'un jeu ou d\'une mise à jour peut potentiellement corrompre l\'installation du jeu.\n\nVoulez-vous vraiment annuler ?</string>
     <string name="downloads_queue_empty">Aucun téléchargement actif.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Paramètres</string>
     <string name="common_ui_enable_all">Tout activer</string>
     <string name="common_ui_disable_all">Tout désactiver</string>
+    <string name="common_ui_select_all">Tout sélectionner</string>
+    <string name="common_ui_deselect_all">Tout désélectionner</string>
     <string name="common_ui_on">Activé</string>
     <string name="common_ui_off">Désactivé</string>
     <string name="common_ui_already_set">Déjà défini</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Raccourci créé</string>
     <string name="library_games_failed_to_create_shortcut">Échec de la création du raccourci : %s</string>
     <string name="library_games_install_path">Chemin d\'installation</string>
+    <string name="library_games_not_enough_space">Il faut %1$s d\'espace en plus</string>
     <string name="library_games_download_slash_install">Télécharger / Installer</string>
     <string name="library_games_save_management">GESTION DES SAUVEGARDES</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Disponible : %3$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Mise à jour disponible</string>
     <string name="store_game_update_check_failed">Échec de la vérification des mises à jour</string>
     <string name="store_game_update">Mettre à jour</string>
+    <string name="store_game_download_already_active">Ce jeu est déjà en cours de téléchargement. Annulez le téléchargement actuel avant d\'ajouter du DLC.</string>
     <string name="common_ui_select">Sélectionner</string>
     <string name="common_ui_select_folder">Sélectionner un dossier</string>
     <string name="common_ui_current_folder">Dossier actuel</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Aggiornamento disponibile</string>
     <string name="store_game_update_check_failed">Controllo aggiornamenti non riuscito</string>
     <string name="store_game_update">Aggiorna</string>
+    <string name="store_game_download_already_active">Questo gioco è già in download. Annulla il download corrente prima di aggiungere DLC.</string>
     <string name="common_ui_select">Seleziona</string>
     <string name="common_ui_select_folder">Seleziona cartella</string>
     <string name="common_ui_current_folder">Cartella corrente</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Installa</string>
     <string name="common_ui_application">Applicazione</string>
     <string name="common_ui_check">Verifica</string>
+    <string name="store_game_check_for_update">Controlla aggiornamenti</string>
+    <string name="store_game_checking_for_update">Controllo...</string>
+    <string name="store_game_download_update">Scarica aggiornamento</string>
+    <string name="store_game_no_update_available">Nessun aggiornamento disponibile</string>
+    <string name="store_game_update_available">Aggiornamento disponibile</string>
+    <string name="store_game_update_check_failed">Controllo aggiornamenti non riuscito</string>
+    <string name="store_game_update">Aggiorna</string>
     <string name="common_ui_select">Seleziona</string>
     <string name="common_ui_select_folder">Seleziona cartella</string>
     <string name="common_ui_current_folder">Cartella corrente</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Annullato</string>
     <string name="downloads_queue_phase_failed">Fallito: %1$s</string>
     <string name="downloads_queue_cancel_download">Annulla download</string>
+    <string name="downloads_queue_cancel_download_title">Annullare il download?</string>
+    <string name="downloads_queue_cancel_download_warning">Annullare il download di un DLC, gioco o aggiornamento potrebbe danneggiare l\'installazione del gioco.\n\nVuoi davvero annullare?</string>
     <string name="downloads_queue_empty">Nessun download attivo.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Impostazioni</string>
     <string name="common_ui_enable_all">Abilita tutto</string>
     <string name="common_ui_disable_all">Disabilita tutto</string>
+    <string name="common_ui_select_all">Seleziona tutto</string>
+    <string name="common_ui_deselect_all">Deseleziona tutto</string>
     <string name="common_ui_on">Attivo</string>
     <string name="common_ui_off">Disattivo</string>
     <string name="common_ui_already_set">Già impostato</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Scorciatoia creata</string>
     <string name="library_games_failed_to_create_shortcut">Impossibile creare la scorciatoia: %s</string>
     <string name="library_games_install_path">Percorso di installazione</string>
+    <string name="library_games_not_enough_space">Servono altri %1$s di spazio</string>
     <string name="library_games_download_slash_install">Scarica / Installa</string>
     <string name="library_games_save_management">GESTIONE SALVATAGGI</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Disponibile: %3$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">업데이트 가능</string>
     <string name="store_game_update_check_failed">업데이트 확인 실패</string>
     <string name="store_game_update">업데이트</string>
+    <string name="store_game_download_already_active">이 게임은 이미 다운로드 중입니다. DLC를 추가하기 전에 현재 다운로드를 취소하세요.</string>
     <string name="common_ui_select">선택</string>
     <string name="common_ui_select_folder">폴더 선택</string>
     <string name="common_ui_current_folder">현재 폴더</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">설정</string>
     <string name="common_ui_enable_all">모두 활성화</string>
     <string name="common_ui_disable_all">모두 비활성화</string>
+    <string name="common_ui_select_all">모두 선택</string>
+    <string name="common_ui_deselect_all">모두 선택 해제</string>
     <string name="common_ui_on">켜기</string>
     <string name="common_ui_off">끄기</string>
     <string name="common_ui_already_set">이미 설정됨</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">바로가기가 생성되었습니다</string>
     <string name="library_games_failed_to_create_shortcut">바로가기 생성 실패: %s</string>
     <string name="library_games_install_path">설치 경로</string>
+    <string name="library_games_not_enough_space">%1$s의 공간이 더 필요합니다</string>
     <string name="library_games_download_slash_install">다운로드 / 설치</string>
     <string name="library_games_save_management">저장 데이터 관리</string>
     <string name="library_games_download_install_available">%1$s / %2$s • 사용 가능: %3$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">설치</string>
     <string name="common_ui_application">애플리케이션</string>
     <string name="common_ui_check">확인</string>
+    <string name="store_game_check_for_update">업데이트 확인</string>
+    <string name="store_game_checking_for_update">확인 중...</string>
+    <string name="store_game_download_update">업데이트 다운로드</string>
+    <string name="store_game_no_update_available">사용 가능한 업데이트 없음</string>
+    <string name="store_game_update_available">업데이트 가능</string>
+    <string name="store_game_update_check_failed">업데이트 확인 실패</string>
+    <string name="store_game_update">업데이트</string>
     <string name="common_ui_select">선택</string>
     <string name="common_ui_select_folder">폴더 선택</string>
     <string name="common_ui_current_folder">현재 폴더</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">취소됨</string>
     <string name="downloads_queue_phase_failed">실패: %1$s</string>
     <string name="downloads_queue_cancel_download">다운로드 취소</string>
+    <string name="downloads_queue_cancel_download_title">다운로드를 취소하시겠습니까?</string>
+    <string name="downloads_queue_cancel_download_warning">DLC, 게임 또는 업데이트 다운로드를 취소하면 게임 설치가 손상될 수 있습니다.\n\n정말 취소하시겠습니까?</string>
     <string name="downloads_queue_empty">활성 다운로드가 없습니다.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Aktualizacja dostępna</string>
     <string name="store_game_update_check_failed">Nie udało się sprawdzić aktualizacji</string>
     <string name="store_game_update">Aktualizuj</string>
+    <string name="store_game_download_already_active">Ta gra jest już pobierana. Anuluj bieżące pobieranie przed dodaniem DLC.</string>
     <string name="common_ui_select">Wybierz</string>
     <string name="common_ui_select_folder">Wybierz folder</string>
     <string name="common_ui_current_folder">Bieżący folder</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Ustawienia</string>
     <string name="common_ui_enable_all">Włącz wszystko</string>
     <string name="common_ui_disable_all">Wyłącz wszystko</string>
+    <string name="common_ui_select_all">Zaznacz wszystko</string>
+    <string name="common_ui_deselect_all">Odznacz wszystko</string>
     <string name="common_ui_on">Wł.</string>
     <string name="common_ui_off">Wył.</string>
     <string name="common_ui_already_set">Już ustawione</string>
@@ -141,6 +143,7 @@
     <string name="library_games_shortcut_created">Skrót utworzony</string>
     <string name="library_games_failed_to_create_shortcut">Nie udało się utworzyć skrótu: %s</string>
     <string name="library_games_install_path">Ścieżka instalacji</string>
+    <string name="library_games_not_enough_space">Potrzeba jeszcze %1$s miejsca</string>
     <string name="library_games_download_slash_install">Pobierz / Zainstaluj</string>
     <string name="library_games_save_management">ZARZĄDZANIE ZAPISAMI</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Dostępne: %3$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Zainstaluj</string>
     <string name="common_ui_application">Aplikacja</string>
     <string name="common_ui_check">Sprawdź</string>
+    <string name="store_game_check_for_update">Sprawdź aktualizacje</string>
+    <string name="store_game_checking_for_update">Sprawdzanie...</string>
+    <string name="store_game_download_update">Pobierz aktualizację</string>
+    <string name="store_game_no_update_available">Brak dostępnych aktualizacji</string>
+    <string name="store_game_update_available">Aktualizacja dostępna</string>
+    <string name="store_game_update_check_failed">Nie udało się sprawdzić aktualizacji</string>
+    <string name="store_game_update">Aktualizuj</string>
     <string name="common_ui_select">Wybierz</string>
     <string name="common_ui_select_folder">Wybierz folder</string>
     <string name="common_ui_current_folder">Bieżący folder</string>
@@ -228,6 +235,8 @@
     <string name="downloads_queue_phase_cancelled">Anulowano</string>
     <string name="downloads_queue_phase_failed">Błąd: %1$s</string>
     <string name="downloads_queue_cancel_download">Anuluj pobieranie</string>
+    <string name="downloads_queue_cancel_download_title">Anulować pobieranie?</string>
+    <string name="downloads_queue_cancel_download_warning">Anulowanie pobierania DLC, gry lub aktualizacji może potencjalnie uszkodzić instalację gry.\n\nCzy na pewno chcesz anulować?</string>
     <string name="downloads_queue_empty">Brak aktywnych pobrań.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Instalar</string>
     <string name="common_ui_application">Aplicativo</string>
     <string name="common_ui_check">Verificar</string>
+    <string name="store_game_check_for_update">Verificar atualização</string>
+    <string name="store_game_checking_for_update">Verificando...</string>
+    <string name="store_game_download_update">Baixar atualização</string>
+    <string name="store_game_no_update_available">Nenhuma atualização disponível</string>
+    <string name="store_game_update_available">Atualização disponível</string>
+    <string name="store_game_update_check_failed">Falha ao verificar atualização</string>
+    <string name="store_game_update">Atualizar</string>
     <string name="common_ui_select">Selecionar</string>
     <string name="common_ui_select_folder">Selecionar pasta</string>
     <string name="common_ui_current_folder">Pasta atual</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Cancelado</string>
     <string name="downloads_queue_phase_failed">Falhou: %1$s</string>
     <string name="downloads_queue_cancel_download">Cancelar Download</string>
+    <string name="downloads_queue_cancel_download_title">Cancelar download?</string>
+    <string name="downloads_queue_cancel_download_warning">Cancelar o download de um DLC, jogo ou atualização pode corromper a instalação do jogo.\n\nTem certeza de que deseja cancelar?</string>
     <string name="downloads_queue_empty">Nenhum download ativo.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Configuracoes</string>
     <string name="common_ui_enable_all">Ativar tudo</string>
     <string name="common_ui_disable_all">Desativar tudo</string>
+    <string name="common_ui_select_all">Selecionar tudo</string>
+    <string name="common_ui_deselect_all">Desmarcar tudo</string>
     <string name="common_ui_on">Ligado</string>
     <string name="common_ui_off">Desligado</string>
     <string name="common_ui_already_set">Ja Definido</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Atalho criado</string>
     <string name="library_games_failed_to_create_shortcut">Falha ao criar atalho: %s</string>
     <string name="library_games_install_path">Caminho de Instalacao</string>
+    <string name="library_games_not_enough_space">Precisa de mais %1$s de espaco</string>
     <string name="library_games_download_slash_install">Baixar / Instalar</string>
     <string name="library_games_save_management">GERENCIAMENTO DE SAVES</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Disponivel: %3$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Atualização disponível</string>
     <string name="store_game_update_check_failed">Falha ao verificar atualização</string>
     <string name="store_game_update">Atualizar</string>
+    <string name="store_game_download_already_active">Este jogo já está sendo baixado. Cancele o download atual antes de adicionar DLC.</string>
     <string name="common_ui_select">Selecionar</string>
     <string name="common_ui_select_folder">Selecionar pasta</string>
     <string name="common_ui_current_folder">Pasta atual</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Setari</string>
     <string name="common_ui_enable_all">Activeaza tot</string>
     <string name="common_ui_disable_all">Dezactiveaza tot</string>
+    <string name="common_ui_select_all">Selecteaza tot</string>
+    <string name="common_ui_deselect_all">Deselecteaza tot</string>
     <string name="common_ui_on">Pornit</string>
     <string name="common_ui_off">Oprit</string>
     <string name="common_ui_already_set">Deja setat</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">Comanda rapida creata</string>
     <string name="library_games_failed_to_create_shortcut">Nu s-a putut crea comanda rapida: %s</string>
     <string name="library_games_install_path">Cale de instalare</string>
+    <string name="library_games_not_enough_space">Mai este nevoie de %1$s spatiu</string>
     <string name="library_games_download_slash_install">Descarca / Instaleaza</string>
     <string name="library_games_save_management">GESTIONARE SALVARI</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Disponibil: %3$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Actualizare disponibilă</string>
     <string name="store_game_update_check_failed">Verificarea actualizărilor a eșuat</string>
     <string name="store_game_update">Actualizează</string>
+    <string name="store_game_download_already_active">Acest joc se descarcă deja. Anulează descărcarea curentă înainte de a adăuga DLC.</string>
     <string name="common_ui_select">Selectează</string>
     <string name="common_ui_select_folder">Selectează folder</string>
     <string name="common_ui_current_folder">Folder curent</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Instaleaza</string>
     <string name="common_ui_application">Aplicație</string>
     <string name="common_ui_check">Verifică</string>
+    <string name="store_game_check_for_update">Caută actualizări</string>
+    <string name="store_game_checking_for_update">Se verifică...</string>
+    <string name="store_game_download_update">Descarcă actualizarea</string>
+    <string name="store_game_no_update_available">Nu există actualizări disponibile</string>
+    <string name="store_game_update_available">Actualizare disponibilă</string>
+    <string name="store_game_update_check_failed">Verificarea actualizărilor a eșuat</string>
+    <string name="store_game_update">Actualizează</string>
     <string name="common_ui_select">Selectează</string>
     <string name="common_ui_select_folder">Selectează folder</string>
     <string name="common_ui_current_folder">Folder curent</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">Anulat</string>
     <string name="downloads_queue_phase_failed">Esuat: %1$s</string>
     <string name="downloads_queue_cancel_download">Anuleaza descarcarea</string>
+    <string name="downloads_queue_cancel_download_title">Anulezi descărcarea?</string>
+    <string name="downloads_queue_cancel_download_warning">Anularea descărcării unui DLC, joc sau actualizare poate corupe instalarea jocului.\n\nSigur vrei să anulezi?</string>
     <string name="downloads_queue_empty">Nu exista descarcari active.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">Налаштування</string>
     <string name="common_ui_enable_all">Увімкнути все</string>
     <string name="common_ui_disable_all">Вимкнути все</string>
+    <string name="common_ui_select_all">Вибрати все</string>
+    <string name="common_ui_deselect_all">Скасувати вибір усього</string>
     <string name="common_ui_on">Увімк.</string>
     <string name="common_ui_off">Вимк.</string>
     <string name="common_ui_already_set">Вже встановлено</string>
@@ -141,6 +143,7 @@
     <string name="library_games_shortcut_created">Ярлик створено</string>
     <string name="library_games_failed_to_create_shortcut">Не вдалося створити ярлик: %s</string>
     <string name="library_games_install_path">Шлях встановлення</string>
+    <string name="library_games_not_enough_space">Потрібно ще %1$s місця</string>
     <string name="library_games_download_slash_install">Завантажити / Встановити</string>
     <string name="library_games_save_management">КЕРУВАННЯ ЗБЕРЕЖЕННЯМИ</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Доступно: %3$s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">Доступне оновлення</string>
     <string name="store_game_update_check_failed">Не вдалося перевірити оновлення</string>
     <string name="store_game_update">Оновити</string>
+    <string name="store_game_download_already_active">Ця гра вже завантажується. Скасуйте поточне завантаження, перш ніж додавати DLC.</string>
     <string name="common_ui_select">Вибрати</string>
     <string name="common_ui_select_folder">Вибрати теку</string>
     <string name="common_ui_current_folder">Поточна тека</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">Встановити</string>
     <string name="common_ui_application">Застосунок</string>
     <string name="common_ui_check">Перевірити</string>
+    <string name="store_game_check_for_update">Перевірити оновлення</string>
+    <string name="store_game_checking_for_update">Перевірка...</string>
+    <string name="store_game_download_update">Завантажити оновлення</string>
+    <string name="store_game_no_update_available">Немає доступних оновлень</string>
+    <string name="store_game_update_available">Доступне оновлення</string>
+    <string name="store_game_update_check_failed">Не вдалося перевірити оновлення</string>
+    <string name="store_game_update">Оновити</string>
     <string name="common_ui_select">Вибрати</string>
     <string name="common_ui_select_folder">Вибрати теку</string>
     <string name="common_ui_current_folder">Поточна тека</string>
@@ -228,6 +235,8 @@
     <string name="downloads_queue_phase_cancelled">Скасовано</string>
     <string name="downloads_queue_phase_failed">Помилка: %1$s</string>
     <string name="downloads_queue_cancel_download">Скасувати завантаження</string>
+    <string name="downloads_queue_cancel_download_title">Скасувати завантаження?</string>
+    <string name="downloads_queue_cancel_download_warning">Скасування завантаження DLC, гри або оновлення може пошкодити встановлену гру.\n\nВи впевнені, що хочете скасувати?</string>
     <string name="downloads_queue_empty">Немає активних завантажень.</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">设置</string>
     <string name="common_ui_enable_all">全部启用</string>
     <string name="common_ui_disable_all">全部禁用</string>
+    <string name="common_ui_select_all">全选</string>
+    <string name="common_ui_deselect_all">取消全选</string>
     <string name="common_ui_on">开</string>
     <string name="common_ui_off">关</string>
     <string name="common_ui_already_set">已设置</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">快捷方式已创建</string>
     <string name="library_games_failed_to_create_shortcut">创建快捷方式失败：%s</string>
     <string name="library_games_install_path">安装路径</string>
+    <string name="library_games_not_enough_space">还需要 %1$s 空间</string>
     <string name="library_games_download_slash_install">下载 / 安装</string>
     <string name="library_games_save_management">存档管理</string>
     <string name="library_games_download_install_available">%1$s / %2$s · 可用：%3$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">安装</string>
     <string name="common_ui_application">应用程序</string>
     <string name="common_ui_check">检查</string>
+    <string name="store_game_check_for_update">检查更新</string>
+    <string name="store_game_checking_for_update">正在检查...</string>
+    <string name="store_game_download_update">下载更新</string>
+    <string name="store_game_no_update_available">没有可用更新</string>
+    <string name="store_game_update_available">有可用更新</string>
+    <string name="store_game_update_check_failed">更新检查失败</string>
+    <string name="store_game_update">更新</string>
     <string name="common_ui_select">选择</string>
     <string name="common_ui_select_folder">选择文件夹</string>
     <string name="common_ui_current_folder">当前文件夹</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">已取消</string>
     <string name="downloads_queue_phase_failed">失败：%1$s</string>
     <string name="downloads_queue_cancel_download">取消下载</string>
+    <string name="downloads_queue_cancel_download_title">取消下载？</string>
+    <string name="downloads_queue_cancel_download_warning">取消 DLC、游戏或更新下载可能会损坏游戏安装。\n\n确定要取消吗？</string>
     <string name="downloads_queue_empty">没有活动下载。</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">有可用更新</string>
     <string name="store_game_update_check_failed">更新检查失败</string>
     <string name="store_game_update">更新</string>
+    <string name="store_game_download_already_active">此游戏已在下载。请先取消当前下载，然后再添加 DLC。</string>
     <string name="common_ui_select">选择</string>
     <string name="common_ui_select_folder">选择文件夹</string>
     <string name="common_ui_current_folder">当前文件夹</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -104,6 +104,13 @@
     <string name="common_ui_install">安裝</string>
     <string name="common_ui_application">應用程式</string>
     <string name="common_ui_check">檢查</string>
+    <string name="store_game_check_for_update">檢查更新</string>
+    <string name="store_game_checking_for_update">正在檢查...</string>
+    <string name="store_game_download_update">下載更新</string>
+    <string name="store_game_no_update_available">沒有可用更新</string>
+    <string name="store_game_update_available">有可用更新</string>
+    <string name="store_game_update_check_failed">更新檢查失敗</string>
+    <string name="store_game_update">更新</string>
     <string name="common_ui_select">選擇</string>
     <string name="common_ui_select_folder">選擇資料夾</string>
     <string name="common_ui_current_folder">目前資料夾</string>
@@ -224,6 +231,8 @@
     <string name="downloads_queue_phase_cancelled">已取消</string>
     <string name="downloads_queue_phase_failed">失敗：%1$s</string>
     <string name="downloads_queue_cancel_download">取消下載</string>
+    <string name="downloads_queue_cancel_download_title">取消下載？</string>
+    <string name="downloads_queue_cancel_download_warning">取消 DLC、遊戲或更新下載可能會損壞遊戲安裝。\n\n確定要取消嗎？</string>
     <string name="downloads_queue_empty">沒有進行中的下載。</string>
 
     <!-- Containers > List -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -111,6 +111,7 @@
     <string name="store_game_update_available">有可用更新</string>
     <string name="store_game_update_check_failed">更新檢查失敗</string>
     <string name="store_game_update">更新</string>
+    <string name="store_game_download_already_active">此遊戲已在下載。請先取消目前的下載，然後再新增 DLC。</string>
     <string name="common_ui_select">選擇</string>
     <string name="common_ui_select_folder">選擇資料夾</string>
     <string name="common_ui_current_folder">目前資料夾</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -66,6 +66,8 @@
     <string name="common_ui_settings">設定</string>
     <string name="common_ui_enable_all">全部啟用</string>
     <string name="common_ui_disable_all">全部停用</string>
+    <string name="common_ui_select_all">全選</string>
+    <string name="common_ui_deselect_all">取消全選</string>
     <string name="common_ui_on">開啟</string>
     <string name="common_ui_off">關閉</string>
     <string name="common_ui_already_set">已設定</string>
@@ -137,6 +139,7 @@
     <string name="library_games_shortcut_created">捷徑已建立</string>
     <string name="library_games_failed_to_create_shortcut">無法建立捷徑：%s</string>
     <string name="library_games_install_path">安裝路徑</string>
+    <string name="library_games_not_enough_space">還需要 %1$s 空間</string>
     <string name="library_games_download_slash_install">下載 / 安裝</string>
     <string name="library_games_save_management">存檔管理</string>
     <string name="library_games_download_install_available">%1$s / %2$s・可用：%3$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="common_ui_settings">Settings</string>
     <string name="common_ui_enable_all">Enable all</string>
     <string name="common_ui_disable_all">Disable all</string>
+    <string name="common_ui_select_all">Select all</string>
+    <string name="common_ui_deselect_all">Deselect all</string>
     <string name="common_ui_on">On</string>
     <string name="common_ui_off">Off</string>
     <string name="common_ui_already_set">Already Set</string>
@@ -139,6 +141,7 @@
     <string name="library_games_shortcut_created">Shortcut created</string>
     <string name="library_games_failed_to_create_shortcut">Failed to create shortcut: %s</string>
     <string name="library_games_install_path">Install Path</string>
+    <string name="library_games_not_enough_space">Need %1$s more space</string>
     <string name="library_games_download_slash_install">Download / Install</string>
     <string name="library_games_save_management">SAVE MANAGEMENT</string>
     <string name="library_games_download_install_available">%1$s / %2$s • Available: %3$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="store_game_update_available">Update available</string>
     <string name="store_game_update_check_failed">Update check failed</string>
     <string name="store_game_update">Update</string>
+    <string name="store_game_download_already_active">This game is already downloading. Cancel the current download before adding DLC.</string>
     <string name="common_ui_select">Select</string>
     <string name="common_ui_storage_roots">Storage Roots</string>
     <string name="common_ui_browse_local_folders_directly">Browse local folders directly</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,13 @@
     <string name="common_ui_install">Install</string>
     <string name="common_ui_application">Application</string>
     <string name="common_ui_check">Check</string>
+    <string name="store_game_check_for_update">Check for Update</string>
+    <string name="store_game_checking_for_update">Checking...</string>
+    <string name="store_game_download_update">Download Update</string>
+    <string name="store_game_no_update_available">No update available</string>
+    <string name="store_game_update_available">Update available</string>
+    <string name="store_game_update_check_failed">Update check failed</string>
+    <string name="store_game_update">Update</string>
     <string name="common_ui_select">Select</string>
     <string name="common_ui_storage_roots">Storage Roots</string>
     <string name="common_ui_browse_local_folders_directly">Browse local folders directly</string>
@@ -239,8 +246,8 @@
     <string name="downloads_queue_phase_unknown">Unknown</string>
     <string name="downloads_queue_paused_resume_hint">Paused - tap Resume to continue</string>
     <string name="downloads_queue_cancel_download">Cancel Download</string>
-    <string name="downloads_queue_cancel_download_confirm">Cancel the download for %1$s and delete all downloaded files?</string>
-    <string name="downloads_queue_this_game">this game</string>
+    <string name="downloads_queue_cancel_download_title">Cancel Download?</string>
+    <string name="downloads_queue_cancel_download_warning">Cancelling a DLC, Game, or Update download can potentially corrupt your game install.\n\nAre you sure you want to cancel?</string>
     <string name="downloads_queue_empty">No active downloads.</string>
 
     <!-- Containers > List -->


### PR DESCRIPTION
- Adds dedicated store game detail UI for Steam library entries and download/install state.
- Routes store game details through `StoreGameDetailScreen` instead of inline `UnifiedActivity` composition.
- Extends Steam license and download metadata handling for DLC app IDs, depots, manifests, and sizes.
- Resolves owned Steam DLC through the Steam service and queues DLC downloads through the existing download flow.
- Updates store download service and UI strings for DLC download status handling.