### PR TITLE
Stop forcing VKD3D_SHADER_MODEL 

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -2230,47 +2230,6 @@ private fun ComponentsSection(
 private fun findKnownEnvVar(name: String): Array<String>? =
     EnvVarsView.knownEnvVars.firstOrNull { it[0] == name }
 
-// WINEESYNC and WINENTSYNC cannot both be enabled. When the user turns one on,
-// flip the other off if it is currently on. If both are set to off (0),
-// default WINEESYNC to on (1) as the fallback.
-private fun applyExclusiveSync(
-    list: MutableList<EnvVarItem>,
-    changedKey: String,
-    newValue: String
-) {
-    if (changedKey != "WINEESYNC" && changedKey != "WINENTSYNC") return
-
-    val isOnNow = newValue == "1" || newValue.equals("true", ignoreCase = true)
-    val sibling = if (changedKey == "WINEESYNC") "WINENTSYNC" else "WINEESYNC"
-    val sIdx = list.indexOfFirst { it.key == sibling }
-
-    if (isOnNow) {
-        // If turning ON, turn OFF the sibling
-        if (sIdx >= 0) {
-            list[sIdx] = EnvVarItem(sibling, "0")
-        }
-    } else {
-        // If turning OFF, check if both are now OFF
-        val siblingIsOn = if (sIdx >= 0) {
-            val sValue = list[sIdx].value
-            sValue == "1" || sValue.equals("true", ignoreCase = true)
-        } else false
-
-        if (!siblingIsOn) {
-            // Both are OFF -> default ESYNC to ON
-            val eIdx = list.indexOfFirst { it.key == "WINEESYNC" }
-            if (eIdx >= 0) {
-                list[eIdx] = EnvVarItem("WINEESYNC", "1")
-            } else {
-                list.add(EnvVarItem("WINEESYNC", "1"))
-            }
-            // If the sibling was NTSYNC and we just added/updated ESYNC, ensure NTSYNC is definitely OFF
-            val nIdx = list.indexOfFirst { it.key == "WINENTSYNC" }
-            if (nIdx >= 0) list[nIdx] = EnvVarItem("WINENTSYNC", "0")
-        }
-    }
-}
-
 @Composable
 private fun VariablesSection(
     state: GameSettingsStateHolder,
@@ -2292,9 +2251,6 @@ private fun VariablesSection(
             changed = true
         }
         if (changed) {
-            // Run exclusivity check to handle cases where both might have been added at once
-            val esyncValue = current.find { it.key == "WINEESYNC" }?.value ?: "1"
-            applyExclusiveSync(current, "WINEESYNC", esyncValue)
             state.envVars.value = current
         }
     }
@@ -2338,14 +2294,12 @@ private fun VariablesSection(
                             state.envVars.value.none { it.key == normalizedKey }
                         if (index in list.indices && isUnique) {
                             list[index] = EnvVarItem(normalizedKey, envVar.value)
-                            applyExclusiveSync(list, normalizedKey, envVar.value)
                             state.envVars.value = list
                         }
                     },
                     onValueChange = { v ->
                         val list = state.envVars.value.toMutableList()
                         list[index] = EnvVarItem(envVar.key, v)
-                        applyExclusiveSync(list, envVar.key, v)
                         state.envVars.value = list
                     },
                     onRemove = { callbacks.onRemoveEnvVar(index) }

--- a/app/src/main/runtime/container/Container.java
+++ b/app/src/main/runtime/container/Container.java
@@ -637,7 +637,7 @@ public class Container {
                 if (appVersion < 16) {
                     EnvVars defaultEnvVars = new EnvVars(DEFAULT_ENV_VARS);
                     EnvVars envVars = new EnvVars(data.getString("envVars"));
-                    for (String name : defaultEnvVars) if (!envVars.has(name)) envVars.put(name, defaultEnvVars.get(name));
+                    for (String name : defaultEnvVars) if (!name.equals("VKD3D_SHADER_MODEL") && !envVars.has(name)) envVars.put(name, defaultEnvVars.get(name));
                     data.put("envVars", envVars.toString());
                 }
             }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -7999,66 +7999,30 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
     }
 
-    private boolean canAccessNtsyncDevice() {
-        java.io.File ntsyncDev = new java.io.File("/dev/ntsync");
-        if (!ntsyncDev.exists()) {
-            Log.d("XServerDisplayActivity", "NTSync: /dev/ntsync does not exist");
-            return false;
-        }
-        try (java.io.FileInputStream fis = new java.io.FileInputStream(ntsyncDev)) {
-            Log.d("XServerDisplayActivity", "NTSync: /dev/ntsync is accessible");
-            return true;
-        } catch (Exception e) {
-            Log.d("XServerDisplayActivity", "NTSync: /dev/ntsync exists but is not accessible: " + e.getMessage());
-            return false;
-        }
-    }
-
     private void normalizeSyncEnvVars(com.winlator.cmod.runtime.wine.EnvVars envVars) {
-        boolean esyncExplicit = "1".equals(envVars.get("WINEESYNC"));
-        boolean ntSyncExplicit = "1".equals(envVars.get("WINENTSYNC"))
-                || "1".equals(envVars.get("PROTON_USE_NTSYNC"));
-
         envVars.remove("WINEFSYNC");
         envVars.put("PROTON_NO_FSYNC", "1");
 
-        if (esyncExplicit && !ntSyncExplicit) {
+        String esyncVal = envVars.get("WINEESYNC");
+        boolean esyncOff = "0".equals(esyncVal) || "false".equalsIgnoreCase(esyncVal);
+        boolean ntSync = "1".equals(envVars.get("WINENTSYNC"))
+                || "1".equals(envVars.get("PROTON_USE_NTSYNC"));
+
+        if (ntSync) {
+            envVars.put("WINENTSYNC", "1");
+            envVars.put("PROTON_USE_NTSYNC", "1");
+        } else {
             envVars.remove("WINENTSYNC");
             envVars.remove("PROTON_USE_NTSYNC");
+        }
+
+        if (esyncOff) {
+            envVars.remove("WINEESYNC");
+            envVars.remove("WINEESYNC_WINLATOR");
+            envVars.put("PROTON_NO_ESYNC", "1");
+        } else {
             envVars.put("WINEESYNC", "1");
             envVars.remove("PROTON_NO_ESYNC");
-            Log.d("XServerDisplayActivity",
-                    "Sync: user selected ESync — using ESync, skipping NTSync detection");
-            return;
-        }
-
-        if (canAccessNtsyncDevice()) {
-            String ntVal = envVars.get("WINENTSYNC");
-            boolean ntDisabled = "0".equals(ntVal) || "false".equalsIgnoreCase(ntVal);
-
-            if (!ntDisabled) {
-                envVars.put("WINENTSYNC", "1");
-                envVars.put("PROTON_USE_NTSYNC", "1");
-                envVars.remove("WINEESYNC");
-                envVars.remove("WINEESYNC_WINLATOR");
-                envVars.remove("PROTON_USE_ESYNC");
-                envVars.put("PROTON_NO_ESYNC", "1");
-                Log.d("XServerDisplayActivity",
-                        "Sync: NTSync enabled (/dev/ntsync accessible) — disabled ESync");
-                return;
-            }
-        }
-
-        envVars.remove("WINENTSYNC");
-        envVars.remove("PROTON_USE_NTSYNC");
-        envVars.put("WINEESYNC", "1");
-        envVars.remove("PROTON_NO_ESYNC");
-        if (ntSyncExplicit) {
-            Log.w("XServerDisplayActivity",
-                    "Sync: NTSync requested but /dev/ntsync not accessible or disabled — falling back to ESync");
-        } else {
-            Log.d("XServerDisplayActivity",
-                    "Sync: NTSync not available or disabled — using ESync");
         }
     }
 

--- a/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/runtime/display/environment/components/GuestProgramLauncherComponent.java
@@ -219,7 +219,7 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
       envVars.put("LD_PRELOAD", ldPreload.toString());
       Log.d("GuestLauncher", "execShellCommand LD_PRELOAD=" + ldPreload.toString());
     }
-    envVars.put("WINEESYNC_WINLATOR", "1");
+    if (!"1".equals(envVars.get("PROTON_NO_ESYNC"))) envVars.put("WINEESYNC_WINLATOR", "1");
     mergeExternalEnvVars(
         envVars,
         envVars.get("LD_PRELOAD"),


### PR DESCRIPTION
VKD3D_SHADER_MODEL stays a creation default but is excluded from the appVersion<16 default merge-back so deleting it sticks. ESync/NTSync are now independent toggles: removed applyExclusiveSync linking, rewrote normalizeSyncEnvVars to honor each toggle (ESync defaults on, honored off on explicit 0; FSync handling unchanged), 