### PR TITLE
feat: virtual gamepad themes — Original/GameHub styles + Xbox/PS labels

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,14 @@
     <string name="input_controls_editor_radial_menu_options">Radial Menu Options</string>
     <string name="input_controls_editor_number_of_bindings">Number of Bindings</string>
     <string name="input_controls_editor_select_profile">Select Profile</string>
+    <string name="input_controls_select_style">Select Style</string>
+    <string name="input_controls_select_label_theme">Button Labels</string>
+    <string name="input_controls_style_original">Original</string>
+    <string name="input_controls_style_gamehub">GameHub</string>
+    <string name="input_controls_label_theme_default">Default</string>
+    <string name="input_controls_label_theme_xbox">Xbox</string>
+    <string name="input_controls_label_theme_playstation">PlayStation</string>
+    <string name="input_controls_edit_duplicating_builtin">Built-in profile — created a copy you can edit.</string>
     <string name="input_controls_editor_profile_name">Profile Name</string>
     <string name="input_controls_editor_no_profile_selected">No profile selected</string>
     <string name="input_controls_editor_no_profile_found">No profile found</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -121,6 +121,8 @@ import com.winlator.cmod.runtime.input.controls.ControlsProfile;
 import com.winlator.cmod.runtime.input.controls.ControllerManager;
 import com.winlator.cmod.runtime.input.controls.ExternalController;
 import com.winlator.cmod.runtime.input.controls.InputControlsManager;
+import com.winlator.cmod.runtime.input.controls.LabelTheme;
+import com.winlator.cmod.runtime.input.controls.VisualStyle;
 import com.winlator.cmod.shared.math.Mathf;
 import com.winlator.cmod.shared.math.XForm;
 import com.winlator.cmod.runtime.audio.midi.MidiHandler;
@@ -2961,16 +2963,33 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private void renderDrawerMenu() {
         if (displayHostComposeView == null || xServerDisplayFrame == null) return;
 
-        ArrayList<ControlsProfile> inputProfiles = inputControlsManager != null ? inputControlsManager.getProfiles(true) : new ArrayList<>();
+        ControlsProfile activeProfile = inputControlsView != null ? inputControlsView.getProfile() : null;
+        ArrayList<ControlsProfile> inputProfiles = getVisibleControlsProfiles();
         ArrayList<String> inputProfileNames = new ArrayList<>();
         int inputSelectedIndex = 0;
         inputProfileNames.add("-- " + getString(R.string.common_ui_disabled) + " --");
-        ControlsProfile activeProfile = inputControlsView != null ? inputControlsView.getProfile() : null;
         for (int i = 0; i < inputProfiles.size(); i++) {
             ControlsProfile profile = inputProfiles.get(i);
             if (activeProfile != null && profile.id == activeProfile.id) inputSelectedIndex = i + 1;
             inputProfileNames.add(profile.getName());
         }
+
+        // Visual style + label theme dropdowns. The order of names here must match the enum
+        // ordinal positions in VisualStyle / LabelTheme so selection by index round-trips cleanly.
+        ArrayList<String> styleNames = new ArrayList<>();
+        styleNames.add(getString(R.string.input_controls_style_original));
+        styleNames.add(getString(R.string.input_controls_style_gamehub));
+        VisualStyle currentStyle = inputControlsView != null && inputControlsView.getVisualStyle() != null
+                ? inputControlsView.getVisualStyle() : VisualStyle.ORIGINAL;
+        int selectedStyleIndex = currentStyle.ordinal();
+
+        ArrayList<String> labelThemeNames = new ArrayList<>();
+        labelThemeNames.add(getString(R.string.input_controls_label_theme_default));
+        labelThemeNames.add(getString(R.string.input_controls_label_theme_xbox));
+        labelThemeNames.add(getString(R.string.input_controls_label_theme_playstation));
+        LabelTheme currentLabelTheme = inputControlsView != null && inputControlsView.getLabelTheme() != null
+                ? inputControlsView.getLabelTheme() : LabelTheme.DEFAULT;
+        int selectedLabelThemeIndex = currentLabelTheme.ordinal();
 
         XServerDrawerState state = XServerDrawerMenuKt.buildXServerDrawerState(
                 this,
@@ -3010,6 +3029,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 colorProfile,
                 inputProfileNames,
                 inputSelectedIndex,
+                styleNames,
+                selectedStyleIndex,
+                labelThemeNames,
+                selectedLabelThemeIndex,
                 preferences.getBoolean("show_touchscreen_controls_enabled", false),
                 isTapToClickEnabled,
                 preferences.getFloat("overlay_opacity", InputControlsView.DEFAULT_OVERLAY_OPACITY),
@@ -3200,9 +3223,31 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                         if (index <= 0) {
                             hideInputControls();
                         } else {
-                            ArrayList<ControlsProfile> profiles = inputControlsManager != null ? inputControlsManager.getProfiles(true) : new ArrayList<>();
+                            // Use the same filtered list the dropdown was rendered from so the
+                            // user's tap selects what they actually saw.
+                            ArrayList<ControlsProfile> profiles = getVisibleControlsProfiles();
                             if (index - 1 < profiles.size()) showInputControls(profiles.get(index - 1));
                         }
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onInputControlsStyleSelected(int index) {
+                        VisualStyle[] all = VisualStyle.values();
+                        if (index < 0 || index >= all.length) return;
+                        VisualStyle chosen = all[index];
+                        if (inputControlsView != null) inputControlsView.setVisualStyle(chosen);
+                        preferences.edit().putString("input_visual_style", chosen.name()).apply();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onInputControlsLabelThemeSelected(int index) {
+                        LabelTheme[] all = LabelTheme.values();
+                        if (index < 0 || index >= all.length) return;
+                        LabelTheme chosen = all[index];
+                        if (inputControlsView != null) inputControlsView.setLabelTheme(chosen);
+                        preferences.edit().putString("input_label_theme", chosen.name()).apply();
                         renderDrawerMenu();
                     }
 
@@ -3244,14 +3289,28 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onInputControlsEditClick() {
                         ControlsProfile activeProfile = inputControlsView != null ? inputControlsView.getProfile() : null;
+                        // Built-in (asset-shipped) profiles are read-only — we silently duplicate
+                        // them before opening the editor and switch the active selection to the
+                        // copy so subsequent saves don't try to mutate read-only state.
+                        if (InputControlsManager.isBuiltinProfile(activeProfile) && inputControlsManager != null) {
+                            ControlsProfile copy = inputControlsManager.duplicateProfile(activeProfile);
+                            if (copy != null) {
+                                showInputControls(copy);
+                                activeProfile = copy;
+                                android.widget.Toast.makeText(XServerDisplayActivity.this,
+                                        R.string.input_controls_edit_duplicating_builtin,
+                                        android.widget.Toast.LENGTH_SHORT).show();
+                            }
+                        }
                         Intent intent = new Intent(XServerDisplayActivity.this, UnifiedActivity.class);
                         intent.putExtra("edit_input_controls", true);
                         intent.putExtra("selected_profile_id", activeProfile != null ? activeProfile.id : 0);
                         intent.putExtra("return_to_game_on_back", true);
+                        final ControlsProfile editingProfile = activeProfile;
                         editInputControlsCallback = () -> {
                             hideInputControls();
                             if (inputControlsManager != null) inputControlsManager.loadProfiles(true);
-                            ControlsProfile reactivated = activeProfile != null && inputControlsManager != null ? inputControlsManager.getProfile(activeProfile.id) : null;
+                            ControlsProfile reactivated = editingProfile != null && inputControlsManager != null ? inputControlsManager.getProfile(editingProfile.id) : null;
                             if (reactivated != null) showInputControls(reactivated);
                             renderDrawerMenu();
                         };
@@ -4458,6 +4517,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         inputControlsView.setTouchpadView(touchpadView);
         inputControlsView.setXServer(xServer);
         applyTouchscreenOverlayPreference();
+        applyInputVisualStylePreferences();
         inputControlsView.setVisibility(View.GONE);
         rootView.addView(inputControlsView);
 
@@ -4740,7 +4800,67 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         editor.apply();
     }
 
+    /**
+     * Returns the profiles to show in the in-game Controls dropdown. The legacy
+     * "Xbox Controller" and "Playstation Controller" profiles are hidden — their visual identity
+     * is now exposed through the separate "Button Labels" dropdown — except when the currently
+     * active profile is one of them, in which case it stays visible so users who haven't yet been
+     * migrated never see an empty selection.
+     */
+    private ArrayList<ControlsProfile> getVisibleControlsProfiles() {
+        ArrayList<ControlsProfile> all = inputControlsManager != null
+                ? inputControlsManager.getProfiles(true)
+                : new ArrayList<>();
+        ControlsProfile active = inputControlsView != null ? inputControlsView.getProfile() : null;
+        ArrayList<ControlsProfile> visible = new ArrayList<>(all.size());
+        for (ControlsProfile p : all) {
+            if (InputControlsManager.isLegacyLabelOnlyProfile(p)
+                    && (active == null || active.id != p.id)) {
+                continue;
+            }
+            visible.add(p);
+        }
+        return visible;
+    }
+
+    /**
+     * Applies the user's chosen visual style + label theme to the on-screen overlay.
+     * Called from session bootstrap so styles persist across launches.
+     */
+    private void applyInputVisualStylePreferences() {
+        if (inputControlsView == null || preferences == null) return;
+        inputControlsView.setVisualStyle(
+                VisualStyle.fromPreference(preferences.getString("input_visual_style", VisualStyle.ORIGINAL.name())));
+        inputControlsView.setLabelTheme(
+                LabelTheme.fromPreference(preferences.getString("input_label_theme", LabelTheme.DEFAULT.name())));
+    }
+
+    /**
+     * One-time migration: if the user's previously-selected profile is the legacy "Xbox" or
+     * "Playstation Controller" asset, switch the active selection to the Virtual Gamepad layout
+     * and apply the matching LabelTheme so the new UI flow takes over without surprising them.
+     * Runs once per install (tracked by the {@code input_controls_label_theme_migrated} flag).
+     */
+    private void maybeMigrateLegacyControllerProfile() {
+        if (preferences == null || inputControlsManager == null) return;
+        if (preferences.getBoolean("input_controls_label_theme_migrated", false)) return;
+        int selectedId = preferences.getInt("selected_profile_id", 0);
+        SharedPreferences.Editor editor = preferences.edit();
+        if (selectedId == InputControlsManager.LEGACY_XBOX_PROFILE_ID) {
+            editor.putInt("selected_profile_id", InputControlsManager.VIRTUAL_GAMEPAD_BUILTIN_ID);
+            editor.putInt("selected_profile_index", -1);
+            editor.putString("input_label_theme", LabelTheme.XBOX.name());
+        } else if (selectedId == InputControlsManager.LEGACY_PS_PROFILE_ID) {
+            editor.putInt("selected_profile_id", InputControlsManager.VIRTUAL_GAMEPAD_BUILTIN_ID);
+            editor.putInt("selected_profile_index", -1);
+            editor.putString("input_label_theme", LabelTheme.PLAYSTATION.name());
+        }
+        editor.putBoolean("input_controls_label_theme_migrated", true);
+        editor.apply();
+    }
+
     private ControlsProfile resolvePreferredStartupProfile() {
+        maybeMigrateLegacyControllerProfile();
         ArrayList<ControlsProfile> profiles = inputControlsManager.getProfiles(true);
         int selectedProfileId = preferences.getInt("selected_profile_id", 0);
         int selectedProfileIndex = preferences.getInt("selected_profile_index", -1);

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -315,6 +315,10 @@ data class XServerDrawerState(
     val colorProfile: Int = 0,
     val inputControlsProfileNames: List<String> = emptyList(),
     val inputControlsSelectedProfileIndex: Int = 0,
+    val inputControlsStyleNames: List<String> = emptyList(),
+    val inputControlsSelectedStyleIndex: Int = 0,
+    val inputControlsLabelThemeNames: List<String> = emptyList(),
+    val inputControlsSelectedLabelThemeIndex: Int = 0,
     val inputControlsShowOverlay: Boolean = false,
     val inputControlsTapToClick: Boolean = true,
     val inputControlsOverlayOpacity: Float = 0.4f,
@@ -489,6 +493,10 @@ interface XServerDrawerActionListener {
 
     fun onInputControlsProfileSelected(index: Int)
 
+    fun onInputControlsStyleSelected(index: Int)
+
+    fun onInputControlsLabelThemeSelected(index: Int)
+
     fun onInputControlsShowOverlayChanged(enabled: Boolean)
 
     fun onInputControlsTapToClickChanged(enabled: Boolean)
@@ -558,6 +566,10 @@ fun buildXServerDrawerState(
     colorProfile: Int = 0,
     inputControlsProfileNames: List<String> = emptyList(),
     inputControlsSelectedProfileIndex: Int = 0,
+    inputControlsStyleNames: List<String> = emptyList(),
+    inputControlsSelectedStyleIndex: Int = 0,
+    inputControlsLabelThemeNames: List<String> = emptyList(),
+    inputControlsSelectedLabelThemeIndex: Int = 0,
     inputControlsShowOverlay: Boolean = false,
     inputControlsTapToClick: Boolean = true,
     inputControlsOverlayOpacity: Float = 0.4f,
@@ -713,6 +725,10 @@ fun buildXServerDrawerState(
         colorProfile = colorProfile,
         inputControlsProfileNames = inputControlsProfileNames,
         inputControlsSelectedProfileIndex = inputControlsSelectedProfileIndex,
+        inputControlsStyleNames = inputControlsStyleNames,
+        inputControlsSelectedStyleIndex = inputControlsSelectedStyleIndex,
+        inputControlsLabelThemeNames = inputControlsLabelThemeNames,
+        inputControlsSelectedLabelThemeIndex = inputControlsSelectedLabelThemeIndex,
         inputControlsShowOverlay = inputControlsShowOverlay,
         inputControlsTapToClick = inputControlsTapToClick,
         inputControlsOverlayOpacity = inputControlsOverlayOpacity,
@@ -1705,6 +1721,28 @@ private fun InputControlsPaneContent(
                     )
                 }
 
+                if (state.inputControlsStyleNames.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
+                        PaneSectionLabel(stringResource(R.string.input_controls_select_style))
+                        InputControlsSimpleDropdown(
+                            options = state.inputControlsStyleNames,
+                            selectedIndex = state.inputControlsSelectedStyleIndex,
+                            onSelected = listener::onInputControlsStyleSelected,
+                        )
+                    }
+                }
+
+                if (state.inputControlsLabelThemeNames.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
+                        PaneSectionLabel(stringResource(R.string.input_controls_select_label_theme))
+                        InputControlsSimpleDropdown(
+                            options = state.inputControlsLabelThemeNames,
+                            selectedIndex = state.inputControlsSelectedLabelThemeIndex,
+                            onSelected = listener::onInputControlsLabelThemeSelected,
+                        )
+                    }
+                }
+
                 DrawerBooleanRow(
                     title = stringResource(R.string.session_drawer_show_touchscreen_controls),
                     checked = state.inputControlsShowOverlay,
@@ -1739,6 +1777,109 @@ private fun InputControlsPaneContent(
                     title = stringResource(R.string.session_gamepad_enable_vibration),
                     checked = state.inputControlsGamepadVibration,
                     onCheckedChange = listener::onInputControlsGamepadVibrationChanged,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Compact dropdown shared by the Style and Label Theme rows in the Controls pane.
+ * Mirrors the styling of [InputControlsProfileSelector] but omits the trailing edit-pencil button
+ * since these are built-in choices, not user-editable.
+ */
+@Composable
+private fun InputControlsSimpleDropdown(
+    options: List<String>,
+    selectedIndex: Int,
+    onSelected: (Int) -> Unit,
+) {
+    val paneScale = LocalPaneScale.current
+    var expanded by remember { mutableStateOf(false) }
+    val selectedText = options.getOrElse(selectedIndex) { options.firstOrNull() ?: "" }
+
+    val cornerRadius = (14f * paneScale).dp
+    val shape = RoundedCornerShape(cornerRadius)
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState().value
+    val bgColor by animateColorAsState(
+        targetValue = if (pressed) PaneInnerPressed else PaneInnerResting,
+        animationSpec = tween(140),
+        label = "inputControlsSimpleBg",
+    )
+
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(shape)
+                    .background(bgColor)
+                    .border(1.dp, RestingCardBorder, shape)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                    ) { expanded = true }
+                    .padding(horizontal = (12f * paneScale).dp, vertical = (10f * paneScale).dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = selectedText,
+                color = DrawerTextPrimary,
+                fontSize = (14f * paneScale).sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = Icons.Outlined.ArrowDropDown,
+                contentDescription = null,
+                tint = DrawerTextSecondary,
+                modifier = Modifier.size((22f * paneScale).dp),
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier =
+                Modifier
+                    .background(PaneSurfaceColor)
+                    .heightIn(max = 280.dp),
+        ) {
+            options.forEachIndexed { index, name ->
+                val isSelected = index == selectedIndex
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = name,
+                            color = if (isSelected) DrawerAccent else DrawerTextPrimary,
+                            fontSize = 14.sp,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                        )
+                    },
+                    trailingIcon =
+                        if (isSelected) {
+                            {
+                                Icon(
+                                    imageVector = Icons.Outlined.Check,
+                                    contentDescription = null,
+                                    tint = DrawerAccent,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                    onClick = {
+                        onSelected(index)
+                        expanded = false
+                    },
+                    colors =
+                        MenuDefaults.itemColors(
+                            textColor = DrawerTextPrimary,
+                        ),
                 )
             }
         }

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -94,6 +94,9 @@ public class ControlElement {
   private boolean wasExpandedOnDown = false;
   private int currentPointerId = -1;
   private final Rect boundingBox = new Rect();
+  /** Scratch rect for the GameHub layout override — kept separate so the cached saved-layout
+   * {@link #boundingBox} stays valid when the user toggles styles back and forth. */
+  private final Rect overrideBoundingBox = new Rect();
   private final Path path = new Path();
   private Path[] paths;
   private boolean[] states = new boolean[4];
@@ -309,7 +312,30 @@ public class ControlElement {
 
   public Rect getBoundingBox() {
     if (boundingBoxNeedsUpdate) computeBoundingBox();
+    // When the GameHub visual style is active (and we're not editing), known gamepad roles get
+    // relocated and resized to the GameHub reference layout. Override is written into a scratch
+    // rect so the cached saved-layout box stays valid for ORIGINAL renderings.
+    if (inputControlsView.getVisualStyle() == VisualStyle.GAMEHUB && !inputControlsView.isEditMode()) {
+      GameHubLayout.Override ov = currentGameHubOverride();
+      if (ov != null) {
+        int snappingSize = inputControlsView.getSnappingSize();
+        if (snappingSize > 0) {
+          int cx = (int) (ov.normX * inputControlsView.getMaxWidth());
+          int cy = (int) (ov.normY * inputControlsView.getMaxHeight());
+          int hw = (int) (ov.halfWidthSnap * snappingSize * ov.scale);
+          int hh = (int) (ov.halfHeightSnap * snappingSize * ov.scale);
+          overrideBoundingBox.set(cx - hw, cy - hh, cx + hw, cy + hh);
+          return overrideBoundingBox;
+        }
+      }
+    }
     return boundingBox;
+  }
+
+  /** Returns the current GameHub override for this element (cached lookup), or null. */
+  private GameHubLayout.Override currentGameHubOverride() {
+    GameHubLayout.Role role = GameHubLayout.roleFor(this);
+    return role != null ? GameHubLayout.overrideFor(role) : null;
   }
 
   private Rect computeBoundingBox() {
@@ -375,18 +401,38 @@ return boundingBox;
 }
 
   private String getDisplayText() {
+    // Per-element text always wins (user explicit override).
     if (text != null && !text.isEmpty()) {
       return text;
-    } else {
-      Binding binding = getBindingAt(0);
-      String text = binding.toString().replace("NUMPAD ", "NP").replace("BUTTON ", "");
-      if (text.length() > 7) {
-        String[] parts = text.split(" ");
-        StringBuilder sb = new StringBuilder();
-        for (String part : parts) sb.append(part.charAt(0));
-        return (binding.isMouse() ? "M" : "") + sb;
-      } else return text;
     }
+    Binding binding = getBindingAt(0);
+    // LabelTheme override (Xbox/PS glyphs and shoulder labels) is applied only when the user
+    // hasn't typed a custom label themselves.
+    LabelTheme theme = inputControlsView.getLabelTheme();
+    String themed = theme != null ? theme.labelFor(binding) : null;
+    if (themed != null) return themed;
+    String text = binding.toString().replace("NUMPAD ", "NP").replace("BUTTON ", "");
+    if (text.length() > 7) {
+      String[] parts = text.split(" ");
+      StringBuilder sb = new StringBuilder();
+      for (String part : parts) sb.append(part.charAt(0));
+      return (binding.isMouse() ? "M" : "") + sb;
+    } else return text;
+  }
+
+  /**
+   * Returns the effective accent color for this element after applying (in order): per-element
+   * customColor (highest priority — user explicit), LabelTheme color for the primary binding, or
+   * {@code -1} if no override applies (caller should fall back to the overlay primary color).
+   */
+  private int resolveAccentColor() {
+    if (customColor != -1) return customColor;
+    LabelTheme theme = inputControlsView.getLabelTheme();
+    if (theme != null) {
+      int c = theme.colorFor(getBindingAt(0));
+      if (c != 0) return c;
+    }
+    return -1;
   }
 
   private String getBindingShortText(int index) {
@@ -431,11 +477,16 @@ return boundingBox;
   }
 
   public void draw(Canvas canvas) {
+    if (inputControlsView.getVisualStyle() == VisualStyle.GAMEHUB) {
+      drawGameHub(canvas);
+      return;
+    }
     int snappingSize = inputControlsView.getSnappingSize();
     Paint paint = inputControlsView.getPaint();
     float effectiveOpacity = inputControlsView.isEditMode() ? Math.max(0.15f, opacity) : opacity;
-    int primaryColor = customColor != -1
-        ? ColorUtils.setAlphaComponent(customColor, (int) (Math.min(1.0f,
+    int accent = resolveAccentColor();
+    int primaryColor = accent != -1
+        ? ColorUtils.setAlphaComponent(accent, (int) (Math.min(1.0f,
             inputControlsView.getOverlayOpacity() * 2.0f) * 255))
         : inputControlsView.getPrimaryColor();
     int alpha = (int) (Color.alpha(primaryColor) * effectiveOpacity);
@@ -446,7 +497,7 @@ return boundingBox;
     int secondaryColor = ColorUtils.setAlphaComponent(inputControlsView.getSecondaryColor(), highlightAlpha);
 
     paint.setColor(
-        (selected && customColor == -1) ? secondaryColor : primaryColor);
+        (selected && accent == -1) ? secondaryColor : primaryColor);
     paint.setStyle(Paint.Style.STROKE);
     float strokeWidth = snappingSize * 0.25f;
     paint.setStrokeWidth(strokeWidth);
@@ -499,7 +550,7 @@ return boundingBox;
 
           paint.setStyle(Paint.Style.STROKE);
           paint.setColor(
-              (selected && customColor == -1)
+              (selected && accent == -1)
                   ? secondaryColor
                   : primaryColor);
           paint.setStrokeWidth(strokeWidth);
@@ -605,7 +656,7 @@ return boundingBox;
 
           paint.setStyle(Paint.Style.STROKE);
           paint.setColor(
-              (selected && customColor == -1)
+              (selected && accent == -1)
                   ? secondaryColor
                   : primaryColor);
           canvas.drawCircle(cx, cy, radius, paint);
@@ -832,6 +883,276 @@ return boundingBox;
               paint);
           break;
         }
+    }
+  }
+
+  /**
+   * GameHub visual style — dark translucent glass body, light white rim, brighter rim & inner glow
+   * when pressed, soft outer shadow. Used when the user picks the "GameHub" style.
+   *
+   * <p>Geometry (positions, bounding boxes, sticks, dpad arms, radial menu paths) is reused from
+   * the original code; only the paint properties differ.
+   */
+  private void drawGameHub(Canvas canvas) {
+    int snappingSize = inputControlsView.getSnappingSize();
+    Paint paint = inputControlsView.getPaint();
+    float effectiveOpacity = inputControlsView.isEditMode() ? Math.max(0.15f, opacity) : opacity;
+    float overlayOpacity = inputControlsView.getOverlayOpacity();
+    boolean engaged = isEngaged();
+    Rect boundingBox = getBoundingBox();
+    GameHubLayout.Override layoutOverride = inputControlsView.isEditMode() ? null : currentGameHubOverride();
+
+    // Resolve accent (user customColor → theme color → none).
+    int accent = resolveAccentColor();
+    boolean hasAccent = accent != -1;
+
+    // GameHub palette — uses the source asset's alpha values directly so the dark-glass identity
+    // doesn't disappear at the default overlay opacity. Per-element opacity still applies; the
+    // overlayOpacity slider modulates with a gentle floor so the controls never look fully washed.
+    float gameHubDim = Math.min(1.0f, 0.5f + overlayOpacity * 0.7f);
+    int fillAlpha = (int) (90 * gameHubDim * effectiveOpacity); // dark glass body
+    int strokeAlpha = (int) (150 * gameHubDim * effectiveOpacity); // light rim
+    int pressedFillAlpha = (int) (60 * gameHubDim * effectiveOpacity); // brighter inner glow when pressed
+    int pressedStrokeAlpha = (int) (220 * gameHubDim * effectiveOpacity); // brighter rim when pressed
+    int textAlpha = (int) (255 * gameHubDim * effectiveOpacity);
+
+    int fillColor = Color.argb(fillAlpha, 0, 0, 0);
+    int strokeColor = hasAccent
+        ? ColorUtils.setAlphaComponent(accent, Math.max(strokeAlpha, 110))
+        : Color.argb(strokeAlpha, 255, 255, 255);
+    int pressedFillBase = hasAccent ? accent : Color.WHITE;
+    int pressedFillColor = ColorUtils.setAlphaComponent(pressedFillBase, pressedFillAlpha);
+    int pressedStrokeColor = hasAccent
+        ? ColorUtils.setAlphaComponent(accent, Math.max(pressedStrokeAlpha, 160))
+        : Color.argb(pressedStrokeAlpha, 255, 255, 255);
+    int textColor = hasAccent
+        ? ColorUtils.setAlphaComponent(accent, textAlpha)
+        : Color.argb(textAlpha, 255, 255, 255);
+
+    // Edit-mode selection highlight reuses the existing secondary color so editing UX stays the
+    // same regardless of style.
+    if (selected && !hasAccent) {
+      int highlightAlpha = (int) (255 * overlayOpacity);
+      strokeColor = ColorUtils.setAlphaComponent(inputControlsView.getSecondaryColor(), highlightAlpha);
+    }
+
+    float strokeWidth = Math.max(2f, snappingSize * 0.18f);
+    paint.setStrokeWidth(strokeWidth);
+    paint.setStrokeJoin(Paint.Join.ROUND);
+    paint.setStrokeCap(Paint.Cap.ROUND);
+
+    switch (type) {
+      case BUTTON: {
+        float cx = boundingBox.centerX();
+        float cy = boundingBox.centerY();
+        boolean isTrigger = layoutOverride != null
+            && (layoutOverride.shape == GameHubLayout.RenderShape.TRIGGER_LT
+                || layoutOverride.shape == GameHubLayout.RenderShape.TRIGGER_LB
+                || layoutOverride.shape == GameHubLayout.RenderShape.TRIGGER_RT
+                || layoutOverride.shape == GameHubLayout.RenderShape.TRIGGER_RB);
+
+        if (isTrigger) {
+          GameHubLayout.buildTriggerPath(
+              path, layoutOverride.shape,
+              boundingBox.left, boundingBox.top, boundingBox.right, boundingBox.bottom);
+          paint.setStyle(Paint.Style.FILL);
+          paint.setColor(fillColor);
+          canvas.drawPath(path, paint);
+          if (engaged) {
+            paint.setColor(pressedFillColor);
+            canvas.drawPath(path, paint);
+          }
+          paint.setStyle(Paint.Style.STROKE);
+          paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+          canvas.drawPath(path, paint);
+        } else {
+          drawGameHubShape(canvas, paint, boundingBox, fillColor, true);
+          if (engaged) drawGameHubShape(canvas, paint, boundingBox, pressedFillColor, true);
+          paint.setStyle(Paint.Style.STROKE);
+          paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+          drawGameHubShape(canvas, paint, boundingBox, 0, false);
+        }
+
+        if (iconId > 0) {
+          drawIcon(canvas, cx, cy, boundingBox.width(), boundingBox.height(), iconId);
+        } else {
+          String label = getDisplayText();
+          paint.setStyle(Paint.Style.FILL);
+          paint.setColor(textColor);
+          paint.setTextSize(
+              Math.min(
+                  getTextSizeForWidth(paint, label, boundingBox.width() - strokeWidth * 2),
+                  snappingSize * 2 * scale));
+          paint.setTextAlign(Paint.Align.CENTER);
+          paint.setFakeBoldText(true);
+          canvas.drawText(label, cx, (cy - ((paint.descent() + paint.ascent()) * 0.5f)), paint);
+          paint.setFakeBoldText(false);
+        }
+        break;
+      }
+      case STICK: {
+        int cx = boundingBox.centerX();
+        int cy = boundingBox.centerY();
+        float ringRadius = boundingBox.height() * 0.5f;
+
+        // Outer ring — solid translucent dark fill matching the button fill alpha so the
+        // joystick shadowing reads with the same weight as the rest of the controls.
+        int ringFillAlpha = fillAlpha;
+        int ringFill = Color.argb(ringFillAlpha, 0, 0, 0);
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(ringFill);
+        canvas.drawCircle(cx, cy, ringRadius, paint);
+
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+        canvas.drawCircle(cx, cy, ringRadius - strokeWidth * 0.5f, paint);
+
+        // Inner thumb — substantial translucent white disc with a thin rim so it visually pops
+        // against the dark ring fill. When a GameHub layout override is active and the stick
+        // isn't being touched, snap the thumb to the overridden center; getCurrentPosition() is
+        // otherwise seeded from the saved profile coordinates and would draw off-center.
+        float thumbX;
+        float thumbY;
+        if (engaged) {
+          thumbX = getCurrentPosition().x;
+          thumbY = getCurrentPosition().y;
+        } else if (layoutOverride != null) {
+          thumbX = cx;
+          thumbY = cy;
+        } else {
+          thumbX = getCurrentPosition().x;
+          thumbY = getCurrentPosition().y;
+        }
+        // Thumb radius at ~48% of outer ring — the user reported the previous 45% looked too
+        // small. Matches GameHub's reference of roughly 0.43-0.50.
+        float thumbRadius =
+            layoutOverride != null ? ringRadius * 0.48f : snappingSize * 3.5f * scale;
+        int thumbFillAlpha = (int) ((engaged ? 100 : 77) * gameHubDim * effectiveOpacity);
+        int thumbFill = hasAccent
+            ? ColorUtils.setAlphaComponent(accent, thumbFillAlpha)
+            : Color.argb(thumbFillAlpha, 255, 255, 255);
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(thumbFill);
+        canvas.drawCircle(thumbX, thumbY, thumbRadius, paint);
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+        canvas.drawCircle(thumbX, thumbY, thumbRadius - strokeWidth * 0.5f, paint);
+        break;
+      }
+      case D_PAD: {
+        float cx = boundingBox.centerX();
+        float cy = boundingBox.centerY();
+
+        // GameHub override: draw 4 detached pentagonal arrows at the cardinal edges of the bbox.
+        if (layoutOverride != null && layoutOverride.shape == GameHubLayout.RenderShape.DPAD_CROSS) {
+          float radius = Math.min(boundingBox.width(), boundingBox.height()) * 0.5f;
+          GameHubLayout.buildDpadArrows(path, cx, cy, radius);
+        } else {
+          // Same dpad geometry as ORIGINAL (used when no override applies — e.g. mixed profiles).
+          float offsetX = snappingSize * 2 * scale;
+          float offsetY = snappingSize * 3 * scale;
+          float start = snappingSize * scale;
+          path.reset();
+          path.moveTo(cx, cy - start);
+          path.lineTo(cx - offsetX, cy - offsetY);
+          path.lineTo(cx - offsetX, boundingBox.top);
+          path.lineTo(cx + offsetX, boundingBox.top);
+          path.lineTo(cx + offsetX, cy - offsetY);
+          path.close();
+          path.moveTo(cx - start, cy);
+          path.lineTo(cx - offsetY, cy - offsetX);
+          path.lineTo(boundingBox.left, cy - offsetX);
+          path.lineTo(boundingBox.left, cy + offsetX);
+          path.lineTo(cx - offsetY, cy + offsetX);
+          path.close();
+          path.moveTo(cx, cy + start);
+          path.lineTo(cx - offsetX, cy + offsetY);
+          path.lineTo(cx - offsetX, boundingBox.bottom);
+          path.lineTo(cx + offsetX, boundingBox.bottom);
+          path.lineTo(cx + offsetX, cy + offsetY);
+          path.close();
+          path.moveTo(cx + start, cy);
+          path.lineTo(cx + offsetY, cy - offsetX);
+          path.lineTo(boundingBox.right, cy - offsetX);
+          path.lineTo(boundingBox.right, cy + offsetX);
+          path.lineTo(cx + offsetY, cy + offsetX);
+          path.close();
+        }
+
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(fillColor);
+        canvas.drawPath(path, paint);
+        if (engaged) {
+          paint.setColor(pressedFillColor);
+          canvas.drawPath(path, paint);
+        }
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+        canvas.drawPath(path, paint);
+        break;
+      }
+      case TRACKPAD: {
+        float radius = boundingBox.height() * 0.18f;
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(fillColor);
+        canvas.drawRoundRect(
+            boundingBox.left, boundingBox.top, boundingBox.right, boundingBox.bottom,
+            radius, radius, paint);
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+        canvas.drawRoundRect(
+            boundingBox.left, boundingBox.top, boundingBox.right, boundingBox.bottom,
+            radius, radius, paint);
+        break;
+      }
+      case RADIAL_MENU:
+      case RANGE_BUTTON:
+      default:
+        // Less common element types — defer to the original renderer to avoid duplicating their
+        // bespoke geometry; the surrounding color resolution already covers theme colors.
+        drawOriginalLegacy(canvas);
+        break;
+    }
+  }
+
+  private void drawGameHubShape(Canvas canvas, Paint paint, Rect bb, int color, boolean fill) {
+    if (fill) {
+      paint.setStyle(Paint.Style.FILL);
+      paint.setColor(color);
+    }
+    int snappingSize = inputControlsView.getSnappingSize();
+    switch (shape) {
+      case CIRCLE:
+        canvas.drawCircle(bb.centerX(), bb.centerY(), bb.width() * 0.5f, paint);
+        break;
+      case RECT:
+        canvas.drawRect(bb, paint);
+        break;
+      case ROUND_RECT: {
+        float r = bb.height() * 0.5f;
+        canvas.drawRoundRect(bb.left, bb.top, bb.right, bb.bottom, r, r, paint);
+        break;
+      }
+      case SQUARE: {
+        float r = snappingSize * 0.85f * scale;
+        canvas.drawRoundRect(bb.left, bb.top, bb.right, bb.bottom, r, r, paint);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Fallback to the original draw routine for element types we don't customize in the GameHub
+   * style (RADIAL_MENU, RANGE_BUTTON). This temporarily switches the view's style back to ORIGINAL
+   * just for this draw call.
+   */
+  private void drawOriginalLegacy(Canvas canvas) {
+    VisualStyle saved = inputControlsView.getVisualStyle();
+    try {
+      inputControlsView.setVisualStyleSilent(VisualStyle.ORIGINAL);
+      draw(canvas);
+    } finally {
+      inputControlsView.setVisualStyleSilent(saved);
     }
   }
 

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -6,8 +6,10 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PointF;
+import android.graphics.RadialGradient;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.Shader;
 import androidx.core.graphics.ColorUtils;
 import com.winlator.cmod.runtime.display.winhandler.MouseEventFlags;
 import com.winlator.cmod.runtime.display.xserver.XServer;
@@ -915,6 +917,9 @@ return boundingBox;
     int pressedFillAlpha = (int) (60 * gameHubDim * effectiveOpacity); // brighter inner glow when pressed
     int pressedStrokeAlpha = (int) (220 * gameHubDim * effectiveOpacity); // brighter rim when pressed
     int textAlpha = (int) (255 * gameHubDim * effectiveOpacity);
+    // Glass vignette — translucent black at the inner edge of each shape that fades to fully
+    // transparent at the center, producing a soft inset-shadow / glass look on top of the base fill.
+    int glassEdgeAlpha = (int) (75 * gameHubDim * effectiveOpacity);
 
     int fillColor = Color.argb(fillAlpha, 0, 0, 0);
     int strokeColor = hasAccent
@@ -962,12 +967,16 @@ return boundingBox;
             paint.setColor(pressedFillColor);
             canvas.drawPath(path, paint);
           }
+          drawGameHubGlassOnPath(
+              canvas, paint, path, cx, cy,
+              Math.max(boundingBox.width(), boundingBox.height()) * 0.5f, glassEdgeAlpha);
           paint.setStyle(Paint.Style.STROKE);
           paint.setColor(engaged ? pressedStrokeColor : strokeColor);
           canvas.drawPath(path, paint);
         } else {
           drawGameHubShape(canvas, paint, boundingBox, fillColor, true);
           if (engaged) drawGameHubShape(canvas, paint, boundingBox, pressedFillColor, true);
+          drawGameHubGlassShape(canvas, paint, boundingBox, glassEdgeAlpha);
           paint.setStyle(Paint.Style.STROKE);
           paint.setColor(engaged ? pressedStrokeColor : strokeColor);
           drawGameHubShape(canvas, paint, boundingBox, 0, false);
@@ -1002,6 +1011,18 @@ return boundingBox;
         paint.setStyle(Paint.Style.FILL);
         paint.setColor(ringFill);
         canvas.drawCircle(cx, cy, ringRadius, paint);
+
+        // Glass vignette across the outer ring — the inner thumb will cover the brightest center
+        // anyway, so this reads as a darker shadow just inside the ring's rim.
+        if (glassEdgeAlpha > 0) {
+          paint.setShader(new RadialGradient(
+              cx, cy, ringRadius,
+              Color.argb(0, 0, 0, 0), Color.argb(glassEdgeAlpha, 0, 0, 0),
+              Shader.TileMode.CLAMP));
+          paint.setStyle(Paint.Style.FILL);
+          canvas.drawCircle(cx, cy, ringRadius, paint);
+          paint.setShader(null);
+        }
 
         paint.setStyle(Paint.Style.STROKE);
         paint.setColor(engaged ? pressedStrokeColor : strokeColor);
@@ -1046,7 +1067,33 @@ return boundingBox;
         // GameHub override: draw 4 detached pentagonal arrows at the cardinal edges of the bbox.
         if (layoutOverride != null && layoutOverride.shape == GameHubLayout.RenderShape.DPAD_CROSS) {
           float radius = Math.min(boundingBox.width(), boundingBox.height()) * 0.5f;
+          // Per-arrow fill + glass vignette so each arrow has its own inner-shadow centroid;
+          // a single radial gradient across the whole cluster would put the bright spot in the
+          // gap between arrows rather than inside each one.
+          float[] arrowCenter = new float[2];
+          float arrowGradR = radius * 0.5f;
+          for (int side = 0; side < 4; side++) {
+            path.reset();
+            GameHubLayout.buildDpadArrow(path, side, cx, cy, radius);
+            paint.setStyle(Paint.Style.FILL);
+            paint.setColor(fillColor);
+            canvas.drawPath(path, paint);
+            if (engaged) {
+              paint.setColor(pressedFillColor);
+              canvas.drawPath(path, paint);
+            }
+            if (glassEdgeAlpha > 0) {
+              GameHubLayout.dpadArrowCenter(side, cx, cy, radius, arrowCenter);
+              drawGameHubGlassOnPath(
+                  canvas, paint, path, arrowCenter[0], arrowCenter[1], arrowGradR, glassEdgeAlpha);
+            }
+          }
+          // Combined stroke pass for all four arrows.
           GameHubLayout.buildDpadArrows(path, cx, cy, radius);
+          paint.setStyle(Paint.Style.STROKE);
+          paint.setColor(engaged ? pressedStrokeColor : strokeColor);
+          canvas.drawPath(path, paint);
+          break;
         } else {
           // Same dpad geometry as ORIGINAL (used when no override applies — e.g. mixed profiles).
           float offsetX = snappingSize * 2 * scale;
@@ -1139,6 +1186,60 @@ return boundingBox;
         break;
       }
     }
+  }
+
+  /**
+   * Draws a soft radial vignette (transparent center → translucent black at the rim) clipped to
+   * the element's GameHub shape. Layered on top of the base fill so the inner edge of the border
+   * darkens and gradually fades toward the center, producing a glass / inset-shadow look.
+   */
+  private void drawGameHubGlassShape(Canvas canvas, Paint paint, Rect bb, int edgeAlpha) {
+    if (edgeAlpha <= 0) return;
+    float cx = bb.exactCenterX();
+    float cy = bb.exactCenterY();
+    float gradR = Math.max(bb.width(), bb.height()) * 0.5f;
+    paint.setShader(new RadialGradient(
+        cx, cy, gradR,
+        Color.argb(0, 0, 0, 0), Color.argb(edgeAlpha, 0, 0, 0),
+        Shader.TileMode.CLAMP));
+    paint.setStyle(Paint.Style.FILL);
+    int snappingSize = inputControlsView.getSnappingSize();
+    switch (shape) {
+      case CIRCLE:
+        canvas.drawCircle(cx, cy, bb.width() * 0.5f, paint);
+        break;
+      case RECT:
+        canvas.drawRect(bb, paint);
+        break;
+      case ROUND_RECT: {
+        float r = bb.height() * 0.5f;
+        canvas.drawRoundRect(bb.left, bb.top, bb.right, bb.bottom, r, r, paint);
+        break;
+      }
+      case SQUARE: {
+        float r = snappingSize * 0.85f * scale;
+        canvas.drawRoundRect(bb.left, bb.top, bb.right, bb.bottom, r, r, paint);
+        break;
+      }
+    }
+    paint.setShader(null);
+  }
+
+  /**
+   * Same vignette as {@link #drawGameHubGlassShape} but clipped to an arbitrary path (used for
+   * trigger silhouettes and per-arrow d-pad shapes). The gradient is anchored at {@code (cx, cy)}
+   * with radius {@code gradR}, which the caller picks to match the path's centroid and extent.
+   */
+  private void drawGameHubGlassOnPath(
+      Canvas canvas, Paint paint, Path path, float cx, float cy, float gradR, int edgeAlpha) {
+    if (edgeAlpha <= 0 || gradR <= 0) return;
+    paint.setShader(new RadialGradient(
+        cx, cy, gradR,
+        Color.argb(0, 0, 0, 0), Color.argb(edgeAlpha, 0, 0, 0),
+        Shader.TileMode.CLAMP));
+    paint.setStyle(Paint.Style.FILL);
+    canvas.drawPath(path, paint);
+    paint.setShader(null);
   }
 
   /**

--- a/app/src/main/runtime/input/controls/GameHubLayout.java
+++ b/app/src/main/runtime/input/controls/GameHubLayout.java
@@ -274,61 +274,95 @@ public final class GameHubLayout {
    */
   public static void buildDpadArrows(Path out, float cx, float cy, float radius) {
     out.reset();
+    for (int side = 0; side < 4; side++) buildDpadArrow(out, side, cx, cy, radius);
+  }
+
+  /** D-pad arrow sides used by {@link #buildDpadArrow} and {@link #dpadArrowCenter}. */
+  public static final int DPAD_UP = 0;
+  public static final int DPAD_DOWN = 1;
+  public static final int DPAD_LEFT = 2;
+  public static final int DPAD_RIGHT = 3;
+
+  /**
+   * Appends a single GameHub d-pad arrow ({@code side} in [0..3]) to {@code out} without resetting
+   * it. Geometry matches {@link #buildDpadArrows}; broken out so callers can render per-arrow
+   * effects (e.g. a radial glass vignette anchored at each arrow's centroid).
+   */
+  public static void buildDpadArrow(Path out, int side, float cx, float cy, float radius) {
     // GameHub d-pad: each arrow is a "house" / "square with a pointer" — a rectangle on the
     // outer side, then two short angled walls converging to a single point that aims AT the
     // center of the d-pad. The two outer corners get a small radius; the inner shoulder corners
     // and the tip stay sharp so the pointer reads clearly.
-    float outer = radius * 0.95f;       // distance from center to the flat outer edge
-    float shoulder = radius * 0.45f;    // distance from center to where the rectangle ends and
-                                        // the pointer begins (length of rectangle body = 0.50r)
-    float inner = radius * 0.18f;        // distance from center to the pointer tip
-    float halfOuter = radius * 0.25f;   // half-width of the rectangular body — equal to half its
-                                        // length (0.25r * 2 = 0.50r), so the body is a square
-    float cornerR = radius * 0.05f;     // small outer-corner rounding
+    float outer = radius * 0.95f;
+    float shoulder = radius * 0.45f;
+    float inner = radius * 0.18f;
+    float halfOuter = radius * 0.275f;
+    float cornerR = radius * 0.05f;
 
-    // UP — rectangle at the top with pointer tip aiming DOWN toward center.
-    out.moveTo(cx - halfOuter + cornerR, cy - outer);
-    out.lineTo(cx + halfOuter - cornerR, cy - outer);
-    out.quadTo(cx + halfOuter, cy - outer, cx + halfOuter, cy - outer + cornerR);
-    out.lineTo(cx + halfOuter, cy - shoulder);
-    out.lineTo(cx, cy - inner);                                 // pointer tip
-    out.lineTo(cx - halfOuter, cy - shoulder);
-    out.lineTo(cx - halfOuter, cy - outer + cornerR);
-    out.quadTo(cx - halfOuter, cy - outer, cx - halfOuter + cornerR, cy - outer);
-    out.close();
+    switch (side) {
+      case DPAD_UP:
+        out.moveTo(cx - halfOuter + cornerR, cy - outer);
+        out.lineTo(cx + halfOuter - cornerR, cy - outer);
+        out.quadTo(cx + halfOuter, cy - outer, cx + halfOuter, cy - outer + cornerR);
+        out.lineTo(cx + halfOuter, cy - shoulder);
+        out.lineTo(cx, cy - inner);
+        out.lineTo(cx - halfOuter, cy - shoulder);
+        out.lineTo(cx - halfOuter, cy - outer + cornerR);
+        out.quadTo(cx - halfOuter, cy - outer, cx - halfOuter + cornerR, cy - outer);
+        out.close();
+        break;
+      case DPAD_DOWN:
+        out.moveTo(cx + halfOuter - cornerR, cy + outer);
+        out.lineTo(cx - halfOuter + cornerR, cy + outer);
+        out.quadTo(cx - halfOuter, cy + outer, cx - halfOuter, cy + outer - cornerR);
+        out.lineTo(cx - halfOuter, cy + shoulder);
+        out.lineTo(cx, cy + inner);
+        out.lineTo(cx + halfOuter, cy + shoulder);
+        out.lineTo(cx + halfOuter, cy + outer - cornerR);
+        out.quadTo(cx + halfOuter, cy + outer, cx + halfOuter - cornerR, cy + outer);
+        out.close();
+        break;
+      case DPAD_LEFT:
+        out.moveTo(cx - outer, cy + halfOuter - cornerR);
+        out.lineTo(cx - outer, cy - halfOuter + cornerR);
+        out.quadTo(cx - outer, cy - halfOuter, cx - outer + cornerR, cy - halfOuter);
+        out.lineTo(cx - shoulder, cy - halfOuter);
+        out.lineTo(cx - inner, cy);
+        out.lineTo(cx - shoulder, cy + halfOuter);
+        out.lineTo(cx - outer + cornerR, cy + halfOuter);
+        out.quadTo(cx - outer, cy + halfOuter, cx - outer, cy + halfOuter - cornerR);
+        out.close();
+        break;
+      case DPAD_RIGHT:
+        out.moveTo(cx + outer, cy - halfOuter + cornerR);
+        out.lineTo(cx + outer, cy + halfOuter - cornerR);
+        out.quadTo(cx + outer, cy + halfOuter, cx + outer - cornerR, cy + halfOuter);
+        out.lineTo(cx + shoulder, cy + halfOuter);
+        out.lineTo(cx + inner, cy);
+        out.lineTo(cx + shoulder, cy - halfOuter);
+        out.lineTo(cx + outer - cornerR, cy - halfOuter);
+        out.quadTo(cx + outer, cy - halfOuter, cx + outer, cy - halfOuter + cornerR);
+        out.close();
+        break;
+    }
+  }
 
-    // DOWN — rectangle at the bottom, pointer aims UP.
-    out.moveTo(cx + halfOuter - cornerR, cy + outer);
-    out.lineTo(cx - halfOuter + cornerR, cy + outer);
-    out.quadTo(cx - halfOuter, cy + outer, cx - halfOuter, cy + outer - cornerR);
-    out.lineTo(cx - halfOuter, cy + shoulder);
-    out.lineTo(cx, cy + inner);
-    out.lineTo(cx + halfOuter, cy + shoulder);
-    out.lineTo(cx + halfOuter, cy + outer - cornerR);
-    out.quadTo(cx + halfOuter, cy + outer, cx + halfOuter - cornerR, cy + outer);
-    out.close();
-
-    // LEFT — rectangle on the left, pointer aims RIGHT.
-    out.moveTo(cx - outer, cy + halfOuter - cornerR);
-    out.lineTo(cx - outer, cy - halfOuter + cornerR);
-    out.quadTo(cx - outer, cy - halfOuter, cx - outer + cornerR, cy - halfOuter);
-    out.lineTo(cx - shoulder, cy - halfOuter);
-    out.lineTo(cx - inner, cy);
-    out.lineTo(cx - shoulder, cy + halfOuter);
-    out.lineTo(cx - outer + cornerR, cy + halfOuter);
-    out.quadTo(cx - outer, cy + halfOuter, cx - outer, cy + halfOuter - cornerR);
-    out.close();
-
-    // RIGHT — rectangle on the right, pointer aims LEFT.
-    out.moveTo(cx + outer, cy - halfOuter + cornerR);
-    out.lineTo(cx + outer, cy + halfOuter - cornerR);
-    out.quadTo(cx + outer, cy + halfOuter, cx + outer - cornerR, cy + halfOuter);
-    out.lineTo(cx + shoulder, cy + halfOuter);
-    out.lineTo(cx + inner, cy);
-    out.lineTo(cx + shoulder, cy - halfOuter);
-    out.lineTo(cx + outer - cornerR, cy - halfOuter);
-    out.quadTo(cx + outer, cy - halfOuter, cx + outer, cy - halfOuter + cornerR);
-    out.close();
+  /**
+   * Writes the approximate centroid of a single d-pad arrow into {@code outXY} (length ≥ 2).
+   * Used as the anchor point for the per-arrow radial glass vignette so each arrow lights up
+   * from its own middle outward rather than from the d-pad cluster center.
+   */
+  public static void dpadArrowCenter(int side, float cx, float cy, float radius, float[] outXY) {
+    // Midpoint between the outer flat edge (0.95r) and the pointer tip (0.18r) along the
+    // arrow's axis — close enough to the visual center for a smooth vignette.
+    float along = radius * 0.565f;
+    switch (side) {
+      case DPAD_UP:    outXY[0] = cx;          outXY[1] = cy - along; break;
+      case DPAD_DOWN:  outXY[0] = cx;          outXY[1] = cy + along; break;
+      case DPAD_LEFT:  outXY[0] = cx - along;  outXY[1] = cy;         break;
+      case DPAD_RIGHT: outXY[0] = cx + along;  outXY[1] = cy;         break;
+      default:         outXY[0] = cx;          outXY[1] = cy;         break;
+    }
   }
 
   private GameHubLayout() {}

--- a/app/src/main/runtime/input/controls/GameHubLayout.java
+++ b/app/src/main/runtime/input/controls/GameHubLayout.java
@@ -1,0 +1,335 @@
+package com.winlator.cmod.runtime.input.controls;
+
+import android.graphics.Path;
+import android.graphics.RectF;
+import java.util.EnumMap;
+
+/**
+ * Layout overlay applied when {@link VisualStyle#GAMEHUB} is active.
+ *
+ * <p>Each on-screen control whose primary binding matches a known gamepad role gets relocated and
+ * reshaped at draw/hit-test time to mirror the GameHub launcher's reference layout (extracted from
+ * the decompiled <code>OfficialLayout_gamepad.gtheme</code>). Underlying profile JSON is never
+ * mutated — overrides are a runtime decoration only, so switching back to {@link
+ * VisualStyle#ORIGINAL} immediately restores the user's saved positions.
+ *
+ * <p>Edit mode bypasses overrides so the user manipulates their real saved layout.
+ */
+public final class GameHubLayout {
+
+  public enum Role {
+    BTN_A,
+    BTN_B,
+    BTN_X,
+    BTN_Y,
+    LB,
+    LT,
+    RB,
+    RT,
+    L3,
+    R3,
+    LSTICK,
+    RSTICK,
+    DPAD,
+    START,
+    SELECT
+  }
+
+  /**
+   * Shapes used by the GameHub renderer. Distinct from {@link ControlElement.Shape} so we don't
+   * pollute the persisted enum with values that only make sense at draw time.
+   */
+  public enum RenderShape {
+    CIRCLE,
+    ROUND_RECT,
+    TRIGGER_LT,
+    TRIGGER_LB,
+    TRIGGER_RT,
+    TRIGGER_RB,
+    DPAD_CROSS
+  }
+
+  public static final class Override {
+    /** Anchor center in normalized view coordinates (0..1). */
+    public final float normX;
+
+    public final float normY;
+    /** Half-extents expressed in snappingSize units (snappingSize = viewWidth/100). */
+    public final float halfWidthSnap;
+
+    public final float halfHeightSnap;
+    public final RenderShape shape;
+    public final float scale;
+
+    Override(float nx, float ny, float hw, float hh, RenderShape shape, float scale) {
+      this.normX = nx;
+      this.normY = ny;
+      this.halfWidthSnap = hw;
+      this.halfHeightSnap = hh;
+      this.shape = shape;
+      this.scale = scale;
+    }
+  }
+
+  private static final EnumMap<Role, Override> OVERRIDES = new EnumMap<>(Role.class);
+
+  static {
+    // Shoulders / triggers — anchored hard against the top corners. Vertical spacing matches the
+    // GameHub asset (LT y=0.115, LB y=0.280) so the two pills sit clearly apart instead of
+    // visually touching.
+    OVERRIDES.put(Role.LT, new Override(0.087f, 0.115f, 5.5f, 2.3f, RenderShape.TRIGGER_LT, 1.0f));
+    OVERRIDES.put(Role.LB, new Override(0.087f, 0.280f, 5.5f, 2.3f, RenderShape.TRIGGER_LB, 1.0f));
+    OVERRIDES.put(Role.RT, new Override(0.913f, 0.115f, 5.5f, 2.3f, RenderShape.TRIGGER_RT, 1.0f));
+    OVERRIDES.put(Role.RB, new Override(0.913f, 0.280f, 5.5f, 2.3f, RenderShape.TRIGGER_RB, 1.0f));
+
+    // Stick-click buttons (L3/R3) — small circles tucked just under the shoulder column.
+    OVERRIDES.put(Role.L3, new Override(0.055f, 0.42f, 2.1f, 2.1f, RenderShape.CIRCLE, 1.0f));
+    OVERRIDES.put(Role.R3, new Override(0.945f, 0.42f, 2.1f, 2.1f, RenderShape.CIRCLE, 1.0f));
+
+    // Joysticks — large translucent rings, bottom row. Ring diameter ≈ 15% of view width,
+    // matching the GameHub reference measurement. Right stick pushed further right to clear the
+    // d-pad cluster and match the GameHub asset's x=0.684 anchor.
+    OVERRIDES.put(Role.LSTICK, new Override(0.16f, 0.70f, 7.0f, 7.0f, RenderShape.CIRCLE, 1.0f));
+    OVERRIDES.put(Role.RSTICK, new Override(0.72f, 0.70f, 7.0f, 7.0f, RenderShape.CIRCLE, 1.0f));
+
+    // D-pad in the gap between the left stick and the right-side face buttons. Bbox is large so
+    // each detached arrow has room to render as a recognizable chevron.
+    OVERRIDES.put(Role.DPAD, new Override(0.335f, 0.70f, 7.5f, 7.5f, RenderShape.DPAD_CROSS, 1.0f));
+
+    // Face buttons — diamond cluster. X↔B center distance set to 0.11 of view WIDTH so it reads
+    // visually equal to the Y↔A 0.24-of-view-HEIGHT span on a typical landscape device (since
+    // view height in landscape ≈ view width / 2.2, 0.24*height ≈ 0.109*width). Cluster center at
+    // 0.89 sits 25% closer to the right edge than the previous 0.85.
+    OVERRIDES.put(Role.BTN_Y, new Override(0.890f, 0.60f, 3.0f, 3.0f, RenderShape.CIRCLE, 1.0f));
+    OVERRIDES.put(Role.BTN_X, new Override(0.835f, 0.72f, 3.0f, 3.0f, RenderShape.CIRCLE, 1.0f));
+    OVERRIDES.put(Role.BTN_B, new Override(0.945f, 0.72f, 3.0f, 3.0f, RenderShape.CIRCLE, 1.0f));
+    OVERRIDES.put(Role.BTN_A, new Override(0.890f, 0.84f, 3.0f, 3.0f, RenderShape.CIRCLE, 1.0f));
+
+    // Start / Select pills along the bottom center — leave at original-ish positions because the
+    // GameHub reference is sparse here.
+    OVERRIDES.put(Role.START, new Override(0.54f, 0.94f, 3f, 1.8f, RenderShape.ROUND_RECT, 1.0f));
+    OVERRIDES.put(Role.SELECT, new Override(0.46f, 0.94f, 3f, 1.8f, RenderShape.ROUND_RECT, 1.0f));
+  }
+
+  public static Override overrideFor(Role role) {
+    return role != null ? OVERRIDES.get(role) : null;
+  }
+
+  /**
+   * Maps a {@link ControlElement} to a logical role by inspecting its primary binding and type.
+   * Returns {@code null} for elements that don't correspond to a known gamepad control (custom
+   * keyboard buttons, trackpads, range buttons, radial menus, etc.) — those keep their saved
+   * positions.
+   */
+  public static Role roleFor(ControlElement element) {
+    if (element == null) return null;
+    ControlElement.Type type = element.getType();
+
+    if (type == ControlElement.Type.STICK) {
+      for (int i = 0; i < element.getBindingCount(); i++) {
+        Binding b = element.getBindingAt(i);
+        if (b == Binding.GAMEPAD_LEFT_THUMB_UP
+            || b == Binding.GAMEPAD_LEFT_THUMB_DOWN
+            || b == Binding.GAMEPAD_LEFT_THUMB_LEFT
+            || b == Binding.GAMEPAD_LEFT_THUMB_RIGHT) return Role.LSTICK;
+        if (b == Binding.GAMEPAD_RIGHT_THUMB_UP
+            || b == Binding.GAMEPAD_RIGHT_THUMB_DOWN
+            || b == Binding.GAMEPAD_RIGHT_THUMB_LEFT
+            || b == Binding.GAMEPAD_RIGHT_THUMB_RIGHT) return Role.RSTICK;
+      }
+      return null;
+    }
+    if (type == ControlElement.Type.D_PAD) return Role.DPAD;
+    if (type != ControlElement.Type.BUTTON) return null;
+
+    Binding b0 = element.getBindingAt(0);
+    switch (b0) {
+      case GAMEPAD_BUTTON_A:
+        return Role.BTN_A;
+      case GAMEPAD_BUTTON_B:
+        return Role.BTN_B;
+      case GAMEPAD_BUTTON_X:
+        return Role.BTN_X;
+      case GAMEPAD_BUTTON_Y:
+        return Role.BTN_Y;
+      case GAMEPAD_BUTTON_L1:
+        return Role.LB;
+      case GAMEPAD_BUTTON_R1:
+        return Role.RB;
+      case GAMEPAD_BUTTON_L2:
+        return Role.LT;
+      case GAMEPAD_BUTTON_R2:
+        return Role.RT;
+      case GAMEPAD_BUTTON_L3:
+        return Role.L3;
+      case GAMEPAD_BUTTON_R3:
+        return Role.R3;
+      case GAMEPAD_BUTTON_START:
+        return Role.START;
+      case GAMEPAD_BUTTON_SELECT:
+        return Role.SELECT;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Builds the exact GameHub shoulder/trigger silhouette in {@code out}. Geometry reverse-engineered
+   * from the decompiled GameHub asset (sources/defpackage/yhm.java) — see References/GameHub.
+   *
+   * <p>For each variant the slanted corner is on the OUTER (screen-edge) side, and is formed by a
+   * straight diagonal between two quadratic-curved "elbow" points. The opposite three corners are
+   * standard 90° arcs of radius {@code r = min(w,h) * 0.1875}.
+   */
+  public static void buildTriggerPath(
+      Path out, RenderShape shape, float left, float top, float right, float bottom) {
+    out.reset();
+    float w = right - left;
+    float h = bottom - top;
+    float r = Math.min(w, h) * 0.1875f;
+    float f = 0.2f * w;
+    float diag = (float) Math.sqrt(h * h + f * f);
+    float sx = (f / diag) * r; // horizontal inset of the slant endpoint near the slanted corner
+    float sy = (h / diag) * r; // vertical inset of the slant endpoint at the elbow
+
+    RectF tmp = new RectF();
+    switch (shape) {
+      case TRIGGER_LT: {
+        // Slant on TOP-LEFT (outer corner of the top-left trigger).
+        out.moveTo(left + sx, bottom - sy);
+        out.lineTo(left + f - sx, top + sy);
+        out.quadTo(left + f, top, left + f + r, top);
+        out.lineTo(right - r, top);
+        tmp.set(right - 2 * r, top, right, top + 2 * r);
+        out.arcTo(tmp, -90, 90, false);
+        out.lineTo(right, bottom - r);
+        tmp.set(right - 2 * r, bottom - 2 * r, right, bottom);
+        out.arcTo(tmp, 0, 90, false);
+        out.lineTo(left + r, bottom);
+        out.quadTo(left, bottom, left + sx, bottom - sy);
+        out.close();
+        break;
+      }
+      case TRIGGER_LB: {
+        // Slant on BOTTOM-LEFT (outer corner of the left bumper).
+        out.moveTo(left + r, top);
+        out.lineTo(right - r, top);
+        tmp.set(right - 2 * r, top, right, top + 2 * r);
+        out.arcTo(tmp, -90, 90, false);
+        out.lineTo(right, bottom - r);
+        tmp.set(right - 2 * r, bottom - 2 * r, right, bottom);
+        out.arcTo(tmp, 0, 90, false);
+        out.lineTo(left + f + r, bottom);
+        out.quadTo(left + f, bottom, left + f - sx, bottom - sy);
+        out.lineTo(left + sx, top + sy);
+        out.quadTo(left, top, left + r, top);
+        out.close();
+        break;
+      }
+      case TRIGGER_RT: {
+        // Slant on TOP-RIGHT (mirror of TRIGGER_LT) — symmetric with the left trigger so both
+        // upper-row triggers point their slanted "tabs" toward the outer screen corners.
+        out.moveTo(right - sx, bottom - sy);
+        out.lineTo(right - f + sx, top + sy);
+        out.quadTo(right - f, top, right - f - r, top);
+        out.lineTo(left + r, top);
+        tmp.set(left, top, left + 2 * r, top + 2 * r);
+        out.arcTo(tmp, 270, -90, false);
+        out.lineTo(left, bottom - r);
+        tmp.set(left, bottom - 2 * r, left + 2 * r, bottom);
+        out.arcTo(tmp, 180, -90, false);
+        out.lineTo(right - r, bottom);
+        out.quadTo(right, bottom, right - sx, bottom - sy);
+        out.close();
+        break;
+      }
+      case TRIGGER_RB: {
+        // Slant on BOTTOM-RIGHT (mirror of TRIGGER_LB) — bumper's outer slant.
+        out.moveTo(right - r, top);
+        out.lineTo(left + r, top);
+        tmp.set(left, top, left + 2 * r, top + 2 * r);
+        out.arcTo(tmp, 270, -90, false);
+        out.lineTo(left, bottom - r);
+        tmp.set(left, bottom - 2 * r, left + 2 * r, bottom);
+        out.arcTo(tmp, 180, -90, false);
+        out.lineTo(right - f - r, bottom);
+        out.quadTo(right - f, bottom, right - f + sx, bottom - sy);
+        out.lineTo(right - sx, top + sy);
+        out.quadTo(right, top, right - r, top);
+        out.close();
+        break;
+      }
+      default:
+        out.addRoundRect(left, top, right, bottom, r, r, Path.Direction.CW);
+        break;
+    }
+  }
+
+  /**
+   * Builds the four separate GameHub d-pad arrows into {@code out} as a single path with four
+   * sub-shapes. Each arrow is a small pentagonal "wedge" with the tip on the outer edge of a
+   * circle of radius {@code radius} centered at {@code (cx, cy)} — matching the proportions in
+   * {@code features_gamepad_config_dpad_center.xml} (128x128 viewport, tip ~1 unit from the edge
+   * and base ~9 units in).
+   */
+  public static void buildDpadArrows(Path out, float cx, float cy, float radius) {
+    out.reset();
+    // GameHub d-pad: each arrow is a "house" / "square with a pointer" — a rectangle on the
+    // outer side, then two short angled walls converging to a single point that aims AT the
+    // center of the d-pad. The two outer corners get a small radius; the inner shoulder corners
+    // and the tip stay sharp so the pointer reads clearly.
+    float outer = radius * 0.95f;       // distance from center to the flat outer edge
+    float shoulder = radius * 0.45f;    // distance from center to where the rectangle ends and
+                                        // the pointer begins (length of rectangle body = 0.50r)
+    float inner = radius * 0.18f;        // distance from center to the pointer tip
+    float halfOuter = radius * 0.25f;   // half-width of the rectangular body — equal to half its
+                                        // length (0.25r * 2 = 0.50r), so the body is a square
+    float cornerR = radius * 0.05f;     // small outer-corner rounding
+
+    // UP — rectangle at the top with pointer tip aiming DOWN toward center.
+    out.moveTo(cx - halfOuter + cornerR, cy - outer);
+    out.lineTo(cx + halfOuter - cornerR, cy - outer);
+    out.quadTo(cx + halfOuter, cy - outer, cx + halfOuter, cy - outer + cornerR);
+    out.lineTo(cx + halfOuter, cy - shoulder);
+    out.lineTo(cx, cy - inner);                                 // pointer tip
+    out.lineTo(cx - halfOuter, cy - shoulder);
+    out.lineTo(cx - halfOuter, cy - outer + cornerR);
+    out.quadTo(cx - halfOuter, cy - outer, cx - halfOuter + cornerR, cy - outer);
+    out.close();
+
+    // DOWN — rectangle at the bottom, pointer aims UP.
+    out.moveTo(cx + halfOuter - cornerR, cy + outer);
+    out.lineTo(cx - halfOuter + cornerR, cy + outer);
+    out.quadTo(cx - halfOuter, cy + outer, cx - halfOuter, cy + outer - cornerR);
+    out.lineTo(cx - halfOuter, cy + shoulder);
+    out.lineTo(cx, cy + inner);
+    out.lineTo(cx + halfOuter, cy + shoulder);
+    out.lineTo(cx + halfOuter, cy + outer - cornerR);
+    out.quadTo(cx + halfOuter, cy + outer, cx + halfOuter - cornerR, cy + outer);
+    out.close();
+
+    // LEFT — rectangle on the left, pointer aims RIGHT.
+    out.moveTo(cx - outer, cy + halfOuter - cornerR);
+    out.lineTo(cx - outer, cy - halfOuter + cornerR);
+    out.quadTo(cx - outer, cy - halfOuter, cx - outer + cornerR, cy - halfOuter);
+    out.lineTo(cx - shoulder, cy - halfOuter);
+    out.lineTo(cx - inner, cy);
+    out.lineTo(cx - shoulder, cy + halfOuter);
+    out.lineTo(cx - outer + cornerR, cy + halfOuter);
+    out.quadTo(cx - outer, cy + halfOuter, cx - outer, cy + halfOuter - cornerR);
+    out.close();
+
+    // RIGHT — rectangle on the right, pointer aims LEFT.
+    out.moveTo(cx + outer, cy - halfOuter + cornerR);
+    out.lineTo(cx + outer, cy + halfOuter - cornerR);
+    out.quadTo(cx + outer, cy + halfOuter, cx + outer - cornerR, cy + halfOuter);
+    out.lineTo(cx + shoulder, cy + halfOuter);
+    out.lineTo(cx + inner, cy);
+    out.lineTo(cx + shoulder, cy - halfOuter);
+    out.lineTo(cx + outer - cornerR, cy - halfOuter);
+    out.quadTo(cx + outer, cy - halfOuter, cx + outer, cy - halfOuter + cornerR);
+    out.close();
+  }
+
+  private GameHubLayout() {}
+}

--- a/app/src/main/runtime/input/controls/InputControlsManager.java
+++ b/app/src/main/runtime/input/controls/InputControlsManager.java
@@ -26,10 +26,32 @@ import org.json.JSONObject;
 
 public class InputControlsManager {
   private static final int ASSET_PROFILE_SYNC_REVISION = 3;
+  /** Profile IDs at or below this value were shipped as read-only built-ins (assets/inputcontrols/profiles/controls-*.icp).
+   * Edits to one of these always go through a duplicate first so the original layout stays pristine. */
+  public static final int LAST_BUILTIN_PROFILE_ID = 6;
+  /** Asset profile ID that holds the canonical "Virtual Gamepad" layout (controls-3.icp).
+   * Used as the post-migration target when legacy Xbox/PS profiles are converted to label themes. */
+  public static final int VIRTUAL_GAMEPAD_BUILTIN_ID = 3;
+  /** Legacy Playstation Controller asset profile (controls-4.icp) — superseded by LabelTheme.PLAYSTATION. */
+  public static final int LEGACY_PS_PROFILE_ID = 4;
+  /** Legacy Xbox Controller asset profile (controls-5.icp) — superseded by LabelTheme.XBOX. */
+  public static final int LEGACY_XBOX_PROFILE_ID = 5;
+
   private final Context context;
   private ArrayList<ControlsProfile> profiles;
   private int maxProfileId;
   private boolean profilesLoaded = false;
+
+  public static boolean isBuiltinProfile(ControlsProfile profile) {
+    return profile != null && profile.id <= LAST_BUILTIN_PROFILE_ID;
+  }
+
+  /** Returns true for asset profiles whose role is now covered by a LabelTheme — these should be
+   * hidden from the user-facing profile picker so the new flow stays uncluttered. */
+  public static boolean isLegacyLabelOnlyProfile(ControlsProfile profile) {
+    if (profile == null) return false;
+    return profile.id == LEGACY_PS_PROFILE_ID || profile.id == LEGACY_XBOX_PROFILE_ID;
+  }
 
   public InputControlsManager(Context context) {
     this.context = context;

--- a/app/src/main/runtime/input/controls/LabelTheme.java
+++ b/app/src/main/runtime/input/controls/LabelTheme.java
@@ -1,0 +1,146 @@
+package com.winlator.cmod.runtime.input.controls;
+
+import android.graphics.Color;
+
+/**
+ * Label/color overlay applied at draw time for gamepad bindings.
+ *
+ * <p>DEFAULT — no overlay; element keeps its own text and {@code customColor}.
+ *
+ * <p>XBOX — A=green, B=red, X=blue, Y=yellow plus LT/LB/RT/RB/L3/R3 labels.
+ *
+ * <p>PLAYSTATION — Cross/Circle/Square/Triangle glyphs with PlayStation accent colors plus
+ * L1/L2/R1/R2/L3/R3 labels.
+ *
+ * <p>Per-element {@code customColor} always wins over the theme so user edits aren't clobbered.
+ */
+public enum LabelTheme {
+  DEFAULT,
+  XBOX,
+  PLAYSTATION;
+
+  public static LabelTheme fromPreference(String name) {
+    if (name == null) return DEFAULT;
+    try {
+      return LabelTheme.valueOf(name);
+    } catch (IllegalArgumentException e) {
+      return DEFAULT;
+    }
+  }
+
+  public static String[] displayNames() {
+    return new String[] {"Default", "Xbox", "PlayStation"};
+  }
+
+  /** Returns the override color for a binding, or {@code 0} if this theme doesn't override it. */
+  public int colorFor(Binding binding) {
+    if (this == DEFAULT || binding == null) return 0;
+    switch (this) {
+      case XBOX:
+        switch (binding) {
+          case GAMEPAD_BUTTON_A:
+            return 0xFF22A348; // Xbox green
+          case GAMEPAD_BUTTON_B:
+            return 0xFFE13C3C; // Xbox red
+          case GAMEPAD_BUTTON_X:
+            return 0xFF1976D2; // Xbox blue
+          case GAMEPAD_BUTTON_Y:
+            return 0xFFE9B007; // Xbox yellow
+          default:
+            return 0;
+        }
+      case PLAYSTATION:
+        switch (binding) {
+          case GAMEPAD_BUTTON_A:
+            return 0xFF5C8DEC; // Cross — blue
+          case GAMEPAD_BUTTON_B:
+            return 0xFFE34A4A; // Circle — red
+          case GAMEPAD_BUTTON_X:
+            return 0xFFD66ED1; // Square — pink/magenta
+          case GAMEPAD_BUTTON_Y:
+            return 0xFF34BFA0; // Triangle — teal
+          default:
+            return 0;
+        }
+      default:
+        return 0;
+    }
+  }
+
+  /** Returns the override label for a binding, or {@code null} if no override. */
+  public String labelFor(Binding binding) {
+    if (this == DEFAULT || binding == null) return null;
+    switch (this) {
+      case XBOX:
+        switch (binding) {
+          case GAMEPAD_BUTTON_A:
+            return "A";
+          case GAMEPAD_BUTTON_B:
+            return "B";
+          case GAMEPAD_BUTTON_X:
+            return "X";
+          case GAMEPAD_BUTTON_Y:
+            return "Y";
+          case GAMEPAD_BUTTON_L1:
+            return "LB";
+          case GAMEPAD_BUTTON_R1:
+            return "RB";
+          case GAMEPAD_BUTTON_L2:
+            return "LT";
+          case GAMEPAD_BUTTON_R2:
+            return "RT";
+          case GAMEPAD_BUTTON_L3:
+            return "L3";
+          case GAMEPAD_BUTTON_R3:
+            return "R3";
+          case GAMEPAD_BUTTON_START:
+            return "≡";
+          case GAMEPAD_BUTTON_SELECT:
+            return "❐";
+          default:
+            return null;
+        }
+      case PLAYSTATION:
+        switch (binding) {
+          case GAMEPAD_BUTTON_A:
+            return "✕";
+          case GAMEPAD_BUTTON_B:
+            return "○";
+          case GAMEPAD_BUTTON_X:
+            return "▢";
+          case GAMEPAD_BUTTON_Y:
+            return "△";
+          case GAMEPAD_BUTTON_L1:
+            return "L1";
+          case GAMEPAD_BUTTON_R1:
+            return "R1";
+          case GAMEPAD_BUTTON_L2:
+            return "L2";
+          case GAMEPAD_BUTTON_R2:
+            return "R2";
+          case GAMEPAD_BUTTON_L3:
+            return "L3";
+          case GAMEPAD_BUTTON_R3:
+            return "R3";
+          case GAMEPAD_BUTTON_START:
+            return "≡";
+          case GAMEPAD_BUTTON_SELECT:
+            return "❐";
+          default:
+            return null;
+        }
+      default:
+        return null;
+    }
+  }
+
+  /** Convenience for callers that don't want to deal with the 0 sentinel. */
+  public boolean overridesColor(Binding binding) {
+    return colorFor(binding) != 0;
+  }
+
+  /** Returns {@link Color#WHITE} as a neutral fallback when {@link #colorFor} returns 0. */
+  public static int safeColor(int themedColor, int fallback) {
+    return themedColor != 0 ? themedColor : fallback;
+  }
+}

--- a/app/src/main/runtime/input/controls/VisualStyle.java
+++ b/app/src/main/runtime/input/controls/VisualStyle.java
@@ -1,0 +1,28 @@
+package com.winlator.cmod.runtime.input.controls;
+
+/**
+ * Visual rendering style for on-screen virtual gamepad elements.
+ *
+ * <p>ORIGINAL preserves the historic Winlator look (translucent white strokes, lightly filled when
+ * engaged). GAMEHUB mimics the dark glass aesthetic used by the GameHub launcher: dark translucent
+ * fill, light white rim, brighter rim and inner fill when pressed, with a soft drop shadow.
+ *
+ * <p>The actual drawing branches on this enum inside {@link ControlElement#draw}.
+ */
+public enum VisualStyle {
+  ORIGINAL,
+  GAMEHUB;
+
+  public static VisualStyle fromPreference(String name) {
+    if (name == null) return ORIGINAL;
+    try {
+      return VisualStyle.valueOf(name);
+    } catch (IllegalArgumentException e) {
+      return ORIGINAL;
+    }
+  }
+
+  public static String[] displayNames() {
+    return new String[] {"Original", "GameHub"};
+  }
+}

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -41,6 +41,8 @@ import com.winlator.cmod.runtime.input.controls.ControlsProfile;
 import com.winlator.cmod.runtime.input.controls.ExternalController;
 import com.winlator.cmod.runtime.input.controls.ExternalControllerBinding;
 import com.winlator.cmod.runtime.input.controls.GamepadState;
+import com.winlator.cmod.runtime.input.controls.LabelTheme;
+import com.winlator.cmod.runtime.input.controls.VisualStyle;
 import com.winlator.cmod.shared.math.Mathf;
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,6 +73,8 @@ public class InputControlsView extends View {
   private volatile float mouseMoveOffsetX = 0f;
   private volatile float mouseMoveOffsetY = 0f;
   private boolean showTouchscreenControls = false;
+  private VisualStyle visualStyle = VisualStyle.ORIGINAL;
+  private LabelTheme labelTheme = LabelTheme.DEFAULT;
 
   private Handler timeoutHandler; // Reference to the activity's timeout handler
   private Runnable hideControlsRunnable; // Runnable to hide the controls
@@ -169,6 +173,30 @@ public class InputControlsView extends View {
 
   public float getOverlayOpacity() {
     return overlayOpacity;
+  }
+
+  public VisualStyle getVisualStyle() {
+    return visualStyle;
+  }
+
+  public void setVisualStyle(VisualStyle style) {
+    this.visualStyle = style != null ? style : VisualStyle.ORIGINAL;
+    invalidate();
+  }
+
+  /** Same as {@link #setVisualStyle} but without {@link #invalidate()}, for internal draw-time
+   * fallbacks where requesting another redraw would loop. */
+  public void setVisualStyleSilent(VisualStyle style) {
+    this.visualStyle = style != null ? style : VisualStyle.ORIGINAL;
+  }
+
+  public LabelTheme getLabelTheme() {
+    return labelTheme;
+  }
+
+  public void setLabelTheme(LabelTheme theme) {
+    this.labelTheme = theme != null ? theme : LabelTheme.DEFAULT;
+    invalidate();
   }
 
   public int getSnappingSize() {


### PR DESCRIPTION
Adds two new dropdowns in the in-game Controls pane:

- "Select Style" (Original, GameHub): swaps the visual rendering of buttons, joysticks, triggers and d-pad. GameHub mirrors the decompiled GameHub launcher: dark-glass fills, light rims, custom slanted trigger silhouettes, detached d-pad arrows (square body + pointer toward center), and a layout override that relocates known gamepad bindings to the GameHub reference positions while leaving the user's saved profile data alone.
- "Button Labels" (Default, Xbox, PlayStation): overlays glyphs + accent colors on gamepad bindings at draw time; per-element customColor still wins.

Edit pencil on a built-in profile (id <= 6) now silently duplicates it before launching the editor so the read-only asset stays pristine.

The legacy "Xbox Controller" / "Playstation Controller" asset profiles are hidden from the picker (their identity is covered by the label theme); a one-time migration converts existing selections to Virtual Gamepad + matching LabelTheme.

Persisted via SharedPreferences keys
input_visual_style, input_label_theme,
input_controls_label_theme_migrated.