### PR TITLE
HUD: backdrop alpha control. 

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -674,6 +674,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_hud_summary">Tune overlay visibility and data points</string>
     <string name="session_drawer_hud_disabled_hint">Turn on the overlay to customize it</string>
     <string name="session_drawer_hud_alpha">Alpha</string>
+    <string name="session_drawer_hud_background_alpha">Background Alpha</string>
+    <string name="session_drawer_hud_background">Background</string>
     <string name="session_drawer_hud_scale">Scale</string>
     <string name="session_drawer_hud_elements">HUD Elements</string>
     <string name="session_drawer_hud_element_fps">FPS</string>
@@ -693,6 +695,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="hud_position_bottom_center">Bottom Center</string>
     <string name="hud_position_bottom_right">Bottom Right</string>
     <string name="session_drawer_hud_alpha_input_title">Set Alpha</string>
+    <string name="session_drawer_hud_background_alpha_input_title">Set Background Alpha</string>
     <string name="session_drawer_hud_scale_input_title">Set Scale</string>
     <string name="session_drawer_hud_input_hint">Enter a value from %1$d to %2$d. Values above the limit are clamped.</string>
     <string name="session_drawer_command_center">Command Center</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,6 +684,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_hud_element_cpu">CPU</string>
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">BAT</string>
+    <string name="session_drawer_hud_element_temp">TMP</string>
     <string name="session_drawer_hud_element_graph">Graph</string>
     <string name="hud_position_menu_title">Move HUD to</string>
     <string name="hud_position_top_left">Top Left</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -337,6 +337,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private boolean isNativeRenderingEnabled = true;
 
     private float hudTransparency = 1.0f;
+    private boolean hudBackgroundAlphaDecoupled = false;
+    private float hudBackgroundTransparency = 1.0f;
     private float hudScale = 1.0f;
     private boolean[] hudElements = new boolean[]{true, true, true, true, true, true, true};
     private boolean dualSeriesBattery = false;
@@ -3815,6 +3817,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 magnifierView != null,
                 enableLogsMenu,
                 hudTransparency,
+                hudBackgroundAlphaDecoupled,
+                hudBackgroundTransparency,
                 hudScale,
                 hudElements,
                 dualSeriesBattery,
@@ -3879,7 +3883,32 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onHUDTransparencyChanged(float transparency) {
                         hudTransparency = transparency;
+                        if (!hudBackgroundAlphaDecoupled) {
+                            hudBackgroundTransparency = clampHudAlpha(transparency * FrameRating.BACKDROP_BASE_ALPHA);
+                        }
                         if (frameRating != null) frameRating.setHudAlpha(transparency);
+                        saveHUDSettings();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onHUDBackgroundAlphaDecoupledChanged(boolean enabled) {
+                        hudBackgroundAlphaDecoupled = enabled;
+                        if (!enabled) {
+                            hudBackgroundTransparency = clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA);
+                        }
+                        if (frameRating != null) {
+                            frameRating.setHudBackgroundAlpha(hudBackgroundTransparency);
+                            frameRating.setBackgroundAlphaDecoupled(enabled);
+                        }
+                        saveHUDSettings();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onHUDBackgroundTransparencyChanged(float transparency) {
+                        hudBackgroundTransparency = transparency;
+                        if (frameRating != null) frameRating.setHudBackgroundAlpha(transparency);
                         saveHUDSettings();
                         renderDrawerMenu();
                     }
@@ -4587,6 +4616,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         colorProfile = preferences.getInt("color_profile", 0);
     }
 
+    private static float clampHudAlpha(float v) {
+        return Math.max(0.1f, Math.min(1.0f, v));
+    }
+
     private void loadHUDSettings() {
         if (container == null) return;
         String json = container.getExtra("hudSettings");
@@ -4594,6 +4627,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             try {
                 JSONObject obj = new JSONObject(json);
                 hudTransparency = (float) obj.optDouble("transparency", 1.0);
+                hudBackgroundAlphaDecoupled = obj.optBoolean("backgroundAlphaDecoupled", false);
+                hudBackgroundTransparency = (float) obj.optDouble("backgroundTransparency",
+                        clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA));
+                if (!hudBackgroundAlphaDecoupled) {
+                    hudBackgroundTransparency = clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA);
+                }
                 hudScale = (float) obj.optDouble("scale", 1.0);
                 hudElements[0] = obj.optBoolean("showFPS", true);
                 hudElements[1] = obj.optBoolean("showRenderer", true);
@@ -4614,6 +4653,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         try {
             JSONObject obj = new JSONObject();
             obj.put("transparency", hudTransparency);
+            obj.put("backgroundAlphaDecoupled", hudBackgroundAlphaDecoupled);
+            obj.put("backgroundTransparency", hudBackgroundTransparency);
             obj.put("scale", hudScale);
             obj.put("showFPS", hudElements[0]);
             obj.put("showRenderer", hudElements[1]);
@@ -4632,6 +4673,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private void applyHUDSettings() {
         if (frameRating != null) {
             frameRating.setHudAlpha(hudTransparency);
+            frameRating.setHudBackgroundAlpha(hudBackgroundTransparency);
+            frameRating.setBackgroundAlphaDecoupled(hudBackgroundAlphaDecoupled);
             frameRating.setHudScale(hudScale);
             frameRating.setDualSeriesBattery(dualSeriesBattery);
             frameRating.setFrametimeNumericMode(frametimeNumericMode);

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -340,7 +340,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private boolean hudBackgroundAlphaDecoupled = false;
     private float hudBackgroundTransparency = 1.0f;
     private float hudScale = 1.0f;
-    private boolean[] hudElements = new boolean[]{true, true, true, true, true, true, true};
+    private boolean[] hudElements = new boolean[]{true, true, true, true, true, true, true, true};
     private boolean dualSeriesBattery = false;
     private boolean frametimeNumericMode = false;
     private boolean hudCardExpanded = false;
@@ -4632,14 +4632,16 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     hudBackgroundTransparency = clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA);
                 }
                 hudScale = (float) obj.optDouble("scale", 1.0);
+                boolean legacyCpuRam = obj.optBoolean("showCpuRam", true);
+                boolean legacyBattTemp = obj.optBoolean("showBattTemp", true);
                 hudElements[0] = obj.optBoolean("showFPS", true);
                 hudElements[1] = obj.optBoolean("showRenderer", true);
                 hudElements[2] = obj.optBoolean("showGPU", true);
-                boolean legacyCpuRam = obj.optBoolean("showCpuRam", true);
                 hudElements[3] = obj.optBoolean("showCPU", legacyCpuRam);
                 hudElements[4] = obj.optBoolean("showRAM", legacyCpuRam);
-                hudElements[5] = obj.optBoolean("showBattTemp", true);
-                hudElements[6] = obj.optBoolean("showGraph", true);
+                hudElements[5] = obj.optBoolean("showBattery", legacyBattTemp);
+                hudElements[6] = obj.optBoolean("showTemp", legacyBattTemp);
+                hudElements[7] = obj.optBoolean("showGraph", true);
             } catch (JSONException e) {
                 Log.e("XServerDisplayActivity", "Failed to load HUD settings", e);
             }
@@ -4659,8 +4661,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             obj.put("showGPU", hudElements[2]);
             obj.put("showCPU", hudElements[3]);
             obj.put("showRAM", hudElements[4]);
-            obj.put("showBattTemp", hudElements[5]);
-            obj.put("showGraph", hudElements[6]);
+            obj.put("showBattery", hudElements[5]);
+            obj.put("showTemp", hudElements[6]);
+            obj.put("showGraph", hudElements[7]);
             container.putExtra("hudSettings", obj.toString());
             container.saveData();
         } catch (JSONException e) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3894,9 +3894,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onHUDBackgroundAlphaDecoupledChanged(boolean enabled) {
                         hudBackgroundAlphaDecoupled = enabled;
-                        if (!enabled) {
-                            hudBackgroundTransparency = clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA);
-                        }
+                        hudBackgroundTransparency = clampHudAlpha(hudTransparency * FrameRating.BACKDROP_BASE_ALPHA);
                         if (frameRating != null) {
                             frameRating.setHudBackgroundAlpha(hudBackgroundTransparency);
                             frameRating.setBackgroundAlphaDecoupled(enabled);

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -207,6 +207,7 @@ private enum class HUDMetricEditor(
 ) {
     ALPHA(minPercent = 10, maxPercent = 100),
     SCALE(minPercent = 30, maxPercent = 200),
+    BACKGROUND_ALPHA(minPercent = 10, maxPercent = 100),
 }
 
 internal enum class DrawerPane { INPUT_CONTROLS, HUD, GYROSCOPE, SCREEN_EFFECTS, TASK_MANAGER, LOGS }
@@ -302,6 +303,8 @@ data class XServerDrawerItem(
 data class XServerDrawerState(
     val items: List<XServerDrawerItem>,
     val hudTransparency: Float = 1.0f,
+    val hudBackgroundAlphaEnabled: Boolean = false,
+    val hudBackgroundTransparency: Float = 1.0f,
     val hudScale: Float = 1.0f,
     val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true),
     val dualSeriesBatteryEnabled: Boolean = false,
@@ -465,6 +468,10 @@ interface XServerDrawerActionListener {
 
     fun onHUDTransparencyChanged(transparency: Float)
 
+    fun onHUDBackgroundAlphaDecoupledChanged(enabled: Boolean)
+
+    fun onHUDBackgroundTransparencyChanged(transparency: Float)
+
     fun onHUDScaleChanged(scale: Float)
 
     fun onDualSeriesBatteryChanged(enabled: Boolean)
@@ -568,6 +575,8 @@ fun buildXServerDrawerState(
     magnifierActive: Boolean,
     showLogs: Boolean,
     hudTransparency: Float = 1.0f,
+    hudBackgroundAlphaEnabled: Boolean = false,
+    hudBackgroundTransparency: Float = 1.0f,
     hudScale: Float = 1.0f,
     hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true),
     dualSeriesBatteryEnabled: Boolean = false,
@@ -738,6 +747,8 @@ fun buildXServerDrawerState(
     return XServerDrawerState(
         items = items,
         hudTransparency = hudTransparency,
+        hudBackgroundAlphaEnabled = hudBackgroundAlphaEnabled,
+        hudBackgroundTransparency = hudBackgroundTransparency,
         hudScale = hudScale,
         hudElements = hudElements,
         dualSeriesBatteryEnabled = dualSeriesBatteryEnabled,
@@ -1511,6 +1522,7 @@ private fun HUDPaneContent(
             initialPercent =
                 when (editor) {
                     HUDMetricEditor.ALPHA -> (state.hudTransparency * 100).roundToInt()
+                    HUDMetricEditor.BACKGROUND_ALPHA -> (state.hudBackgroundTransparency * 100).roundToInt()
                     HUDMetricEditor.SCALE -> (state.hudScale * 100).roundToInt()
                 },
             onDismiss = { activeEditor = null },
@@ -1519,6 +1531,9 @@ private fun HUDPaneContent(
                 when (editor) {
                     HUDMetricEditor.ALPHA -> {
                         listener.onHUDTransparencyChanged(enteredPercent.coerceIn(editor.minPercent, editor.maxPercent) / 100f)
+                    }
+                    HUDMetricEditor.BACKGROUND_ALPHA -> {
+                        listener.onHUDBackgroundTransparencyChanged(enteredPercent.coerceIn(editor.minPercent, editor.maxPercent) / 100f)
                     }
                     HUDMetricEditor.SCALE -> {
                         listener.onHUDScaleChanged(enteredPercent.coerceIn(editor.minPercent, editor.maxPercent) / 100f)
@@ -1551,10 +1566,22 @@ private fun HUDPaneContent(
                     valueText = "${(state.hudTransparency * 100).toInt()}%",
                     value = state.hudTransparency,
                     valueRange = 0.1f..1f,
-                    steps = 8,
+                    steps = 17,
                     onValueClick = { activeEditor = HUDMetricEditor.ALPHA },
-                    onValueChange = { listener.onHUDTransparencyChanged(it.snapToStep(0.1f, 0.1f, 1f)) },
+                    onValueChange = { listener.onHUDTransparencyChanged(it.snapToStep(0.05f, 0.1f, 1f)) },
                 )
+
+                if (state.hudBackgroundAlphaEnabled) {
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_hud_background),
+                        valueText = "${(state.hudBackgroundTransparency * 100).toInt()}%",
+                        value = state.hudBackgroundTransparency,
+                        valueRange = 0.1f..1f,
+                        steps = 17,
+                        onValueClick = { activeEditor = HUDMetricEditor.BACKGROUND_ALPHA },
+                        onValueChange = { listener.onHUDBackgroundTransparencyChanged(it.snapToStep(0.05f, 0.1f, 1f)) },
+                    )
+                }
 
                 DrawerSliderRow(
                     label = stringResource(R.string.session_drawer_hud_scale),
@@ -1564,6 +1591,12 @@ private fun HUDPaneContent(
                     steps = 16,
                     onValueClick = { activeEditor = HUDMetricEditor.SCALE },
                     onValueChange = { listener.onHUDScaleChanged(it.snapToStep(0.1f, 0.3f, 2.0f)) },
+                )
+
+                DrawerBooleanRow(
+                    title = stringResource(R.string.session_drawer_hud_background_alpha),
+                    checked = state.hudBackgroundAlphaEnabled,
+                    onCheckedChange = listener::onHUDBackgroundAlphaDecoupledChanged,
                 )
 
                 Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
@@ -4065,6 +4098,7 @@ private fun HUDMetricInputDialog(
         title =
             when (editor) {
                 HUDMetricEditor.ALPHA -> stringResource(R.string.session_drawer_hud_alpha_input_title)
+                HUDMetricEditor.BACKGROUND_ALPHA -> stringResource(R.string.session_drawer_hud_background_alpha_input_title)
                 HUDMetricEditor.SCALE -> stringResource(R.string.session_drawer_hud_scale_input_title)
             },
         maxWidth = 380.dp,

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -306,7 +306,7 @@ data class XServerDrawerState(
     val hudBackgroundAlphaEnabled: Boolean = false,
     val hudBackgroundTransparency: Float = 1.0f,
     val hudScale: Float = 1.0f,
-    val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true),
+    val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true),
     val dualSeriesBatteryEnabled: Boolean = false,
     val frametimeNumericEnabled: Boolean = false,
     val hudCardExpanded: Boolean = false,
@@ -578,7 +578,7 @@ fun buildXServerDrawerState(
     hudBackgroundAlphaEnabled: Boolean = false,
     hudBackgroundTransparency: Float = 1.0f,
     hudScale: Float = 1.0f,
-    hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true),
+    hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true),
     dualSeriesBatteryEnabled: Boolean = false,
     frametimeNumericEnabled: Boolean = false,
     hudCardExpanded: Boolean = false,
@@ -1511,8 +1511,10 @@ private fun HUDPaneContent(
             stringResource(R.string.session_drawer_hud_element_cpu),
             stringResource(R.string.session_drawer_hud_element_ram),
             stringResource(R.string.session_drawer_hud_element_battery),
+            stringResource(R.string.session_drawer_hud_element_temp),
             stringResource(R.string.session_drawer_hud_element_graph),
         )
+    val elementOrder = listOf(1, 2, 3, 4, 5, 6, 0, 7)
     val active =
         state.items.firstOrNull { it.itemId == R.id.main_menu_fps_monitor }?.active ?: false
 
@@ -1614,9 +1616,9 @@ private fun HUDPaneContent(
                 Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
                     PaneSectionLabel(stringResource(R.string.session_drawer_hud_elements))
                     ChipFlow {
-                        elementNames.forEachIndexed { index, name ->
+                        elementOrder.forEach { index ->
                             HUDToggleChip(
-                                label = name,
+                                label = elementNames[index],
                                 checked = state.hudElements[index],
                                 onClick = { listener.onHUDElementToggled(index, !state.hudElements[index]) },
                             )

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -1599,6 +1599,18 @@ private fun HUDPaneContent(
                     onCheckedChange = listener::onHUDBackgroundAlphaDecoupledChanged,
                 )
 
+                DrawerBooleanRow(
+                    title = stringResource(R.string.session_drawer_hud_frametime_numeric),
+                    checked = state.frametimeNumericEnabled,
+                    onCheckedChange = listener::onFrametimeNumericChanged,
+                )
+
+                FPSLimiterCard(
+                    currentLimit = state.fpsLimit,
+                    maxRefreshRate = state.maxRefreshRate,
+                    onLimitChanged = listener::onFPSLimitChanged,
+                )
+
                 Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
                     PaneSectionLabel(stringResource(R.string.session_drawer_hud_elements))
                     ChipFlow {
@@ -1613,21 +1625,9 @@ private fun HUDPaneContent(
                 }
 
                 DrawerBooleanRow(
-                    title = stringResource(R.string.session_drawer_hud_frametime_numeric),
-                    checked = state.frametimeNumericEnabled,
-                    onCheckedChange = listener::onFrametimeNumericChanged,
-                )
-
-                DrawerBooleanRow(
                     title = stringResource(R.string.session_drawer_dual_series_battery),
                     checked = state.dualSeriesBatteryEnabled,
                     onCheckedChange = listener::onDualSeriesBatteryChanged,
-                )
-
-                FPSLimiterCard(
-                    currentLimit = state.fpsLimit,
-                    maxRefreshRate = state.maxRefreshRate,
-                    onLimitChanged = listener::onFPSLimitChanged,
                 )
             }
             }

--- a/app/src/main/runtime/display/ui/FrameRating.java
+++ b/app/src/main/runtime/display/ui/FrameRating.java
@@ -97,7 +97,8 @@ public class FrameRating extends LinearLayout implements Runnable {
   private volatile int cpuPercent;
   private volatile int cpuTemp;
   private volatile float currentMs;
-  private boolean enableBattTemp;
+  private boolean enableBatt;
+  private boolean enableTemp;
   private boolean enableCpu;
   private boolean enableRam;
   private boolean enableFps;
@@ -210,7 +211,8 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.enableGpu = true;
     this.enableCpu = true;
     this.enableRam = true;
-    this.enableBattTemp = true;
+    this.enableBatt = true;
+    this.enableTemp = true;
     this.enableRenderer = true;
     this.cpuPercent = -1;
     this.gpuLoad = -1;
@@ -1106,11 +1108,14 @@ public class FrameRating extends LinearLayout implements Runnable {
         if (this.tvRam != null) this.tvRam.setVisibility(v);
         break;
       case 5:
-        this.enableBattTemp = visible;
+        this.enableBatt = visible;
         if (this.tvBat != null) this.tvBat.setVisibility(v);
-        if (this.tvTemp != null) this.tvTemp.setVisibility(v);
         break;
       case 6:
+        this.enableTemp = visible;
+        if (this.tvTemp != null) this.tvTemp.setVisibility(v);
+        break;
+      case 7:
         this.enableGraph = visible;
         applyFrametimeDisplayVisibility();
         break;
@@ -1375,7 +1380,7 @@ public class FrameRating extends LinearLayout implements Runnable {
         this.ramText = "N/A";
       }
     }
-    if (this.enableBattTemp && this.canReadBatt) {
+    if ((this.enableBatt || this.enableTemp) && this.canReadBatt) {
       try {
         float amps = getBatteryCurrentAmps();
         Intent intent =
@@ -1443,46 +1448,43 @@ public class FrameRating extends LinearLayout implements Runnable {
       this.tvRam.setVisibility(View.GONE);
     }
 
-    if (this.enableBattTemp) {
-      if (this.tvBat != null) {
-        float displayedBatteryWatts =
-            this.batteryWatts >= 0.0f && this.dualSeriesBattery
-                ? this.batteryWatts * 2.0f
-                : this.batteryWatts;
-        SpannableStringBuilder b = new SpannableStringBuilder();
-        append(b, "BAT ", this.C_BAT);
-        // While charging, prefix the live wattage with an outlined plug glyph
-        // instead of the old "CHRG" placeholder text.
-        if (this.isCharging) {
-          appendPlugIcon(b);
-        }
-        append(
-            b,
-            displayedBatteryWatts >= 0.0f
-                ? String.format(Locale.US, "%.1fw", displayedBatteryWatts)
-                : "N/A",
-            this.C_VALUE);
-        this.tvBat.setText(b);
-        this.tvBat.setVisibility(View.VISIBLE);
+    if (this.enableBatt && this.tvBat != null) {
+      float displayedBatteryWatts =
+          this.batteryWatts >= 0.0f && this.dualSeriesBattery
+              ? this.batteryWatts * 2.0f
+              : this.batteryWatts;
+      SpannableStringBuilder b = new SpannableStringBuilder();
+      append(b, "BAT ", this.C_BAT);
+      if (this.isCharging) {
+        appendPlugIcon(b);
       }
-      if (this.tvTemp != null) {
-        SpannableStringBuilder b = new SpannableStringBuilder();
-        append(b, "TMP ", this.C_TEMP);
-        if (this.cpuTemp >= 0) {
-          // Battery temperature: amber in the warm range, red once hot.
-          int tempColor =
-              this.cpuTemp >= 45 ? this.C_HOT : this.cpuTemp >= 40 ? this.C_WARM : this.C_VALUE;
-          append(b, this.cpuTemp + "°", tempColor);
-          appendSmall(b, "C", tempColor, 0.7f);
-        } else {
-          append(b, "N/A", this.C_VALUE);
-        }
-        this.tvTemp.setText(b);
-        this.tvTemp.setVisibility(View.VISIBLE);
+      append(
+          b,
+          displayedBatteryWatts >= 0.0f
+              ? String.format(Locale.US, "%.1fw", displayedBatteryWatts)
+              : "N/A",
+          this.C_VALUE);
+      this.tvBat.setText(b);
+      this.tvBat.setVisibility(View.VISIBLE);
+    } else if (this.tvBat != null) {
+      this.tvBat.setVisibility(View.GONE);
+    }
+
+    if (this.enableTemp && this.tvTemp != null) {
+      SpannableStringBuilder b = new SpannableStringBuilder();
+      append(b, "TMP ", this.C_TEMP);
+      if (this.cpuTemp >= 0) {
+        int tempColor =
+            this.cpuTemp >= 45 ? this.C_HOT : this.cpuTemp >= 40 ? this.C_WARM : this.C_VALUE;
+        append(b, this.cpuTemp + "°", tempColor);
+        appendSmall(b, "C", tempColor, 0.7f);
+      } else {
+        append(b, "N/A", this.C_VALUE);
       }
-    } else {
-      if (this.tvBat != null) this.tvBat.setVisibility(View.GONE);
-      if (this.tvTemp != null) this.tvTemp.setVisibility(View.GONE);
+      this.tvTemp.setText(b);
+      this.tvTemp.setVisibility(View.VISIBLE);
+    } else if (this.tvTemp != null) {
+      this.tvTemp.setVisibility(View.GONE);
     }
 
     if (this.enableFps && this.tvFpsBig != null) {

--- a/app/src/main/runtime/display/ui/FrameRating.java
+++ b/app/src/main/runtime/display/ui/FrameRating.java
@@ -176,6 +176,11 @@ public class FrameRating extends LinearLayout implements Runnable {
   private int displayMode = 0;
   private static final int MODE_COUNT = 4;
   private GradientDrawable backdropDrawable;
+  private static final int BACKDROP_BASE_COLOR = 0xA6000000;
+  public static final float BACKDROP_BASE_ALPHA = ((BACKDROP_BASE_COLOR >>> 24) & 0xFF) / 255f;
+  private boolean bgAlphaDecoupled = false;
+  private float readoutAlpha = 1.0f;
+  private float backgroundAlpha = 1.0f;
   // Outlined plug glyph shown next to the battery wattage while charging (lazily loaded + tinted).
   private Drawable plugIcon;
   private boolean dualSeriesBattery;
@@ -272,7 +277,7 @@ public class FrameRating extends LinearLayout implements Runnable {
 
     // Create backdrop drawable (rounded, semi-transparent black)
     this.backdropDrawable = new GradientDrawable();
-    this.backdropDrawable.setColor(0xA6000000); // 65% black
+    this.backdropDrawable.setColor(BACKDROP_BASE_COLOR);
     this.backdropDrawable.setCornerRadius(8f);
 
     loadPersistedHudPreferences();
@@ -1006,7 +1011,37 @@ public class FrameRating extends LinearLayout implements Runnable {
   }
 
   public void setHudAlpha(float alpha) {
-    setAlpha(alpha);
+    this.readoutAlpha = alpha;
+    applyAlpha();
+  }
+
+  public void setHudBackgroundAlpha(float alpha) {
+    this.backgroundAlpha = alpha;
+    applyAlpha();
+  }
+
+  public void setBackgroundAlphaDecoupled(boolean decoupled) {
+    this.bgAlphaDecoupled = decoupled;
+    applyAlpha();
+  }
+
+  private void applyAlpha() {
+    if (bgAlphaDecoupled) {
+      setAlpha(1.0f);
+      setChildrenAlpha(readoutAlpha);
+      int a = Math.max(0, Math.min(255, Math.round(backgroundAlpha * 255f)));
+      backdropDrawable.setColor((a << 24) | (BACKDROP_BASE_COLOR & 0x00FFFFFF));
+    } else {
+      setChildrenAlpha(1.0f);
+      backdropDrawable.setColor(BACKDROP_BASE_COLOR);
+      setAlpha(readoutAlpha);
+    }
+  }
+
+  private void setChildrenAlpha(float alpha) {
+    for (int i = 0; i < getChildCount(); i++) {
+      getChildAt(i).setAlpha(alpha);
+    }
   }
 
   public void setHudScale(float scale) {


### PR DESCRIPTION
Add a Background Alpha toggle in the HUD drawer pane. Off (default) keeps the single Alpha slider driving the whole HUD as before. On reveals a second Background slider: readout alpha applies per text child, backdrop alpha applies to the backdrop drawable, controlled independently. On enable the Background slider starts at the current effective backdrop opacity (readout x 0.651) so there is no visual jump; on disable it relinks to the Alpha value. Alpha sliders now step in 5% increments. Persisted per container.