### PR TITLE
i18n + comment cleanup for Steam Save Download/Conflict (#493)

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -973,11 +973,7 @@ class UnifiedActivity :
         }
     }
 
-    /**
-     * When the "Sign in to Google on launch" toggle (Settings ▸ Google) is enabled, attempt a
-     * Google Play Games sign-in once per process launch. No toast — the result is reflected in the
-     * Google tab. When the toggle is off (default), this is a no-op and the app never auto-signs-in.
-     */
+    /** When the "Sign in to Google on launch" toggle is on, attempt a silent Play Games sign-in once per launch. */
     private fun maybeAutoSignInGoogleOnLaunch() {
         if (!com.winlator.cmod.feature.sync.google.CloudSyncManager.isAutoSignInOnLaunchEnabled(this)) return
         runCatching {

--- a/app/src/main/feature/steamcloudsync/SteamAutoCloud.kt
+++ b/app/src/main/feature/steamcloudsync/SteamAutoCloud.kt
@@ -44,32 +44,7 @@ object SteamAutoCloud {
     private const val PERSIST_STATE_PERSISTED = 0
     private const val PERSIST_STATE_DELETED = 2
 
-    /**
-     * Per-Steam-protocol content-divergence check used by the launch-time conflict probe.
-     *
-     * Returns `true` if ANY persisted cloud file is missing locally OR has a differing
-     * size/SHA-1. Returns `false` only when every cloud file is present locally with
-     * matching size and SHA — the canonical "no conflict" condition.
-     *
-     * Optimizations:
-     *  - Size comparison is a free pre-filter (no SHA on obvious size delta).
-     *  - `Sequence.any {  }` short-circuits on the first divergence.
-     *  - We compute the local SHA only on files whose size already matches.
-     */
-    /**
-     * Group persisted cloud files by the local path they resolve to.
-     *
-     * Steam Cloud can hold DUPLICATE / stale entries for one logical save file under different
-     * prefixes or filenames — e.g. Monster Hunter Rise lists both `win64_save/X` and
-     * `%SteamUserData%win64_save/X` (plus token-in-filename leftovers from earlier bad uploads),
-     * all mapping to the same on-disk file. Collapsing by resolved local path lets the downloader
-     * fetch each file once (any working variant satisfies it) and the conflict/verification checks
-     * treat a path as in-sync when the local file matches ANY variant — instead of failing the
-     * whole sync on a redundant phantom entry the CDN no longer has.
-     *
-     * Unresolvable entries (null local path) are dropped: they're malformed leftovers, not real
-     * saves, and must not wedge the sync into a permanent "conflict".
-     */
+    /** Group persisted cloud files by resolved local path, deduping Steam's stale/duplicate entries (unresolvable ones dropped). */
     private fun groupPersistedCloudFilesByLocalPath(
         response: CloudFileChangeList,
         prefixToPath: (String) -> String,
@@ -101,6 +76,7 @@ object SteamAutoCloud {
         return variants.any { it.rawFileSize == localSize && localSha.contentEquals(it.shaFile) }
     }
 
+    /** True if any cloud file diverges from local content (missing, or no matching size/SHA variant). */
     fun cloudContentDiffersFromLocal(
         response: CloudFileChangeList,
         prefixToPath: (String) -> String,
@@ -117,8 +93,7 @@ object SteamAutoCloud {
         }
     }
 
-    // Delegates to the canonical resolver so the conflict check and remotecache.vdf writer
-    // resolve a cloud file to the EXACT path the downloader writes it to.
+    // Delegates to the canonical resolver so every consumer resolves to the path the downloader writes.
     private fun resolveLocalPathForCloudFile(
         cloudFile: CloudFileInfo,
         response: CloudFileChangeList,
@@ -293,16 +268,7 @@ object SteamAutoCloud {
         return CloudPathRouting(rootAliases, exactPrefixTargets)
     }
 
-    // ── Canonical cloud-file → local-path resolution ──
-    //
-    // SINGLE source of truth shared by the downloader, the post-download hash verification,
-    // the launch/probe conflict checks, and the remotecache.vdf writer. Previously the
-    // downloader and the conflict check used two different mappings, so for games that use
-    // uploadRoot/uploadPath (rootoverrides) aliases, ROOT_MOD prefixes, or %GameInstall%
-    // routing the download landed in path A while the check read path B — leaving the save
-    // "different from cloud" forever and re-prompting the conflict on every launch even after
-    // the user picked "Use Cloud". Resolving every consumer through one function guarantees we
-    // verify exactly the file we wrote.
+    // ── Canonical cloud-file → local-path resolution (single source of truth for all consumers) ──
 
     private fun pathTypePairsFor(
         fileList: CloudFileChangeList,
@@ -383,11 +349,7 @@ object SteamAutoCloud {
         }
     }
 
-    /**
-     * Resolve a cloud file to the absolute local path it belongs at — the exact path the
-     * downloader writes to. This is the canonical mapping; all conflict/verification consumers
-     * must route through it so we never check a different location than we wrote.
-     */
+    /** Resolve a cloud file to the absolute local path the downloader writes to (the canonical mapping). */
     private fun resolveCloudFileLocalPath(
         file: CloudFileInfo,
         fileList: CloudFileChangeList,
@@ -396,8 +358,7 @@ object SteamAutoCloud {
     ): Path? {
         val routing = cloudRouting ?: CloudPathRouting(emptyMap(), emptyMap())
 
-        // Steam sometimes returns prefix="" and filename="%GameInstall%save0.dat" instead of
-        // splitting correctly — route the embedded token the same way the downloader does.
+        // Steam sometimes embeds the %GameInstall% token in the filename with an empty prefix; route it like the downloader.
         val gameInstallPrefix = "%${PathType.GameInstall.name}%"
         if (file.filename.startsWith(gameInstallPrefix)) {
             val stripped = file.filename.removePrefix(gameInstallPrefix).trimStart('/', '\\')
@@ -822,10 +783,7 @@ object SteamAutoCloud {
                 changesExist to FileChanges(deletedFiles, modifiedFiles, newFiles)
             }
 
-            // Post-download verification: every cloud file's bytes must be present locally.
-            // Deduped by resolved local path with match-ANY semantics so the redundant/stale
-            // duplicate entries Steam Cloud keeps for one logical file (different prefixes/names)
-            // can't make a fully-restored save look like it still conflicts.
+            // Post-download verification: each resolved local path must match ANY of its cloud variants.
             val hasHashConflicts: (Map<String, List<UserFileInfo>>, CloudFileChangeList) -> Boolean =
                 { _, fileList ->
                     groupPersistedCloudFilesByLocalPath(fileList, prefixToPath, cloudRouting)
@@ -890,11 +848,7 @@ object SteamAutoCloud {
                 parentScope.async {
                     var filesDownloaded = 0
                     var bytesDownloaded = 0L
-                    // Dedup by resolved local path: a logical save file Steam lists under multiple
-                    // prefixes/names is downloaded ONCE. We try each cloud-name variant until one
-                    // fetches successfully, so a redundant/stale entry the CDN no longer has can't
-                    // fail the whole sync. filesDownloaded counts UNIQUE local paths written and is
-                    // compared against the same unique-path total by the caller.
+                    // Download each unique local path once, trying each cloud variant until one fetches; count unique paths written.
                     val groups = groupPersistedCloudFilesByLocalPath(fileList, prefixToPath, cloudRouting)
                     val totalFiles = groups.size
 
@@ -1189,9 +1143,7 @@ object SteamAutoCloud {
                                     getFilesDiff(remoteUserFiles, allLocalUserFiles).second.filesDeleted
                                 }
 
-                            // Count UNIQUE local paths to download — Steam Cloud's duplicate/stale
-                            // entries for one logical file must not inflate the target and wedge the
-                            // sync into permanent DownloadFail (the Monster Hunter Rise symptom).
+                            // Count UNIQUE local paths so duplicate/stale cloud entries can't inflate the target into permanent DownloadFail.
                             val cloudTargetPaths =
                                 groupPersistedCloudFilesByLocalPath(appFileListChange, prefixToPath, cloudRouting).keys
                             val expectedDownloads = cloudTargetPaths.size
@@ -1216,9 +1168,7 @@ object SteamAutoCloud {
                                     } else {
                                         var totalFilesDeleted = 0
                                         filesDeletedByCloud.forEach {
-                                            // Safety: never delete a local file the cloud actually has
-                                            // under SOME variant name (guards against the duplicate-
-                                            // prefix entries making a kept file look "removed remotely").
+                                            // Never delete a local file the cloud still has under some variant name.
                                             val abs =
                                                 runCatching { it.getAbsPath(prefixToPath).toAbsolutePath().normalize() }
                                                     .getOrNull()
@@ -1404,18 +1354,7 @@ object SteamAutoCloud {
                                         }
 
                                         SaveLocation.None -> {
-                                            // A real Steam conflict requires the local and cloud
-                                            // FILE CONTENT to actually diverge — not merely a
-                                            // change-number mismatch. The change number can drift
-                                            // (e.g. an upload's batch change number lags the next
-                                            // GetAppFileChangelist, or the persisted baseline is
-                                            // lost) while every file is byte-identical, which used
-                                            // to surface a phantom conflict dialog on every launch.
-                                            // Steam itself compares file SHAs; if both sides hold
-                                            // the same bytes there is nothing to resolve. Mirror the
-                                            // launch-probe hardening here: only prompt on genuine
-                                            // content divergence, otherwise silently reconcile the
-                                            // baseline so the false conflict cannot recur.
+                                            // Only a real content divergence is a conflict; a bare change-number drift reconciles the baseline silently.
                                             val contentDiffers =
                                                 cloudContentDiffersFromLocal(appFileListChange, prefixToPath, appInfo)
                                             if (contentDiffers) {

--- a/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
+++ b/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
@@ -515,13 +515,7 @@ object SteamSaveSnapshotManager {
         return sources.values.toList()
     }
 
-    /**
-     * Public view of [enumerateSaveSources] for the Google Play Games saved-game backend
-     * ([GameSaveBackupManager]) so a Steam save can be mirrored to / restored from Google using
-     * the exact same `zipRoot -> live dir` mapping the local snapshot history uses. Backup and
-     * restore both call this, so the part archive's zip roots round-trip without the manifest
-     * needing to store any paths.
-     */
+    /** Public view of [enumerateSaveSources] (zipRoot -> live dir) so [GameSaveBackupManager] mirrors Steam saves to/from Google. */
     fun enumerateGoogleSaveSources(
         context: Context,
         appId: Int,

--- a/app/src/main/feature/stores/steam/wnsteam/WnSteamSession.kt
+++ b/app/src/main/feature/stores/steam/wnsteam/WnSteamSession.kt
@@ -222,13 +222,7 @@ class WnSteamSession : AutoCloseable {
         return nativeGetCloudDownloadInfo(h, appId, filename)
     }
 
-    // Blocking Steam Cloud file download. Steam may store a save compressed (fileSize <
-    // rawFileSize) in any of several wrappers (single-entry PKZip, gzip, zlib, or raw deflate),
-    // or serve it via transport Content-Encoding. We request `identity` to get the exact stored
-    // blob, then auto-detect and decode it, validating the result against rawFileSize. The old
-    // code assumed a single-entry zip, which silently failed for games whose (typically larger)
-    // saves use a different wrapper or get transparently decoded by the HTTP stack — leaving the
-    // file un-restored and the launch conflict prompt recurring forever (e.g. Monster Hunter Rise).
+    // Blocking Steam Cloud download: request `identity`, then auto-detect/decode the stored wrapper and validate against rawFileSize.
     fun downloadCloudFile(appId: Int, filename: String): ByteArray? {
         val infoJson = getCloudDownloadInfo(appId, filename) ?: return null
         return try {
@@ -237,12 +231,10 @@ class WnSteamSession : AutoCloseable {
             if (host.isEmpty()) return null
             val rawFileSize = obj.optInt("rawFileSize", 0)
             val encrypted = obj.optBoolean("encrypted", false)
-            // Steam CM gives http/https per file; force https on Android (cleartext is blocked by
-            // default and the CDN serves both) but keep the host/path it handed us.
+            // Force https on Android (cleartext is blocked by default; the CDN serves both).
             val url = java.net.URL("https://$host${obj.optString("urlPath")}")
 
-            // Up to 3 attempts — a transient HTTP/network blip must NOT strand the save and
-            // re-trigger the conflict dialog next launch.
+            // Up to 3 attempts so a transient HTTP/network blip can't strand the save.
             var raw: ByteArray? = null
             var lastCode = -1
             for (attempt in 0 until 3) {
@@ -251,9 +243,7 @@ class WnSteamSession : AutoCloseable {
                     connectTimeout = 15_000
                     readTimeout = 30_000
                     instanceFollowRedirects = true
-                    // Get the exact stored bytes; we decode below. Prevents the HTTP stack from
-                    // transparently gunzipping a Content-Encoding:gzip response (which left the
-                    // body already-decoded yet still routed through the unzip path).
+                    // Get the exact stored bytes (we decode below); stops the HTTP stack from transparently gunzipping.
                     setRequestProperty("Accept-Encoding", "identity")
                     obj.optJSONArray("headers")?.let { headers ->
                         for (i in 0 until headers.length()) {
@@ -297,12 +287,7 @@ class WnSteamSession : AutoCloseable {
         }
     }
 
-    /**
-     * Decode a Steam Cloud download payload to the raw file bytes. Tries, in order: already-raw
-     * (uncompressed or transport-decoded), single-entry PKZip, gzip, zlib, and raw DEFLATE — and
-     * accepts the first candidate whose length equals [rawFileSize]. Returns null if nothing
-     * decodes to the expected size (e.g. an encrypted file we can't decrypt).
-     */
+    /** Decode a Steam Cloud payload, trying raw/PKZip/gzip/zlib/raw-DEFLATE and accepting the first match for [rawFileSize]. */
     private fun decodeCloudPayload(raw: ByteArray, rawFileSize: Int): ByteArray? {
         if (raw.isEmpty()) return if (rawFileSize == 0) raw else null
         // Already the raw file (uncompressed, or the HTTP stack decoded transport compression).

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -134,13 +134,7 @@ object GameSaveBackupManager {
         /** GOG cloud's live file listing. Restore pulls full cloud state down. */
         GOG_CLOUD,
 
-        /**
-         * Google Play Games **Saved Games (Snapshots)**. A logical save is one manifest
-         * snapshot plus N gzipped-zip "part" snapshots (split to fit `getMaxDataSize()`).
-         * Surfaced in Save History as a single entry with the GOOGLE badge; restore
-         * reassembles the parts, extracts into the resolved save dirs, then pushes the
-         * restored state back to the game's primary cloud (Steam Cloud for Steam).
-         */
+        /** Google Play Games Saved Games: one manifest snapshot plus N gzipped-zip part snapshots, shown as a single GOOGLE entry. */
         GOOGLE,
     }
 
@@ -263,11 +257,7 @@ object GameSaveBackupManager {
     /** Pref name kept verbatim ("google_drive_connected") for upgrade compatibility — the backend is now PGS. */
     fun isDriveConnected(context: Context): Boolean = prefs(context).getBoolean(KEY_GOOGLE_DRIVE_CONNECTED, false)
 
-    /**
-     * Records whether a Google Play Games session is connected. Public so the sign-in
-     * surfaces (Google tab account card, the launch auto-sign-in, the on-launch toggle) can
-     * keep this flag — the gate for showing/loading Google Saved-Games history — in sync.
-     */
+    /** Records whether a Google Play Games session is connected — the gate for loading Google Saved-Games history. */
     fun setDriveConnected(context: Context, connected: Boolean) {
         prefs(context).edit().putBoolean(KEY_GOOGLE_DRIVE_CONNECTED, connected).apply()
     }
@@ -309,10 +299,7 @@ object GameSaveBackupManager {
                 // 1) Local rolling snapshot — the offline rollback safety net (always attempted).
                 val localOk = SteamSaveSnapshotManager.recordSnapshot(activity.applicationContext, appId, origin)
 
-                // 2) Mirror the kept save to Google Play Games (split + zipped) when a Google
-                //    session is connected. Uses the caller's [authMode] (RESUME from the launch
-                //    conflict flow), so when the user is NOT signed in this is a silent no-op and
-                //    only the local snapshot is kept.
+                // 2) Mirror to Google Play Games when signed in; a silent no-op otherwise (only the local snapshot is kept).
                 val googleResult =
                     runCatching {
                         backupSaveToGoogle(activity, gameSource, gameId, gameName, origin, authMode)
@@ -335,18 +322,7 @@ object GameSaveBackupManager {
 
     // ── Google Play Games saved-game backup / list / restore ──
 
-    /**
-     * Back up the current local save for a game to Google Play Games **Saved Games**.
-     *
-     * Pipeline: collect save sources → stream a single gzipped-zip into a cache file →
-     * split into ≤[MAX_PARTS] part snapshots sized to fit `SnapshotsClient.getMaxDataSize()`
-     * → write the parts first, then the manifest LAST (its presence is the commit point).
-     * The manifest references the part names plus the uncompressed size and SHA-256 so a
-     * later restore can verify integrity. Returns a user-facing [BackupResult].
-     *
-     * Silent when not signed in: with [authMode] = RESUME/SILENT, a missing Google session
-     * short-circuits to a failure result with no UI and no toast.
-     */
+    /** Back up the current local save to Google Play Games as ≤[MAX_PARTS] part snapshots plus a manifest written last (the commit point). */
     @JvmOverloads
     suspend fun backupSaveToGoogle(
         activity: Activity,
@@ -446,11 +422,7 @@ object GameSaveBackupManager {
             }
         }
 
-    /**
-     * List a game's Google Play Games saved-game history, newest-first. Each manifest snapshot
-     * becomes one [BackupHistoryEntry] with `storage = GOOGLE`. Returns empty (no UI) when no
-     * Google session is connected.
-     */
+    /** List a game's Google Play Games saved-game history (one entry per manifest, newest-first); empty when not signed in. */
     @JvmOverloads
     suspend fun listGoogleHistory(
         activity: Activity,
@@ -488,12 +460,7 @@ object GameSaveBackupManager {
             }
         }
 
-    /**
-     * Restore a Google Play Games saved-game [entry]: read its manifest, download + concatenate
-     * the parts, verify the SHA-256, extract into the resolved save dirs, then push the restored
-     * state up to the game's primary cloud (Steam Cloud for Steam). The reassembled archive is
-     * always deleted afterward.
-     */
+    /** Restore a Google saved-game [entry]: reassemble + verify the parts, extract into the save dirs, then push to the game's primary cloud. */
     @JvmOverloads
     suspend fun restoreFromGoogle(
         activity: Activity,
@@ -755,12 +722,7 @@ object GameSaveBackupManager {
     ): List<SaveBackupSource> =
         when (source) {
             GameSource.STEAM -> {
-                // Steam's primary cloud is Steam Cloud, but a Steam save can ALSO be mirrored
-                // to Google Play Games (the conflict "keep a copy" flow). Reuse the exact source
-                // enumeration the local Steam snapshot manager uses so backup and restore resolve
-                // identical zipRoot -> dir mappings (the manifest doesn't need to store paths).
-                // The containerHint pins resolution to the game's own wineprefix so restore writes
-                // into — and the follow-up Steam Cloud upload reads from — the same container.
+                // Reuse the local Steam snapshot manager's source enumeration so backup/restore share identical zipRoot -> dir mappings.
                 val appId = gameId.toIntOrNull() ?: return emptyList()
                 SteamSaveSnapshotManager
                     .enumerateGoogleSaveSources(context, appId, forRestore, containerHint)

--- a/app/src/main/feature/sync/google/GoogleScreen.kt
+++ b/app/src/main/feature/sync/google/GoogleScreen.kt
@@ -153,9 +153,7 @@ fun GoogleScreen() {
                     autoSignIn = enabled
                     CloudSyncManager.setAutoSignInOnLaunchEnabled(context, enabled)
                     if (enabled) {
-                        // The user opted in — sign in right away so it takes effect immediately
-                        // (and every subsequent launch). A toast here is expected, unlike the
-                        // silent OFF behavior.
+                        // Opted in: sign in right away (a toast here is expected, unlike the silent OFF path).
                         val currentActivity = activity ?: return@AutoSignInToggleCard
                         busy = true
                         CloudSyncManager.signIn(currentActivity) { success, message ->

--- a/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
+++ b/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
@@ -209,8 +209,7 @@ internal fun CloudSavesContent(
                                     emptyList()
                                 }
                             }
-                        // Saves the user chose to "keep a copy" of are mirrored to Google Play
-                        // Games; surface them in the same list (silent no-op when not signed in).
+                        // Surface Google-mirrored "keep a copy" saves in the same list (silent no-op when not signed in).
                         val google =
                             GameSaveBackupManager.listGoogleHistory(
                                 activity,
@@ -1107,8 +1106,7 @@ private fun SaveHistoryRow(
                     android.text.format.DateUtils.MINUTE_IN_MILLIS,
                 ).toString()
         }
-    // Badge reflects WHERE the save is backed up, not the conflict side it came from:
-    // Steam Cloud / local snapshots → "Steam", Play Games mirror → "Google", etc.
+    // Badge reflects where the save is backed up (Steam/Google/Epic/GOG), not the conflict side it came from.
     val storageLabel =
         when (entry.storage) {
             GameSaveBackupManager.BackupStorage.STEAM_CLOUD,

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -942,6 +942,9 @@ Installeret sti:
     <string name="google_cloud_sync_started">Skysynkronisering startet.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google-tjenester</string>
+    <string name="google_auto_signin_title">Log ind på Google ved opstart</string>
+    <string name="google_auto_signin_summary">Opret automatisk forbindelse til Google Play Spil, når appen starter, så sikkerhedskopier af gemte filer og synkronisering altid er klar. Når den er slået fra, logger appen aldrig ind af sig selv.</string>
+    <string name="google_auto_signin_section">Ved opstart</string>
     <string name="google_cloud_play_games">Google Play Spil</string>
     <string name="google_cloud_status_syncing">Synkroniserer</string>
     <string name="google_cloud_status_connected">Forbundet</string>
@@ -1117,6 +1120,10 @@ Installeret sti:
     <string name="cloud_saves_history_empty">Ingen tidligere saves er sikkerhedskopieret endnu. Erstattede saves og manuelle sikkerhedskopier vises her i 30 dage.</string>
     <string name="cloud_saves_history_loading">Indlæser save-historik\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">cloud</string>
     <string name="cloud_saves_history_origin_local">lokal</string>
     <string name="cloud_saves_history_origin_manual">manuel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -942,6 +942,9 @@ Installierter Pfad:
     <string name="google_cloud_sync_started">Cloud-Synchronisierung gestartet.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google-Dienste</string>
+    <string name="google_auto_signin_title">Beim Start bei Google anmelden</string>
+    <string name="google_auto_signin_summary">Beim App-Start automatisch mit Google Play Games verbinden, damit Spielstand-Backups und Synchronisierung immer bereit sind. Wenn deaktiviert, meldet sich die App nie von selbst an.</string>
+    <string name="google_auto_signin_section">Beim Start</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Synchronisiere</string>
     <string name="google_cloud_status_connected">Verbunden</string>
@@ -1117,6 +1120,10 @@ Installierter Pfad:
     <string name="cloud_saves_history_empty">Noch keine früheren Spielstände gesichert. Ersetzte Spielstände und manuelle Backups erscheinen hier für 30 Tage.</string>
     <string name="cloud_saves_history_loading">Speicherverlauf wird geladen\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">cloud</string>
     <string name="cloud_saves_history_origin_local">lokal</string>
     <string name="cloud_saves_history_origin_manual">manuell</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -942,6 +942,9 @@ Ruta instalada:
     <string name="google_cloud_sync_started">Sincronización en la nube iniciada.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Servicios de Google</string>
+    <string name="google_auto_signin_title">Iniciar sesión en Google al abrir</string>
+    <string name="google_auto_signin_summary">Conéctate automáticamente a Google Play Games cuando se inicia la aplicación para que las copias de seguridad y la sincronización de partidas guardadas estén siempre listas. Si está desactivado, la aplicación nunca inicia sesión por su cuenta.</string>
+    <string name="google_auto_signin_section">Al iniciar</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Sincronizando</string>
     <string name="google_cloud_status_connected">Conectado</string>
@@ -1117,6 +1120,10 @@ Ruta instalada:
     <string name="cloud_saves_history_empty">Aún no hay partidas guardadas anteriores. Las partidas reemplazadas y las copias manuales aparecerán aquí durante 30 días.</string>
     <string name="cloud_saves_history_loading">Cargando historial de partidas\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">nube</string>
     <string name="cloud_saves_history_origin_local">local</string>
     <string name="cloud_saves_history_origin_manual">manual</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -942,6 +942,9 @@ Chemin installé :
     <string name="google_cloud_sync_started">Synchronisation cloud démarrée.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Services Google</string>
+    <string name="google_auto_signin_title">Se connecter à Google au démarrage</string>
+    <string name="google_auto_signin_summary">Se connecter automatiquement à Google Play Jeux au démarrage de l\'application afin que les sauvegardes et la synchronisation soient toujours prêtes. Lorsque l\'option est désactivée, l\'application ne se connecte jamais d\'elle-même.</string>
+    <string name="google_auto_signin_section">Au démarrage</string>
     <string name="google_cloud_play_games">Google Play Jeux</string>
     <string name="google_cloud_status_syncing">Synchronisation</string>
     <string name="google_cloud_status_connected">Connecté</string>
@@ -1117,6 +1120,10 @@ Chemin installé :
     <string name="cloud_saves_history_empty">Aucune sauvegarde précédente pour l\'instant. Les sauvegardes remplacées et les sauvegardes manuelles apparaîtront ici pendant 30 jours.</string>
     <string name="cloud_saves_history_loading">Chargement de l\'historique des sauvegardes\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">cloud</string>
     <string name="cloud_saves_history_origin_local">local</string>
     <string name="cloud_saves_history_origin_manual">manuel</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1044,6 +1044,9 @@
     <string name="google_cloud_sync_started">क्लाउड सिंक शुरू हुआ।</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google सेवाएँ</string>
+    <string name="google_auto_signin_title">लॉन्च पर Google में साइन इन करें</string>
+    <string name="google_auto_signin_summary">ऐप शुरू होने पर अपने आप Google Play Games से कनेक्ट करें ताकि सेव बैकअप और सिंक हमेशा तैयार रहें. बंद होने पर, ऐप कभी भी अपने आप साइन इन नहीं करता.</string>
+    <string name="google_auto_signin_section">लॉन्च पर</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">सिंक हो रहा है</string>
     <string name="google_cloud_status_connected">कनेक्टेड</string>
@@ -1123,6 +1126,10 @@
     <string name="cloud_saves_history_origin_cloud">क्लाउड</string>
     <string name="cloud_saves_history_origin_manual">मैनुअल</string>
     <string name="cloud_saves_history_origin_auto">ऑटो</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_restore">पुनर्स्थापित करें</string>
     <string name="cloud_saves_history_restore_confirm_title">इस बैकअप को पुनर्स्थापित करें?</string>
     <string name="cloud_saves_history_restore_confirm_body">यह आपके वर्तमान स्थानीय सेव को %1$s के बैकअप से बदल देगा।</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -942,6 +942,9 @@ Percorso installato:
     <string name="google_cloud_sync_started">Sincronizzazione cloud avviata.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Servizi Google</string>
+    <string name="google_auto_signin_title">Accedi a Google all\'avvio</string>
+    <string name="google_auto_signin_summary">Connettiti automaticamente a Google Play Giochi all\'avvio dell\'app, così i backup dei salvataggi e la sincronizzazione sono sempre pronti. Se disattivato, l\'app non accede mai da sola.</string>
+    <string name="google_auto_signin_section">All\'avvio</string>
     <string name="google_cloud_play_games">Google Play Giochi</string>
     <string name="google_cloud_status_syncing">Sincronizzazione</string>
     <string name="google_cloud_status_connected">Connesso</string>
@@ -1117,6 +1120,10 @@ Percorso installato:
     <string name="cloud_saves_history_empty">Nessun salvataggio precedente ancora sottoposto a backup. I salvataggi sostituiti e i backup manuali appariranno qui per 30 giorni.</string>
     <string name="cloud_saves_history_loading">Caricamento cronologia salvataggi\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">cloud</string>
     <string name="cloud_saves_history_origin_local">locale</string>
     <string name="cloud_saves_history_origin_manual">manuale</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -942,6 +942,9 @@
     <string name="google_cloud_sync_started">클라우드 동기화가 시작되었습니다.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google 서비스</string>
+    <string name="google_auto_signin_title">실행 시 Google에 로그인</string>
+    <string name="google_auto_signin_summary">앱이 시작될 때 자동으로 Google Play 게임에 연결하여 저장 백업과 동기화가 항상 준비되도록 합니다. 끄면 앱이 자동으로 로그인하지 않습니다.</string>
+    <string name="google_auto_signin_section">실행 시</string>
     <string name="google_cloud_play_games">Google Play 게임</string>
     <string name="google_cloud_status_syncing">동기화 중</string>
     <string name="google_cloud_status_connected">연결됨</string>
@@ -1118,6 +1121,10 @@
     <string name="cloud_saves_history_empty">아직 백업된 이전 저장 파일이 없습니다. 교체된 저장 파일과 수동 백업이 30일 동안 여기에 표시됩니다.</string>
     <string name="cloud_saves_history_loading">저장 기록 불러오는 중\u2026</string>
     <string name="cloud_saves_history_origin_auto">자동</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">클라우드</string>
     <string name="cloud_saves_history_origin_local">로컬</string>
     <string name="cloud_saves_history_origin_manual">수동</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -948,6 +948,9 @@ Zainstalowana ścieżka:
     <string name="google_cloud_sync_started">Rozpoczęto synchronizację w chmurze.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Usługi Google</string>
+    <string name="google_auto_signin_title">Logowanie do Google przy starcie</string>
+    <string name="google_auto_signin_summary">Automatycznie łącz z Google Play Games po uruchomieniu aplikacji, aby kopie zapasowe zapisów i synchronizacja były zawsze gotowe. Gdy wyłączone, aplikacja nigdy nie loguje się samodzielnie.</string>
+    <string name="google_auto_signin_section">Przy starcie</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Synchronizowanie</string>
     <string name="google_cloud_status_connected">Połączono</string>
@@ -1123,6 +1126,10 @@ Zainstalowana ścieżka:
     <string name="cloud_saves_history_empty">Brak poprzednich zapisów w kopii zapasowej. Zastąpione zapisy i ręczne kopie zapasowe będą tu widoczne przez 30 dni.</string>
     <string name="cloud_saves_history_loading">Ładowanie historii zapisów\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">chmura</string>
     <string name="cloud_saves_history_origin_local">lokalne</string>
     <string name="cloud_saves_history_origin_manual">ręczne</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -942,6 +942,9 @@ Caminho instalado:
     <string name="google_cloud_sync_started">Sincronizacao na nuvem iniciada.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Servicos Google</string>
+    <string name="google_auto_signin_title">Entrar no Google ao iniciar</string>
+    <string name="google_auto_signin_summary">Conecte-se automaticamente ao Google Play Games quando o app é iniciado para que os backups de saves e a sincronização estejam sempre prontos. Quando desativado, o app nunca entra sozinho.</string>
+    <string name="google_auto_signin_section">Ao iniciar</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Sincronizando</string>
     <string name="google_cloud_status_connected">Conectado</string>
@@ -1117,6 +1120,10 @@ Caminho instalado:
     <string name="cloud_saves_history_empty">Nenhum save anterior com backup ainda. Saves substituídos e backups manuais aparecerão aqui por 30 dias.</string>
     <string name="cloud_saves_history_loading">Carregando histórico de saves\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">nuvem</string>
     <string name="cloud_saves_history_origin_local">local</string>
     <string name="cloud_saves_history_origin_manual">manual</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -942,6 +942,9 @@ Cale instalata:
     <string name="google_cloud_sync_started">Sincronizarea cloud a inceput.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Servicii Google</string>
+    <string name="google_auto_signin_title">Conectare la Google la pornire</string>
+    <string name="google_auto_signin_summary">Conectează-te automat la Google Play Games la pornirea aplicației, astfel încât copiile de rezervă ale salvărilor și sincronizarea să fie mereu pregătite. Când este dezactivat, aplicația nu se conectează niciodată singură.</string>
+    <string name="google_auto_signin_section">La pornire</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Se sincronizeaza</string>
     <string name="google_cloud_status_connected">Conectat</string>
@@ -1117,6 +1120,10 @@ Cale instalata:
     <string name="cloud_saves_history_empty">Nicio salvare anterioară arhivată încă. Salvările înlocuite și copiile de siguranță manuale vor apărea aici timp de 30 de zile.</string>
     <string name="cloud_saves_history_loading">Se încarcă istoricul salvărilor\u2026</string>
     <string name="cloud_saves_history_origin_auto">auto</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">cloud</string>
     <string name="cloud_saves_history_origin_local">local</string>
     <string name="cloud_saves_history_origin_manual">manual</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1006,6 +1006,9 @@
     <string name="google_cloud_sync_started">Синхронизация с облаком началась.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Сервисы Google</string>
+    <string name="google_auto_signin_title">Вход в Google при запуске</string>
+    <string name="google_auto_signin_summary">Автоматически подключаться к Google Play Games при запуске приложения, чтобы резервные копии сохранений и синхронизация всегда были готовы. Когда выключено, приложение никогда не входит само.</string>
+    <string name="google_auto_signin_section">При запуске</string>
     <string name="google_cloud_play_games">Google Play Games</string>
     <string name="google_cloud_status_syncing">Синхронизация</string>
     <string name="google_cloud_status_connected">Подключено</string>
@@ -1086,6 +1089,10 @@
     <string name="cloud_saves_history_origin_cloud">облако</string>
     <string name="cloud_saves_history_origin_manual">вручную</string>
     <string name="cloud_saves_history_origin_auto">авто</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_restore">Восстановить</string>
     <string name="cloud_saves_history_restore_confirm_title">Восстановить эту резервную копию?</string>
     <string name="cloud_saves_history_restore_confirm_body">Это заменит ваше текущее локальное сохранение резервной копией от %1$s.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -948,6 +948,9 @@
     <string name="google_cloud_sync_started">Хмарну синхронізацію розпочато.</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Сервіси Google</string>
+    <string name="google_auto_signin_title">Вхід у Google під час запуску</string>
+    <string name="google_auto_signin_summary">Автоматично підключатися до Google Play Ігри під час запуску додатка, щоб резервні копії збережень і синхронізація завжди були готові. Коли вимкнено, додаток ніколи не входить самостійно.</string>
+    <string name="google_auto_signin_section">Під час запуску</string>
     <string name="google_cloud_play_games">Google Play Ігри</string>
     <string name="google_cloud_status_syncing">Синхронізація</string>
     <string name="google_cloud_status_connected">Підключено</string>
@@ -1123,6 +1126,10 @@
     <string name="cloud_saves_history_empty">Попередніх збережень ще немає. Замінені збереження та ручні резервні копії з\'являтимуться тут протягом 30 днів.</string>
     <string name="cloud_saves_history_loading">Завантаження історії збережень\u2026</string>
     <string name="cloud_saves_history_origin_auto">авто</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">хмара</string>
     <string name="cloud_saves_history_origin_local">локально</string>
     <string name="cloud_saves_history_origin_manual">вручну</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -942,6 +942,9 @@
     <string name="google_cloud_sync_started">云同步已开始。</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google 服务</string>
+    <string name="google_auto_signin_title">启动时登录 Google</string>
+    <string name="google_auto_signin_summary">应用启动时自动连接到 Google Play 游戏，让存档备份和同步始终就绪。关闭后，应用绝不会自行登录。</string>
+    <string name="google_auto_signin_section">启动时</string>
     <string name="google_cloud_play_games">Google Play 游戏</string>
     <string name="google_cloud_status_syncing">同步中</string>
     <string name="google_cloud_status_connected">已连接</string>
@@ -1117,6 +1120,10 @@
     <string name="cloud_saves_history_empty">暂无已备份的历史存档。被替换的存档和手动备份将在此处保留 30 天。</string>
     <string name="cloud_saves_history_loading">正在加载存档历史\u2026</string>
     <string name="cloud_saves_history_origin_auto">自动</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">云端</string>
     <string name="cloud_saves_history_origin_local">本地</string>
     <string name="cloud_saves_history_origin_manual">手动</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -942,6 +942,9 @@
     <string name="google_cloud_sync_started">雲端同步已開始。</string>
     <string name="google_cloud_google">Google</string>
     <string name="google_cloud_services">Google 服務</string>
+    <string name="google_auto_signin_title">啟動時登入 Google</string>
+    <string name="google_auto_signin_summary">應用程式啟動時自動連線到 Google Play 遊戲，讓存檔備份與同步隨時就緒。關閉時，應用程式絕不會自行登入。</string>
+    <string name="google_auto_signin_section">啟動時</string>
     <string name="google_cloud_play_games">Google Play 遊戲</string>
     <string name="google_cloud_status_syncing">同步中</string>
     <string name="google_cloud_status_connected">已連線</string>
@@ -1117,6 +1120,10 @@
     <string name="cloud_saves_history_empty">尚無先前的存檔備份。被取代的存檔和手動備份將在此顯示 30 天。</string>
     <string name="cloud_saves_history_loading">正在載入存檔歷史紀錄\u2026</string>
     <string name="cloud_saves_history_origin_auto">自動</string>
+    <string name="cloud_saves_history_storage_steam">Steam</string>
+    <string name="cloud_saves_history_storage_google">Google</string>
+    <string name="cloud_saves_history_storage_epic">Epic</string>
+    <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_origin_cloud">雲端</string>
     <string name="cloud_saves_history_origin_local">本機</string>
     <string name="cloud_saves_history_origin_manual">手動</string>


### PR DESCRIPTION
Follow-up to 4f9f629 (Fix: Steam Save Download/Conflict).

Missing translations:
- That commit added 7 new string keys to only the default values/strings.xml, leaving all 14 translated locales without them so non-English users saw the English fallback. Add translated entries for google_auto_signin_{title,summary,section} and cloud_saves_history_storage_{steam,google,epic,gog} to da, de, es, fr, hi, it, ko, pl, pt-rBR, ro, ru, uk, zh-rCN and zh-rTW. Brand badges (Steam/Google/Epic/GOG) are kept verbatim; sentence strings translated.

Code cleanup (comments only, no behavior change):
- Collapse the commit's verbose multi-line comments to a single line each.
- Remove an orphaned/duplicated KDoc the commit left stranded above groupPersistedCloudFilesByLocalPath, and give cloudContentDiffersFromLocal its own one-line doc.