### PR TITLE
Fix: preserve user custom library artwork across launch/refresh

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -9452,6 +9452,8 @@ class UnifiedActivity :
                 content.append("launch_exe_path=${detectedLaunchExecutable}\n")
                 content.append("use_container_defaults=1\n")
 
+                appendPreservedArtworkExtras(content, shortcutFile)
+
                 com.winlator.cmod.shared.io.FileUtils
                     .writeString(shortcutFile, content.toString())
 
@@ -9464,6 +9466,30 @@ class UnifiedActivity :
                 withContext(Dispatchers.Main) {
                     launchGame(context, intent)
                 }
+            }
+        }
+    }
+
+    // Carry over user artwork / identity extras when regenerating an existing .desktop.
+    private fun appendPreservedArtworkExtras(
+        content: StringBuilder,
+        shortcutFile: java.io.File,
+    ) {
+        if (!shortcutFile.exists()) return
+        val preserve =
+            setOf(
+                "uuid", "customCoverArtPath", "customLibraryIconPath",
+                "customLibraryHeroArtPath", "customLibraryGridArtPath",
+                "customLibraryCarouselArtPath", "customLibraryListArtPath", "iconExtracted",
+            )
+        var inExtra = false
+        for (line in com.winlator.cmod.shared.io.FileUtils.readLines(shortcutFile)) {
+            if (line.contains("[Extra Data]")) {
+                inExtra = true
+                continue
+            }
+            if (inExtra && line.substringBefore("=", "").trim() in preserve) {
+                content.append(line).append("\n")
             }
         }
     }
@@ -9664,6 +9690,8 @@ class UnifiedActivity :
                 }
                 content.append("use_container_defaults=1\n")
 
+                appendPreservedArtworkExtras(content, shortcutFile)
+
                 com.winlator.cmod.shared.io.FileUtils
                     .writeString(shortcutFile, content.toString())
 
@@ -9860,6 +9888,7 @@ class UnifiedActivity :
                 }
                 content.append("use_container_defaults=1\n")
 
+            appendPreservedArtworkExtras(content, shortcutFile)
             com.winlator.cmod.shared.io.FileUtils
                 .writeString(shortcutFile, content.toString())
             container.saveData()

--- a/app/src/main/runtime/container/Shortcut.java
+++ b/app/src/main/runtime/container/Shortcut.java
@@ -142,6 +142,14 @@ public class Shortcut {
     }
   }
 
+  private boolean hasUserCustomArt() {
+    return !getExtra("customLibraryIconPath").isEmpty()
+        || !getExtra("customLibraryHeroArtPath").isEmpty()
+        || !getExtra("customLibraryGridArtPath").isEmpty()
+        || !getExtra("customLibraryCarouselArtPath").isEmpty()
+        || !getExtra("customLibraryListArtPath").isEmpty();
+  }
+
   private void loadCoverArt() {
     // 1. Check if we already have a saved path in the metadata
     if (customCoverArtPath != null && !customCoverArtPath.isEmpty()) {
@@ -163,19 +171,20 @@ public class Shortcut {
       return;
     }
 
-    // 3. SMART AUTO-DISCOVERY
-    // We use the EXE path (this.path) to find the game on your Android storage
-    ImageFs imageFs = ImageFs.find(container.getManager().getContext());
-    File exeFile = com.winlator.cmod.runtime.wine.WineUtils.getNativePath(this.container, imageFs, this.path);
+    // 3. Auto-extract the EXE icon once at import; skip if user set custom art.
+    if (!hasUserCustomArt() && !"1".equals(getExtra("iconExtracted"))) {
+      ImageFs imageFs = ImageFs.find(container.getManager().getContext());
+      File exeFile = com.winlator.cmod.runtime.wine.WineUtils.getNativePath(this.container, imageFs, this.path);
 
-    if (exeFile != null && exeFile.exists()) {
-      // A. Try extracting the real high-quality icon from the EXE
-      if (PeIconExtractor.INSTANCE.extractAndSave(exeFile, customIconFile)) {
-        this.coverArt = BitmapFactory.decodeFile(customIconFile.getPath());
-        this.customCoverArtPath = customIconFile.getAbsolutePath();
-        putExtra("customCoverArtPath", customCoverArtPath);
-        saveData(); // Save it to the file so we don't have to extract it again
-        return;
+      if (exeFile != null && exeFile.exists()) {
+        if (PeIconExtractor.INSTANCE.extractAndSave(exeFile, customIconFile)) {
+          this.coverArt = BitmapFactory.decodeFile(customIconFile.getPath());
+          this.customCoverArtPath = customIconFile.getAbsolutePath();
+          putExtra("customCoverArtPath", customCoverArtPath);
+          putExtra("iconExtracted", "1");
+          saveData();
+          return;
+        }
       }
     }
 

--- a/app/src/main/runtime/wine/MSLink.java
+++ b/app/src/main/runtime/wine/MSLink.java
@@ -256,9 +256,31 @@ public abstract class MSLink {
         new File(lnkFilePath.substring(0, lnkFilePath.lastIndexOf(".")) + ".desktop");
     String name = lnkFile.getName().substring(0, lnkFile.getName().lastIndexOf("."));
 
-    // Smart Discovery (Synchronized like main):
+    // Preserve user artwork / identity extras so regeneration never wipes a custom picture.
+    java.util.Map<String, String> existingExtras = new java.util.LinkedHashMap<>();
+    if (desktopFile.exists()) {
+      boolean inExtra = false;
+      for (String line : com.winlator.cmod.shared.io.FileUtils.readLines(desktopFile)) {
+        if (line.contains("[Extra Data]")) {
+          inExtra = true;
+          continue;
+        }
+        if (!inExtra) continue;
+        int eq = line.indexOf('=');
+        if (eq > 0) existingExtras.put(line.substring(0, eq).trim(), line.substring(eq + 1));
+      }
+    }
+    boolean hasCustomArt =
+        existingExtras.containsKey("customCoverArtPath")
+            || existingExtras.containsKey("customLibraryIconPath")
+            || existingExtras.containsKey("customLibraryHeroArtPath")
+            || existingExtras.containsKey("customLibraryGridArtPath")
+            || existingExtras.containsKey("customLibraryCarouselArtPath")
+            || existingExtras.containsKey("customLibraryListArtPath");
+
+    // Extract the EXE icon only when no custom art exists yet.
     String customLibraryIconPath = "";
-    if (exeFile != null && exeFile.exists()) {
+    if (!hasCustomArt && exeFile != null && exeFile.exists()) {
       String safeName =
           lnkFile
               .getName()
@@ -310,7 +332,17 @@ public abstract class MSLink {
         pw.write("launch_exe_path=" + windowsPath + "\n");
       }
       
-      if (!customLibraryIconPath.isEmpty()) {
+      // Re-emit preserved extras (art, identity, per-game settings) not rewritten above.
+      java.util.Set<String> written =
+          new java.util.HashSet<>(
+              java.util.Arrays.asList(
+                  "game_source", "custom_name", "use_container_defaults", "container_id",
+                  "custom_exe", "launch_exe_path", "custom_game_folder"));
+      for (java.util.Map.Entry<String, String> e : existingExtras.entrySet()) {
+        if (!written.contains(e.getKey())) pw.write(e.getKey() + "=" + e.getValue() + "\n");
+      }
+
+      if (!customLibraryIconPath.isEmpty() && !existingExtras.containsKey("customCoverArtPath")) {
         pw.write("customCoverArtPath=" + customLibraryIconPath + "\n");
       }
       return true;


### PR DESCRIPTION
- loadCoverArt: extract EXE icon only at first import; skip when custom art set (iconExtracted flag)
- Steam/Epic/GOG launch: keep art + identity extras when regenerating .desktop on lookup-miss
- MSLink.createDesktopFile: preserve existing [Extra Data]; don't re-extract over custom art