### PR TITLE
fix: Swizzle AHB GPUImages red and blue channels when BGRA8 is expected but buffer is RGBA8

### DIFF
--- a/app/src/main/cpp/winlator/vk/vk_image.c
+++ b/app/src/main/cpp/winlator/vk/vk_image.c
@@ -1213,11 +1213,15 @@ VkTexture* vkr_texture_import_ahb(VkRenderer* r, AHardwareBuffer* ahb, bool tran
     if (t->ycbcr != VK_NULL_HANDLE) {
         vi.components = format_props.samplerYcbcrConversionComponents;
     } else {
-        vi.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+        // fixes devices that supports vulkan bgra8 format, but doesn't support bgra8 ahb images
+        bool swizzle_rb = format_props.format == VK_FORMAT_R8G8B8A8_UNORM
+            && r->caps.upload_format == VK_FORMAT_B8G8R8A8_UNORM;
+        vi.components.r = swizzle_rb ? VK_COMPONENT_SWIZZLE_B : VK_COMPONENT_SWIZZLE_IDENTITY;
         vi.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
-        vi.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+        vi.components.b = swizzle_rb ? VK_COMPONENT_SWIZZLE_R : VK_COMPONENT_SWIZZLE_IDENTITY;
         vi.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
     }
+
     vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     vi.subresourceRange.levelCount = 1;
     vi.subresourceRange.layerCount = 1;


### PR DESCRIPTION
Fixes inverted red and blue colors on devices that supports Vulkan BGRA8 format but doesn't support BGRA8 on AHB Images.
This pr is swizzling red and blue channels on AHB Images with format RGBA8 when the expected format is BGRA8.

Test device was a Samsung A15 4g (mali g57 mc2 gpu) while playing Skyrim LE