### PR TITLE
Fix trackpad spinning and input drops during trackpad+button use

### DIFF
--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -7,7 +7,6 @@ import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.SystemClock;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.Log;
@@ -84,15 +83,6 @@ public class WinHandler {
   private final DatagramPacket sendPacket = new DatagramPacket(this.sendData.array(), 64);
   private final DatagramPacket receivePacket = new DatagramPacket(this.receiveData.array(), 64);
   private final Handler inputHandler = new Handler(Looper.getMainLooper());
-  private static final long VIRTUAL_SEND_THROTTLE_MS = 8;
-  private long lastVirtualSendMs = 0;
-  private boolean virtualSendPending = false;
-  private final Runnable virtualSendFlush =
-      () -> {
-        virtualSendPending = false;
-        lastVirtualSendMs = SystemClock.uptimeMillis();
-        sendGamepadState();
-      };
   private final ArrayDeque<Runnable> actions = new ArrayDeque<>();
   private boolean initReceived = false;
   private volatile boolean running = false;
@@ -642,19 +632,6 @@ public class WinHandler {
     writeVirtualGamepadState(shouldApplyGyroToTarget(GAMEPAD_SOURCE_VIRTUAL, null));
     XServer xServer = activity.getXServer();
     if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
-  }
-
-  // Coalesce high-rate virtual stick sends to ~display cadence; buttons stay immediate.
-  public void sendGamepadStateCoalesced() {
-    long now = SystemClock.uptimeMillis();
-    long elapsed = now - lastVirtualSendMs;
-    if (elapsed >= VIRTUAL_SEND_THROTTLE_MS) {
-      lastVirtualSendMs = now;
-      sendGamepadState();
-    } else if (!virtualSendPending) {
-      virtualSendPending = true;
-      inputHandler.postDelayed(virtualSendFlush, VIRTUAL_SEND_THROTTLE_MS - elapsed);
-    }
   }
 
   private void writeVirtualGamepadState(boolean applyGyroOverlay) {

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -7,6 +7,7 @@ import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.Log;
@@ -79,6 +80,15 @@ public class WinHandler {
   private final DatagramPacket sendPacket = new DatagramPacket(this.sendData.array(), 64);
   private final DatagramPacket receivePacket = new DatagramPacket(this.receiveData.array(), 64);
   private final Handler inputHandler = new Handler(Looper.getMainLooper());
+  private static final long VIRTUAL_SEND_THROTTLE_MS = 8;
+  private long lastVirtualSendMs = 0;
+  private boolean virtualSendPending = false;
+  private final Runnable virtualSendFlush =
+      () -> {
+        virtualSendPending = false;
+        lastVirtualSendMs = SystemClock.uptimeMillis();
+        sendGamepadState();
+      };
   private final ArrayDeque<Runnable> actions = new ArrayDeque<>();
   private boolean initReceived = false;
   private volatile boolean running = false;
@@ -670,6 +680,19 @@ public class WinHandler {
     writeVirtualGamepadState(shouldApplyGyroToTarget(GAMEPAD_SOURCE_VIRTUAL, null));
     XServer xServer = activity.getXServer();
     if (xServer != null && xServer.getRenderer() != null) xServer.getRenderer().requestRenderCoalesced();
+  }
+
+  // Coalesce high-rate virtual stick sends to ~display cadence; buttons stay immediate.
+  public void sendGamepadStateCoalesced() {
+    long now = SystemClock.uptimeMillis();
+    long elapsed = now - lastVirtualSendMs;
+    if (elapsed >= VIRTUAL_SEND_THROTTLE_MS) {
+      lastVirtualSendMs = now;
+      sendGamepadState();
+    } else if (!virtualSendPending) {
+      virtualSendPending = true;
+      inputHandler.postDelayed(virtualSendFlush, VIRTUAL_SEND_THROTTLE_MS - elapsed);
+    }
   }
 
   private void writeVirtualGamepadState(boolean applyGyroOverlay) {

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -474,6 +474,28 @@ public class InputControlsView extends View {
     activeTouchElements.clear();
   }
 
+  // Release captures whose pointer is no longer reported (missed UP/CANCEL).
+  private void releaseStaleCaptures(MotionEvent event) {
+    boolean removedAny = false;
+    for (int i = activeTouchElements.size() - 1; i >= 0; i--) {
+      int capturedId = activeTouchElements.keyAt(i);
+      boolean stillDown = false;
+      for (int p = 0, count = event.getPointerCount(); p < count; p++) {
+        if (event.getPointerId(p) == capturedId) {
+          stillDown = true;
+          break;
+        }
+      }
+      if (!stillDown) {
+        ControlElement element = activeTouchElements.valueAt(i);
+        if (element != null) element.handleTouchUp(capturedId);
+        activeTouchElements.removeAt(i);
+        removedAny = true;
+      }
+    }
+    if (removedAny) syncCapturedPointers();
+  }
+
   public void cancelContinuousMouseMove() {
     mouseMoveOffsetX = 0f;
     mouseMoveOffsetY = 0f;
@@ -836,7 +858,7 @@ public class InputControlsView extends View {
             batchingUpdates = false;
             WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
             if (anyControlHandled && winHandler != null) {
-              winHandler.sendGamepadState();
+              winHandler.sendGamepadStateCoalesced();
             }
 
             syncCapturedPointers();
@@ -877,6 +899,8 @@ public class InputControlsView extends View {
             break;
           }
       }
+
+      releaseStaleCaptures(event);
     }
     return true;
   }

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -858,7 +858,7 @@ public class InputControlsView extends View {
             batchingUpdates = false;
             WinHandler winHandler = xServer != null ? xServer.getWinHandler() : null;
             if (anyControlHandled && winHandler != null) {
-              winHandler.sendGamepadStateCoalesced();
+              winHandler.sendGamepadState();
             }
 
             syncCapturedPointers();


### PR DESCRIPTION
- Release captured pointers no longer reported by the OS so a trackpad-bound gamepad stick can't stay latched (stuck spin) when an UP/CANCEL is dropped.
- Coalesce high-rate virtual stick sends to ~display cadence so trackpad movement can't flood the shared input ring and drop a simultaneous button.