### PR TITLE
feat(downloads): confirm Cancel/Cancel All with singular vs plural pr…

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -6921,6 +6921,7 @@ class UnifiedActivity :
                                 }
                                 onSelectDownload(null)
                             },
+                            isCancelAll = request.isCancelAll,
                         )
                     }
                 }
@@ -7164,12 +7165,16 @@ class UnifiedActivity :
         expanded: Boolean,
         onDismissRequest: () -> Unit,
         onConfirm: () -> Unit,
+        isCancelAll: Boolean = false,
     ) {
+        val titleRes = if (isCancelAll) R.string.downloads_queue_cancel_all_title else R.string.downloads_queue_cancel_download_title
+        val messageRes = if (isCancelAll) R.string.downloads_queue_cancel_all_warning else R.string.downloads_queue_cancel_download_warning
+        val confirmRes = if (isCancelAll) R.string.downloads_queue_cancel_all else R.string.downloads_queue_cancel_download
         LaunchDangerConfirmDialog(
             visible = expanded,
-            title = stringResource(R.string.downloads_queue_cancel_download_title),
-            message = stringResource(R.string.downloads_queue_cancel_download_warning),
-            confirmLabel = stringResource(R.string.downloads_queue_cancel_download),
+            title = stringResource(titleRes),
+            message = stringResource(messageRes),
+            confirmLabel = stringResource(confirmRes),
             onDismissRequest = onDismissRequest,
             onConfirm = onConfirm,
             icon = Icons.Outlined.Warning,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,7 +248,9 @@
     <string name="downloads_queue_paused_resume_hint">Paused - tap Resume to continue</string>
     <string name="downloads_queue_cancel_download">Cancel Download</string>
     <string name="downloads_queue_cancel_download_title">Cancel Download?</string>
-    <string name="downloads_queue_cancel_download_warning">Cancelling a DLC, Game, or Update download can potentially corrupt your game install.\n\nAre you sure you want to cancel?</string>
+    <string name="downloads_queue_cancel_download_warning">Cancelling a DLC, Game, or Update download can potentially corrupt your game install.\n\nAre you sure you want to cancel this Download and delete the files downloaded so far?</string>
+    <string name="downloads_queue_cancel_all_title">Cancel All Downloads?</string>
+    <string name="downloads_queue_cancel_all_warning">Cancelling DLC, Game, or Update downloads can potentially corrupt your game installs.\n\nAre you sure you want to cancel all Downloads and delete the files downloaded so far?</string>
     <string name="downloads_queue_empty">No active downloads.</string>
 
     <!-- Containers > List -->


### PR DESCRIPTION
Added Feature:
Added Confirmation Window when Cancelling Downloads.

Differentiates the existing cancel-confirmation dialog by adding an isCancelAll flag to DownloadCancelWarningMenu and two new strings, so "Cancel" asks about the single Download and "Cancel All" asks about all Downloads. Both paths still confirm before invoking the cancel/delete.