### PR TITLE
fix: Wine CFG reset and force native dinput8/xinput overrides

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4435,7 +4435,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
         // Proton-version flips repair controller detection because they rebuild the prefix and
         // restore controller DllOverrides. Keep that correction narrow and explicit here.
-        WineUtils.ensureControllerDllOverrides(container);
         WineUtils.setJoystickRegistryKeys(container, dinputEnabled, exclusiveXInput);
         WineUtils.ensureWinebusConfig(container);
 

--- a/app/src/main/runtime/wine/WineRegistryEditor.java
+++ b/app/src/main/runtime/wine/WineRegistryEditor.java
@@ -2,172 +2,90 @@ package com.winlator.cmod.runtime.wine;
 
 import android.util.Log;
 import com.winlator.cmod.shared.io.FileUtils;
-import com.winlator.cmod.shared.io.StreamUtils;
 import com.winlator.cmod.shared.math.Mathf;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.Closeable;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class WineRegistryEditor implements Closeable {
+public class WineRegistryEditor implements java.io.Closeable {
   private static final String TAG = "WineRegistryEditor";
   private final File file;
-  private final File cloneFile;
+  private final ArrayList<String> lines = new ArrayList<>();
   private boolean modified = false;
   private boolean createKeyIfNotExist = true;
-  private int lastParentKeyPosition = 0;
-  private String lastParentKey = "";
-
-  public static class Location {
-    public final int offset;
-    public final int start;
-    public final int end;
-
-    public Location(int offset, int start, int end) {
-      this.offset = offset;
-      this.start = start;
-      this.end = end;
-    }
-
-    public int length() {
-      return end - start;
-    }
-  }
 
   public WineRegistryEditor(File file) {
     this.file = file;
-    cloneFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-    if (!file.isFile()) {
-      try {
-        cloneFile.createNewFile();
-      } catch (IOException e) {
+    if (file.isFile()) {
+      String content = FileUtils.readString(file);
+      if (content != null) {
+        // Handle both CRLF and LF, but preserve the lines
+        String[] split = content.split("\\r?\\n", -1);
+        for (String line : split) lines.add(line);
       }
-    } else FileUtils.copy(file, cloneFile);
+    }
   }
 
   private static String escape(String str) {
     return str.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
-  private static String unescape(String str) {
-    return str.replace("\\\"", "\"").replace("\\\\", "\\");
-  }
-
-  private static boolean lineHasName(String line) {
-    int index;
-    return (index = line.indexOf('"')) != -1
-        && (index = line.indexOf('"', index)) != -1
-        && (index = line.indexOf('=', index)) != -1;
-  }
-
   @Override
   public void close() {
-    if (modified && cloneFile.exists()) {
-      cloneFile.renameTo(file);
-    } else cloneFile.delete();
-  }
-
-  private void resetLastParentKeyPositionIfNeed(String newKey) {
-    int lastIndex = newKey.lastIndexOf("\\");
-    if (lastIndex == -1) {
-      lastParentKeyPosition = 0;
-      lastParentKey = "";
-      return;
+    if (modified) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < lines.size(); i++) {
+        sb.append(lines.get(i));
+        if (i < lines.size() - 1) sb.append("\n");
+      }
+      File tempFile = FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
+      if (FileUtils.writeString(tempFile, sb.toString())) {
+        tempFile.renameTo(file);
+      } else {
+        tempFile.delete();
+        Log.e(TAG, "Failed to write modified registry to " + file.getPath());
+      }
     }
-
-    String parentKey = newKey.substring(0, lastIndex);
-    if (!parentKey.equals(lastParentKey)) lastParentKeyPosition = 0;
-    lastParentKey = parentKey;
   }
 
   public void setCreateKeyIfNotExist(boolean createKeyIfNotExist) {
     this.createKeyIfNotExist = createKeyIfNotExist;
   }
 
-  private Location createKey(String key) {
-    return createKey(key, null);
+  private int findKeyLine(String key) {
+    String escapedKey = "[" + escape(key) + "]";
+    for (int i = 0; i < lines.size(); i++) {
+      if (lines.get(i).trim().equals(escapedKey)) return i;
+    }
+    return -1;
   }
 
-  private Location createKey(String key, Location insertionPoint) {
-    lastParentKeyPosition = 0;
-    Location location = insertionPoint != null ? insertionPoint : getParentKeyLocation(key);
-    boolean success = false;
-    int offset = 0;
-    int totalLength = 0;
+  private int ensureKey(String key) {
+    int index = findKeyLine(key);
+    if (index != -1) return index;
 
-    char[] buffer = new char[StreamUtils.BUFFER_SIZE];
-    File tempFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-
-    try (BufferedReader reader =
-            new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE);
-        BufferedWriter writer =
-            new BufferedWriter(new FileWriter(tempFile), StreamUtils.BUFFER_SIZE)) {
-
-      int length;
-      for (int i = 0, end = location != null ? location.end + 1 : (int) cloneFile.length();
-          i < end;
-          i += length) {
-        length = Math.min(buffer.length, end - i);
-        reader.read(buffer, 0, length);
-        writer.write(buffer, 0, length);
-        totalLength += length;
+    if (createKeyIfNotExist) {
+      if (lines.isEmpty() || !lines.get(0).startsWith("WINE REGISTRY Version")) {
+        if (lines.isEmpty()) lines.add("WINE REGISTRY Version 2");
+      }
+      
+      // Ensure parent keys exist (recursive-ish)
+      int lastSlash = key.lastIndexOf("\\");
+      if (lastSlash != -1) {
+        ensureKey(key.substring(0, lastSlash));
       }
 
-      offset = totalLength;
-      long ticks1601To1970 = 86400L * (369 * 365 + 89) * 10000000;
-      long currentTime = System.currentTimeMillis() + ticks1601To1970;
-      String content =
-          "\n["
-              + escape(key)
-              + "] "
-              + ((currentTime - ticks1601To1970) / 1000)
-              + String.format(
-                  Locale.ENGLISH, "\n#time=%x%08x", currentTime >> 32, (int) currentTime)
-              + "\n";
-      writer.write(content);
-      totalLength += content.length() - 1;
-
-      while ((length = reader.read(buffer)) != -1) writer.write(buffer, 0, length);
-      success = true;
-    } catch (IOException e) {
-      Log.e(TAG, "Failed to create registry key: " + key, e);
-    }
-
-    if (success) {
+      lines.add("");
+      lines.add("[" + escape(key) + "]");
       modified = true;
-      tempFile.renameTo(cloneFile);
-      return new Location(offset, totalLength, totalLength);
-    } else {
-      tempFile.delete();
-      return null;
+      return lines.size() - 1;
     }
-  }
-
-  private Location ensureKey(String key) {
-    Location existingLocation = getKeyLocation(key);
-    if (existingLocation != null) return existingLocation;
-
-    int lastIndex = key.lastIndexOf("\\");
-    if (lastIndex != -1) {
-      String parentKey = key.substring(0, lastIndex);
-      Location parentLocation = ensureKey(parentKey);
-      if (parentLocation == null) return null;
-      return createKey(key, parentLocation);
-    }
-
-    return createKey(key, null);
+    return -1;
   }
 
   public String getStringValue(String key, String name) {
@@ -176,7 +94,10 @@ public class WineRegistryEditor implements Closeable {
 
   public String getStringValue(String key, String name, String fallback) {
     String value = getRawValue(key, name);
-    return value != null ? value.substring(1, value.length() - 1) : fallback;
+    if (value != null && value.startsWith("\"") && value.endsWith("\"")) {
+      return value.substring(1, value.length() - 1).replace("\\\"", "\"").replace("\\\\", "\\");
+    }
+    return fallback;
   }
 
   public void setStringValue(String key, String name, String value) {
@@ -189,7 +110,14 @@ public class WineRegistryEditor implements Closeable {
 
   public Integer getDwordValue(String key, String name, Integer fallback) {
     String value = getRawValue(key, name);
-    return value != null ? Integer.decode("0x" + value.substring(6)) : fallback;
+    if (value != null && value.startsWith("dword:")) {
+      try {
+        return Integer.decode("0x" + value.substring(6));
+      } catch (NumberFormatException e) {
+        return fallback;
+      }
+    }
+    return fallback;
   }
 
   public void setDwordValue(String key, String name, int value) {
@@ -197,105 +125,126 @@ public class WineRegistryEditor implements Closeable {
   }
 
   public void setHexValue(String key, String name, String value) {
-    int start = (int) Mathf.roundTo(name.length(), 2) + 7;
-    StringBuilder lines = new StringBuilder();
-    for (int i = 0, j = start; i < value.length(); i++) {
-      if (i > 0 && (i % 2) == 0) lines.append(",");
-      if (j++ > 56) {
-        lines.append("\\\n  ");
-        j = 8;
+    int startLength = (name != null ? escape(name).length() + 2 : 1) + 5; // "name"=hex:
+    StringBuilder formatted = new StringBuilder();
+    int currentLineLength = startLength;
+    
+    for (int i = 0; i < value.length(); i += 2) {
+      if (i > 0) formatted.append(",");
+      formatted.append(value.substring(i, i + 2));
+      currentLineLength += 3;
+      
+      if (currentLineLength > 75 && i + 2 < value.length()) {
+        formatted.append("\\\n  ");
+        currentLineLength = 2;
       }
-      lines.append(value.charAt(i));
     }
-    setRawValue(key, name, "hex:" + lines);
+    setRawValue(key, name, "hex:" + formatted.toString());
   }
 
   public void setHexValue(String key, String name, byte[] bytes) {
     StringBuilder data = new StringBuilder();
-    for (byte b : bytes) data.append(String.format(Locale.ENGLISH, "%02x", Byte.toUnsignedInt(b)));
+    for (byte b : bytes) data.append(String.format(Locale.ENGLISH, "%02x", b & 0xff));
     setHexValue(key, name, data.toString());
   }
 
   private String getRawValue(String key, String name) {
-    lastParentKeyPosition = 0;
-    Location keyLocation = getKeyLocation(key);
-    if (keyLocation == null) return null;
+    int keyLine = findKeyLine(key);
+    if (keyLine == -1) return null;
 
-    Location valueLocation = getValueLocation(keyLocation, name);
-    if (valueLocation == null) return null;
-    boolean success = false;
-    char[] buffer = new char[valueLocation.length()];
+    String prefix = (name != null ? "\"" + escape(name) + "\"" : "@") + "=";
+    StringBuilder fullValue = new StringBuilder();
+    boolean found = false;
 
-    try (BufferedReader reader =
-        new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE)) {
-      reader.skip(valueLocation.start);
-      success = reader.read(buffer) == buffer.length;
-    } catch (IOException e) {
+    for (int i = keyLine + 1; i < lines.size(); i++) {
+      String line = lines.get(i).trim();
+      if (line.startsWith("[")) break;
+      
+      if (!found) {
+        if (line.startsWith(prefix)) {
+          found = true;
+          fullValue.append(line.substring(prefix.length()));
+        }
+      } else {
+        if (line.isEmpty() || (line.contains("=") && !line.startsWith(" "))) break;
+        fullValue.append(line);
+      }
     }
-    return success ? unescape(new String(buffer)) : null;
+    
+    if (found) {
+        String result = fullValue.toString().replace("\\\n", "").trim();
+        return result;
+    }
+    return null;
   }
 
   private void setRawValue(String key, String name, String value) {
-    resetLastParentKeyPositionIfNeed(key);
+    int keyLine = ensureKey(key);
+    if (keyLine == -1) return;
 
-    Location keyLocation = getKeyLocation(key);
-    if (keyLocation == null) {
-      if (createKeyIfNotExist) {
-        keyLocation = ensureKey(key);
-      } else return;
-    }
-    if (keyLocation == null) {
-      Log.e(TAG, "Unable to resolve registry key for write: " + key);
-      return;
-    }
+    String prefix = (name != null ? "\"" + escape(name) + "\"" : "@") + "=";
+    String newLine = prefix + value;
+    String[] newValueLines = newLine.split("\\n");
 
-    Location valueLocation = getValueLocation(keyLocation, name);
-    char[] buffer = new char[StreamUtils.BUFFER_SIZE];
-    boolean success = false;
+    int valueStartLine = -1;
+    int valueEndLine = -1;
 
-    File tempFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-
-    try (BufferedReader reader =
-            new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE);
-        BufferedWriter writer =
-            new BufferedWriter(new FileWriter(tempFile), StreamUtils.BUFFER_SIZE)) {
-
-      int length;
-      for (int i = 0, end = valueLocation != null ? valueLocation.start : keyLocation.end;
-          i < end;
-          i += length) {
-        length = Math.min(buffer.length, end - i);
-        reader.read(buffer, 0, length);
-        writer.write(buffer, 0, length);
+    for (int i = keyLine + 1; i < lines.size(); i++) {
+      String line = lines.get(i).trim();
+      if (line.startsWith("[")) break;
+      if (line.startsWith(prefix)) {
+        valueStartLine = i;
+        // Find where this multi-line value ends
+        int j = i + 1;
+        while (j < lines.size()) {
+            String nextLine = lines.get(j);
+            if (nextLine.trim().startsWith("[") || (nextLine.contains("=") && !nextLine.startsWith(" "))) break;
+            j++;
+        }
+        valueEndLine = j - 1;
+        break;
       }
-
-      if (valueLocation == null) {
-        writer.write("\n" + (name != null ? "\"" + escape(name) + "\"" : "@") + "=" + value);
-      } else {
-        writer.write(value);
-        reader.skip(valueLocation.length());
-      }
-
-      while ((length = reader.read(buffer)) != -1) writer.write(buffer, 0, length);
-      success = true;
-    } catch (IOException e) {
     }
 
-    if (success) {
-      modified = true;
-      tempFile.renameTo(cloneFile);
-    } else tempFile.delete();
+    if (valueStartLine != -1) {
+      // Replace existing lines
+      for (int i = valueEndLine; i >= valueStartLine; i--) lines.remove(i);
+      for (int i = 0; i < newValueLines.length; i++) {
+        lines.add(valueStartLine + i, newValueLines[i]);
+      }
+    } else {
+      // Append new value under key
+      int insertPos = keyLine + 1;
+      while (insertPos < lines.size() && !lines.get(insertPos).trim().startsWith("[")) {
+          insertPos++;
+      }
+      for (int i = 0; i < newValueLines.length; i++) {
+        lines.add(insertPos + i, newValueLines[i]);
+      }
+    }
+    modified = true;
   }
 
   public void removeValue(String key, String name) {
-    lastParentKeyPosition = 0;
-    Location keyLocation = getKeyLocation(key);
-    if (keyLocation == null) return;
+    int keyLine = findKeyLine(key);
+    if (keyLine == -1) return;
 
-    Location valueLocation = getValueLocation(keyLocation, name);
-    if (valueLocation == null) return;
-    removeRegion(valueLocation);
+    String prefix = (name != null ? "\"" + escape(name) + "\"" : "@") + "=";
+    for (int i = keyLine + 1; i < lines.size(); i++) {
+      String line = lines.get(i).trim();
+      if (line.startsWith("[")) break;
+      if (line.startsWith(prefix)) {
+        // Remove this line and any continuation lines
+        lines.remove(i);
+        while (i < lines.size()) {
+            String nextLine = lines.get(i);
+            if (nextLine.trim().startsWith("[") || (nextLine.contains("=") && !nextLine.startsWith(" "))) break;
+            lines.remove(i);
+        }
+        modified = true;
+        break;
+      }
+    }
   }
 
   public boolean removeKey(String key) {
@@ -303,260 +252,46 @@ public class WineRegistryEditor implements Closeable {
   }
 
   public boolean removeKey(String key, boolean removeTree) {
-    lastParentKeyPosition = 0;
-    boolean removed = false;
     if (removeTree) {
-      Location location;
-      while ((location = getKeyLocation(key, true)) != null) {
-        if (removeRegion(location)) removed = true;
-      }
+        String prefix = "[" + escape(key);
+        boolean anyRemoved = false;
+        for (int i = lines.size() - 1; i >= 0; i--) {
+            if (lines.get(i).trim().startsWith(prefix)) {
+                removeKeyAt(i);
+                anyRemoved = true;
+            }
+        }
+        return anyRemoved;
     } else {
-      Location location = getKeyLocation(key, false);
-      if (location != null && removeRegion(location)) removed = true;
+        int line = findKeyLine(key);
+        if (line != -1) {
+            removeKeyAt(line);
+            return true;
+        }
     }
-    return removed;
+    return false;
+  }
+  
+  private void removeKeyAt(int lineIndex) {
+      lines.remove(lineIndex);
+      while (lineIndex < lines.size()) {
+          if (lines.get(lineIndex).trim().startsWith("[")) break;
+          lines.remove(lineIndex);
+      }
+      modified = true;
   }
 
   public boolean hasKey(String key) {
-    lastParentKeyPosition = 0;
-    return getKeyLocation(key) != null;
-  }
-
-  public String exportKeyTree(String key) {
-    lastParentKeyPosition = 0;
-    StringBuilder content = new StringBuilder();
-    Location location;
-    while ((location = getKeyLocation(key, true)) != null) {
-      String block = readRegion(location);
-      if (block == null || block.isEmpty()) break;
-      if (content.length() > 0 && content.charAt(content.length() - 1) != '\n') {
-        content.append('\n');
-      }
-      content.append(block);
-      removeRegion(location);
-    }
-    return content.toString();
+    return findKeyLine(key) != -1;
   }
 
   public boolean appendRawContent(String rawContent) {
     if (rawContent == null || rawContent.trim().isEmpty()) return true;
-
-    char[] buffer = new char[StreamUtils.BUFFER_SIZE];
-    boolean success = false;
-    File tempFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-
-    try (BufferedReader reader =
-            new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE);
-        BufferedWriter writer =
-            new BufferedWriter(new FileWriter(tempFile), StreamUtils.BUFFER_SIZE)) {
-      int length;
-      while ((length = reader.read(buffer)) != -1) writer.write(buffer, 0, length);
-
-      if (cloneFile.length() > 0) {
-        writer.write("\n");
-      }
-      writer.write(rawContent.trim());
-      writer.write("\n");
-      success = true;
-    } catch (IOException e) {
-      Log.e(TAG, "Failed to append raw registry content", e);
-    }
-
-    if (success) {
-      modified = true;
-      tempFile.renameTo(cloneFile);
-    } else tempFile.delete();
-    return success;
-  }
-
-  public boolean removeKeyTreeByPrefix(String key) {
-    if (key == null || key.isEmpty()) return false;
-
-    String rawContent = FileUtils.readString(cloneFile);
-    if (rawContent == null || rawContent.isEmpty()) return false;
-
-    String escapedKey = key.replace("\\", "\\\\");
-    String prefix = "[" + escapedKey;
-    StringBuilder rebuilt = new StringBuilder();
-    boolean capturing = false;
-    boolean removed = false;
-
-    String[] lines = rawContent.split("\n", -1);
-    for (String line : lines) {
-      if (line.startsWith("[")) {
-        if (capturing && !line.startsWith(prefix)) {
-          capturing = false;
-        }
-        if (!capturing && line.startsWith(prefix)) {
-          capturing = true;
-          removed = true;
-        }
-      }
-      if (!capturing) {
-        rebuilt.append(line).append('\n');
-      }
-    }
-
-    if (!removed) return false;
-
-    File tempFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-    if (!FileUtils.writeString(tempFile, rebuilt.toString())) {
-      tempFile.delete();
-      return false;
-    }
-
+    lines.add("");
+    String[] newLines = rawContent.trim().split("\\r?\\n");
+    for (String line : newLines) lines.add(line);
     modified = true;
-    tempFile.renameTo(cloneFile);
     return true;
-  }
-
-  private boolean removeRegion(Location location) {
-    char[] buffer = new char[StreamUtils.BUFFER_SIZE];
-    boolean success = false;
-
-    File tempFile =
-        FileUtils.createTempFile(file.getParentFile(), FileUtils.getBasename(file.getPath()));
-
-    try (BufferedReader reader =
-            new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE);
-        BufferedWriter writer =
-            new BufferedWriter(new FileWriter(tempFile), StreamUtils.BUFFER_SIZE)) {
-
-      int length = 0;
-      for (int i = 0; i < location.offset; i += length) {
-        length = Math.min(buffer.length, location.offset - i);
-        reader.read(buffer, 0, length);
-        writer.write(buffer, 0, length);
-      }
-
-      boolean skipLine = length > 1 && buffer[length - 1] == '\n';
-      reader.skip(location.end - location.offset + (skipLine ? 1 : 0));
-      while ((length = reader.read(buffer)) != -1) writer.write(buffer, 0, length);
-      success = true;
-    } catch (IOException e) {
-    }
-
-    if (success) {
-      modified = true;
-      tempFile.renameTo(cloneFile);
-    } else tempFile.delete();
-    return success;
-  }
-
-  private String readRegion(Location location) {
-    char[] buffer = new char[location.end - location.offset];
-    try (BufferedReader reader =
-        new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE)) {
-      reader.skip(location.offset);
-      int read = reader.read(buffer);
-      return read > 0 ? new String(buffer, 0, read) : "";
-    } catch (IOException e) {
-      Log.e(TAG, "Failed to read registry region", e);
-      return null;
-    }
-  }
-
-  private Location getKeyLocation(String key) {
-    return getKeyLocation(key, false);
-  }
-
-  private Location getKeyLocation(String key, boolean keyAsPrefix) {
-    try (BufferedReader reader =
-        new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE)) {
-      int lastIndex = key.lastIndexOf("\\");
-      String parentKey =
-          lastParentKeyPosition == 0 && lastIndex != -1
-              ? "[" + escape(key.substring(0, lastIndex))
-              : null;
-
-      if (lastParentKeyPosition > 0) reader.skip(lastParentKeyPosition);
-      key = "[" + escape(key) + (!keyAsPrefix ? "]" : "");
-      int totalLength = lastParentKeyPosition;
-      int start = -1;
-      int end = -1;
-      int emptyLines = 0;
-      int offset = 0;
-
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if (start == -1) {
-          if (parentKey != null && line.startsWith(parentKey)) {
-            lastParentKeyPosition = totalLength;
-            parentKey = null;
-          }
-
-          if (parentKey == null && line.startsWith(key)) {
-            offset = totalLength - 1;
-            start = totalLength + line.length() + 1;
-          }
-        } else {
-          if (line.startsWith("[")) {
-            end = Math.max(-1, totalLength - emptyLines - 1);
-            break;
-          } else emptyLines = line.isEmpty() ? emptyLines + 1 : 0;
-        }
-        totalLength += line.length() + 1;
-      }
-
-      if (end == -1) end = totalLength - 1;
-      return start != -1 ? new Location(offset, start, end) : null;
-    } catch (IOException e) {
-      return null;
-    }
-  }
-
-  private Location getParentKeyLocation(String key) {
-    String[] parts = key.split("\\\\");
-    ArrayList<String> stack = new ArrayList<>(Arrays.asList(parts).subList(0, parts.length - 1));
-
-    while (!stack.isEmpty()) {
-      String currentKey = String.join("\\", stack);
-      Location location = getKeyLocation(currentKey, true);
-      if (location != null) return location;
-      stack.remove(stack.size() - 1);
-    }
-
-    return null;
-  }
-
-  private Location getValueLocation(Location keyLocation, String name) {
-    if (keyLocation == null) return null;
-    if (keyLocation.start == keyLocation.end) return null;
-    try (BufferedReader reader =
-        new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE)) {
-      reader.skip(keyLocation.start);
-      name = name != null ? "\"" + escape(name) + "\"=" : "@=";
-      int totalLength = 0;
-      int start = -1;
-      int end = -1;
-      int offset = 0;
-
-      String line;
-      while ((line = reader.readLine()) != null && totalLength < keyLocation.length()) {
-        if (start == -1) {
-          if (line.startsWith(name)) {
-            offset = totalLength - 1;
-            start = totalLength + name.length();
-          }
-        } else {
-          if (line.isEmpty() || lineHasName(line)) {
-            end = totalLength - 1;
-            break;
-          }
-        }
-        totalLength += line.length() + 1;
-      }
-
-      if (end == -1) end = totalLength - 1;
-      return start != -1
-          ? new Location(
-              keyLocation.start + offset, keyLocation.start + start, keyLocation.start + end)
-          : null;
-    } catch (IOException e) {
-      return null;
-    }
   }
 
   public void importReg(String regFile) {

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -622,12 +622,26 @@ public abstract class WineUtils {
   }
 
   public static boolean isRegistryFileValid(File regFile) {
-    if (regFile == null || !regFile.isFile() || regFile.length() < 24) return false;
+    if (regFile == null || !regFile.isFile()) {
+        Log.w("WineUtils", "isRegistryFileValid: " + (regFile == null ? "null" : regFile.getPath()) + " is not a file");
+        return false;
+    }
+    if (regFile.length() < 24) {
+        Log.w("WineUtils", "isRegistryFileValid: " + regFile.getPath() + " is too short (" + regFile.length() + " bytes)");
+        return false;
+    }
     String contents = FileUtils.readString(regFile);
-    if (contents == null) return false;
+    if (contents == null) {
+        Log.w("WineUtils", "isRegistryFileValid: " + regFile.getPath() + " could not be read");
+        return false;
+    }
 
     String normalized = contents.trim();
-    return normalized.startsWith("WINE REGISTRY Version");
+    boolean valid = normalized.startsWith("WINE REGISTRY Version");
+    if (!valid) {
+        Log.w("WineUtils", "isRegistryFileValid: " + regFile.getPath() + " has invalid header: " + (normalized.length() > 24 ? normalized.substring(0, 24) : normalized));
+    }
+    return valid;
   }
 
   public static boolean isPrefixValid(File containerDir) {
@@ -638,10 +652,20 @@ public abstract class WineUtils {
     File userRegFile = new File(prefixDir, "user.reg");
     File windowsDir = new File(prefixDir, "drive_c/windows");
 
-    return prefixDir.isDirectory()
-        && windowsDir.isDirectory()
-        && isRegistryFileValid(systemRegFile)
-        && isRegistryFileValid(userRegFile);
+    boolean prefixExists = prefixDir.isDirectory();
+    boolean windowsExists = windowsDir.isDirectory();
+    boolean systemRegValid = isRegistryFileValid(systemRegFile);
+    boolean userRegValid = isRegistryFileValid(userRegFile);
+
+    if (!prefixExists || !windowsExists || !systemRegValid || !userRegValid) {
+        Log.w("WineUtils", "isPrefixValid: invalid for " + containerDir.getName() + 
+            " prefixDir=" + prefixExists + 
+            " windowsDir=" + windowsExists + 
+            " systemReg=" + systemRegValid + 
+            " userReg=" + userRegValid);
+    }
+
+    return prefixExists && windowsExists && systemRegValid && userRegValid;
   }
 
   private static void setWindowMetrics(WineRegistryEditor registryEditor) {
@@ -725,9 +749,9 @@ public abstract class WineUtils {
       for (String name : direct3dLibs)
         registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
       for (String name : dinputLibs)
-        registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
       for (String name : xinputLibs)
-        registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
       // Conditional OpenGL override for ARM64EC (exclude Mali GPUs)
       if (wineInfo != null
           && wineInfo.isArm64EC()
@@ -799,15 +823,15 @@ public abstract class WineUtils {
 
     try (WineRegistryEditor registryEditor = new WineRegistryEditor(userRegFile)) {
       for (String name : dinputLibs) {
-        if (!"builtin,native".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
-          registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        if (!"native,builtin".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
+          registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
         }
       }
 
       for (String dll : XINPUT_DLLS) {
         String name = dll.substring(0, dll.length() - 4);
-        if (!"builtin,native".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
-          registryEditor.setStringValue(dllOverridesKey, name, "builtin,native");
+        if (!"native,builtin".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
+          registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
         }
       }
     }

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -807,36 +807,6 @@ public abstract class WineUtils {
     }
   }
 
-  private static final String[] XINPUT_DLLS = {
-    "xinput1_1.dll", "xinput1_2.dll", "xinput1_3.dll",
-    "xinput1_4.dll", "xinput9_1_0.dll", "xinputuap.dll"
-  };
-
-  public static void ensureControllerDllOverrides(Container container) {
-    if (container == null) return;
-
-    File userRegFile = new File(container.getRootDir(), ".wine/user.reg");
-    if (!userRegFile.isFile()) return;
-
-    final String dllOverridesKey = "Software\\Wine\\DllOverrides";
-    final String[] dinputLibs = {"dinput", "dinput8"};
-
-    try (WineRegistryEditor registryEditor = new WineRegistryEditor(userRegFile)) {
-      for (String name : dinputLibs) {
-        if (!"native,builtin".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
-          registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
-        }
-      }
-
-      for (String dll : XINPUT_DLLS) {
-        String name = dll.substring(0, dll.length() - 4);
-        if (!"native,builtin".equals(registryEditor.getStringValue(dllOverridesKey, name, ""))) {
-          registryEditor.setStringValue(dllOverridesKey, name, "native,builtin");
-        }
-      }
-    }
-  }
-
   // Pre-seed the VC++ 2015-2022 redistributable registry markers when the proton
   // wcp has already laid down the runtime DLLs (msvcp140, vcruntime140, etc.) in
   // system32. Without these registry keys vc_redist's Burn bootstrapper sees


### PR DESCRIPTION
* Prevents wineCFG from being overridden by corrupted prefixes. Triggering a validation check (WineUtils.isPrefixValid). Because the file is corrupted and no longer starts with the correct header, the check fails. The app then thinks
'the container is "broken" and triggers a Full Repair,
which wipes your .wine directory and extracts a fresh, default one from Prefixpack'
* Changes Dinput8 and Xinput_dll to native then builtin.