### PR TITLE
fix(io): keep new OnExtractFileListener methods from R8 stripping

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,6 +4,10 @@
 
 -keep class com.winlator.cmod.shared.util.OnExtractFileListener {
     public java.io.File onExtractFile(java.io.File, long);
+    public void onExtractFileProgress(java.io.File, long);
+    public boolean mapsExtractedFiles();
+    public boolean reportsExtractedBytesOnly();
+    public void onExtractedBytes(long);
 }
 
 -keep class com.winlator.cmod.runtime.content.Downloader$DownloadListener {


### PR DESCRIPTION
native_content_io.cpp's JavaExtractListener resolves five methods on OnExtractFileListener via JNI (onExtractFile, onExtractFileProgress, mapsExtractedFiles, reportsExtractedBytesOnly, onExtractedBytes), but proguard-rules.pro only kept onExtractFile. In release builds the four default methods added in #435 were stripped/renamed, so GetMethodID returned null, enabled_ evaluated to false, and map() returned nullopt for every entry — every Wine/Proton/ImageFS file got silently skipped while the tar stream was still drained, so extraction "succeeded" with zero bytes written. Layers never initialized and Wine/Proton .wcp installs failed with ERROR_NOPROFILE, looping until the user gave up.