### PR TITLE
Fps limiter and right stick fix

### DIFF
--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -372,6 +372,7 @@ public class WinHandler {
             this.sendData.putShort((short) wheelDelta);
             this.sendData.put((byte) ((flags & 1) != 0 ? 1 : 0));
             sendPacket(CLIENT_PORT);
+            if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
           } catch (IOException ignored) {
           }
         });
@@ -560,6 +561,7 @@ public class WinHandler {
     setLastGamepadSource(GAMEPAD_SOURCE_VIRTUAL, null);
     maybeClearGyroTarget(GAMEPAD_SOURCE_VIRTUAL, null);
     writeVirtualGamepadState(shouldApplyGyroToTarget(GAMEPAD_SOURCE_VIRTUAL, null));
+    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
   }
 
   private void writeVirtualGamepadState(boolean applyGyroOverlay) {
@@ -594,6 +596,7 @@ public class WinHandler {
     maybeClearGyroTarget(GAMEPAD_SOURCE_CONTROLLER, controller);
     writeControllerGamepadState(
         controller, shouldApplyGyroToTarget(GAMEPAD_SOURCE_CONTROLLER, controller));
+    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
   }
 
   private void writeControllerGamepadState(
@@ -1242,6 +1245,8 @@ public class WinHandler {
     } else {
       writeControllerGamepadState(targetController, gyroActive);
     }
+
+    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
 
     this.lastGyroTargetSource = gyroActive ? targetSource : GAMEPAD_SOURCE_NONE;
     this.lastGyroTargetController =

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -372,7 +372,8 @@ public class WinHandler {
             this.sendData.putShort((short) wheelDelta);
             this.sendData.put((byte) ((flags & 1) != 0 ? 1 : 0));
             sendPacket(CLIENT_PORT);
-            if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
+            XServer xServer = activity.getXServer();
+    if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
           } catch (IOException ignored) {
           }
         });
@@ -561,7 +562,8 @@ public class WinHandler {
     setLastGamepadSource(GAMEPAD_SOURCE_VIRTUAL, null);
     maybeClearGyroTarget(GAMEPAD_SOURCE_VIRTUAL, null);
     writeVirtualGamepadState(shouldApplyGyroToTarget(GAMEPAD_SOURCE_VIRTUAL, null));
-    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
+    XServer xServer = activity.getXServer();
+    if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
   }
 
   private void writeVirtualGamepadState(boolean applyGyroOverlay) {
@@ -596,7 +598,8 @@ public class WinHandler {
     maybeClearGyroTarget(GAMEPAD_SOURCE_CONTROLLER, controller);
     writeControllerGamepadState(
         controller, shouldApplyGyroToTarget(GAMEPAD_SOURCE_CONTROLLER, controller));
-    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
+    XServer xServer = activity.getXServer();
+    if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
   }
 
   private void writeControllerGamepadState(
@@ -1246,7 +1249,8 @@ public class WinHandler {
       writeControllerGamepadState(targetController, gyroActive);
     }
 
-    if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
+    XServer xServer = activity.getXServer();
+    if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
 
     this.lastGyroTargetSource = gyroActive ? targetSource : GAMEPAD_SOURCE_NONE;
     this.lastGyroTargetController =

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -473,6 +473,7 @@ public class InputControlsView extends View {
                   xServer.injectPointerMoveDelta(
                       (int) (mouseMoveOffsetX * cursorSpeed * 20),
                       (int) (mouseMoveOffsetY * cursorSpeed * 20));
+                if (xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
               }
             }
           },
@@ -574,6 +575,7 @@ public class InputControlsView extends View {
     WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
     if (winHandler != null) {
       winHandler.sendGamepadState(controller);
+      if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
     }
   }
 
@@ -912,6 +914,7 @@ public class InputControlsView extends View {
 
     if (winHandler != null && sendUpdate) {
       winHandler.sendGamepadState();
+      if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
     }
   }
 
@@ -989,6 +992,7 @@ public class InputControlsView extends View {
       if (winHandler != null && sendUpdate && stateChanged) {
         if (controller != null) winHandler.sendGamepadState(controller);
         else winHandler.sendGamepadState();
+        if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
       }
     } else {
       if (binding == Binding.MOUSE_MOVE_LEFT || binding == Binding.MOUSE_MOVE_RIGHT) {


### PR DESCRIPTION
Tracking a current issue where fps limiter causes some input delay or jitters.
I have added xServer.getRenderer().requestRenderCoalesced()
To input events other then the mouse input. 
Tracking seems to lock with fps limiter capped now.

How to test.
Set fps cap at 30 or 45
Play game with touch controls
Could possibly try game with controller. 