### PR TITLE
feat(steam): Launch Options selector in the STEAM dropdown

### DIFF
--- a/app/src/main/app/shell/StoreGameDetailScreen.kt
+++ b/app/src/main/app/shell/StoreGameDetailScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.FactCheck
 import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.CloudSync
 import androidx.compose.material.icons.outlined.Construction
 import androidx.compose.material.icons.outlined.Delete
@@ -57,6 +58,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.RocketLaunch
 import androidx.compose.material.icons.outlined.SportsEsports
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.SystemUpdate
@@ -113,6 +115,13 @@ internal data class StoreDlcItem(
     val isInstalled: Boolean = false,
 )
 
+internal data class StoreLaunchOptionItem(
+    // Relative path, '/'-separated (appinfo config.launch entry).
+    val executable: String,
+    val arguments: String,
+    val label: String,
+)
+
 private val StoreBlack = Color.Black
 private val StoreCard = Color(0xFF12121B)
 private val StoreAccent = Color(0xFF1A9FFF)
@@ -149,6 +158,9 @@ internal fun StoreGameDetailScreen(
     showWorkshop: Boolean = false,
     showVerifyFiles: Boolean = false,
     areSteamActionsEnabled: Boolean = true,
+    launchOptions: List<StoreLaunchOptionItem> = emptyList(),
+    selectedLaunchOption: StoreLaunchOptionItem? = null,
+    onSelectLaunchOption: (StoreLaunchOptionItem) -> Unit = {},
     dlcs: List<StoreDlcItem> = emptyList(),
     selectedDlcIds: Set<Int> = emptySet(),
     isDlcSelectionEnabled: Boolean = true,
@@ -186,7 +198,9 @@ internal fun StoreGameDetailScreen(
         val showUpdateCta = updateCheckAvailable && isUpdateAvailable
         val verifyFilesAvailable = showVerifyFiles && isInstalled
         val workshopAvailable = showWorkshop && isInstalled
-        val sourceMenuEnabled = updateCheckAvailable || verifyFilesAvailable || workshopAvailable
+        val launchOptionsAvailable = isInstalled && launchOptions.size >= 2
+        val sourceMenuEnabled =
+            updateCheckAvailable || verifyFilesAvailable || workshopAvailable || launchOptionsAvailable
         val showDlcCard = dlcs.isNotEmpty()
         val showActionColumn =
             showDownloadCta || showUpdateCta ||
@@ -293,6 +307,9 @@ internal fun StoreGameDetailScreen(
                 showCheckForUpdate = updateCheckAvailable,
                 showVerifyFiles = verifyFilesAvailable,
                 showWorkshop = workshopAvailable,
+                showLaunchOptions = launchOptionsAvailable,
+                launchOptions = launchOptions,
+                selectedLaunchOption = selectedLaunchOption,
                 isCheckingForUpdate = isCheckingForUpdate,
                 areSteamActionsEnabled = areSteamActionsEnabled,
                 isUpdateCheckEnabled =
@@ -303,6 +320,7 @@ internal fun StoreGameDetailScreen(
                 onVerifyFiles = onVerifyFiles,
                 onCheckForUpdate = onCheckForUpdate,
                 onWorkshop = onWorkshop,
+                onSelectLaunchOption = onSelectLaunchOption,
             )
         }
 
@@ -780,14 +798,19 @@ private fun StoreSourceTag(
     showCheckForUpdate: Boolean = false,
     showVerifyFiles: Boolean = false,
     showWorkshop: Boolean = false,
+    showLaunchOptions: Boolean = false,
+    launchOptions: List<StoreLaunchOptionItem> = emptyList(),
+    selectedLaunchOption: StoreLaunchOptionItem? = null,
     isCheckingForUpdate: Boolean = false,
     areSteamActionsEnabled: Boolean = true,
     isUpdateCheckEnabled: Boolean = true,
     onVerifyFiles: () -> Unit = {},
     onCheckForUpdate: () -> Unit = {},
     onWorkshop: () -> Unit = {},
+    onSelectLaunchOption: (StoreLaunchOptionItem) -> Unit = {},
 ) {
     var menuOpen by remember { mutableStateOf(false) }
+    var launchOptionsPage by remember { mutableStateOf(false) }
     var anchorHeightPx by remember { mutableIntStateOf(0) }
     Box {
         Surface(
@@ -797,7 +820,16 @@ private fun StoreSourceTag(
             modifier =
                 Modifier
                     .onSizeChanged { anchorHeightPx = it.height }
-                    .then(if (menuEnabled) Modifier.clickable { menuOpen = true } else Modifier),
+                    .then(
+                        if (menuEnabled) {
+                            Modifier.clickable {
+                                launchOptionsPage = false
+                                menuOpen = true
+                            }
+                        } else {
+                            Modifier
+                        },
+                    ),
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
@@ -832,34 +864,63 @@ private fun StoreSourceTag(
             val gapPx = with(LocalDensity.current) { 6.dp.roundToPx() }
             StoreSourceActionPopup(
                 expanded = menuOpen,
-                onDismissRequest = { menuOpen = false },
+                onDismissRequest = {
+                    menuOpen = false
+                    launchOptionsPage = false
+                },
                 offset = IntOffset(0, anchorHeightPx + gapPx),
             ) {
-                if (showVerifyFiles) {
+                if (launchOptionsPage) {
                     StoreSourceMenuItem(
-                        icon = Icons.AutoMirrored.Outlined.FactCheck,
-                        label = stringResource(R.string.store_game_verify_files),
-                        enabled = areSteamActionsEnabled && !isCheckingForUpdate,
-                    ) { menuOpen = false; onVerifyFiles() }
-                }
-                if (showCheckForUpdate) {
-                    StoreSourceMenuItem(
-                        icon = Icons.Outlined.Refresh,
-                        label =
-                            if (isCheckingForUpdate) {
-                                stringResource(R.string.store_game_checking_for_update)
-                            } else {
-                                stringResource(R.string.store_game_check_for_update)
-                            },
-                        enabled = areSteamActionsEnabled && isUpdateCheckEnabled,
-                    ) { menuOpen = false; onCheckForUpdate() }
-                }
-                if (showWorkshop) {
-                    StoreSourceMenuItem(
-                        icon = Icons.Outlined.Construction,
-                        label = stringResource(R.string.store_game_workshop),
-                        enabled = areSteamActionsEnabled,
-                    ) { menuOpen = false; onWorkshop() }
+                        icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                        label = stringResource(R.string.store_game_launch_options),
+                    ) { launchOptionsPage = false }
+                    StoreDlcDivider()
+                    launchOptions.forEach { option ->
+                        StoreLaunchOptionRow(
+                            label = option.label,
+                            selected = option == selectedLaunchOption,
+                            enabled = areSteamActionsEnabled,
+                        ) {
+                            menuOpen = false
+                            launchOptionsPage = false
+                            onSelectLaunchOption(option)
+                        }
+                    }
+                } else {
+                    if (showVerifyFiles) {
+                        StoreSourceMenuItem(
+                            icon = Icons.AutoMirrored.Outlined.FactCheck,
+                            label = stringResource(R.string.store_game_verify_files),
+                            enabled = areSteamActionsEnabled && !isCheckingForUpdate,
+                        ) { menuOpen = false; onVerifyFiles() }
+                    }
+                    if (showCheckForUpdate) {
+                        StoreSourceMenuItem(
+                            icon = Icons.Outlined.Refresh,
+                            label =
+                                if (isCheckingForUpdate) {
+                                    stringResource(R.string.store_game_checking_for_update)
+                                } else {
+                                    stringResource(R.string.store_game_check_for_update)
+                                },
+                            enabled = areSteamActionsEnabled && isUpdateCheckEnabled,
+                        ) { menuOpen = false; onCheckForUpdate() }
+                    }
+                    if (showWorkshop) {
+                        StoreSourceMenuItem(
+                            icon = Icons.Outlined.Construction,
+                            label = stringResource(R.string.store_game_workshop),
+                            enabled = areSteamActionsEnabled,
+                        ) { menuOpen = false; onWorkshop() }
+                    }
+                    if (showLaunchOptions) {
+                        StoreSourceMenuItem(
+                            icon = Icons.Outlined.RocketLaunch,
+                            label = stringResource(R.string.store_game_launch_options),
+                            enabled = areSteamActionsEnabled,
+                        ) { launchOptionsPage = true }
+                    }
                 }
             }
         }
@@ -944,6 +1005,44 @@ private fun StoreSourceMenuItem(
             color = contentColor,
             fontSize = 12.sp,
             fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun StoreLaunchOptionRow(
+    label: String,
+    selected: Boolean,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    val contentColor = if (enabled) Color.White else Color.White.copy(alpha = 0.45f)
+    Row(
+        modifier =
+            Modifier
+                .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier)
+                .padding(start = 14.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(Modifier.size(16.dp), contentAlignment = Alignment.Center) {
+            if (selected) {
+                Icon(
+                    Icons.Outlined.Check,
+                    contentDescription = null,
+                    tint = StoreAccent,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+        Text(
+            label,
+            color = if (selected) StoreAccent else contentColor,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = 280.dp),
         )
     }
 }

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -8486,6 +8486,8 @@ class UnifiedActivity :
         var isCheckingForUpdate by remember(app.id) { mutableStateOf(false) }
         var isUpdateCheckCoolingDown by remember(app.id) { mutableStateOf(false) }
         var showWorkshopDialog by remember(app.id) { mutableStateOf(false) }
+        var launchOptions by remember(app.id) { mutableStateOf<List<StoreLaunchOptionItem>>(emptyList()) }
+        var selectedLaunchOption by remember(app.id) { mutableStateOf<StoreLaunchOptionItem?>(null) }
         var updateInfo by remember(app.id) { mutableStateOf<SteamService.SteamUpdateInfo?>(null) }
         var updateStatusText by remember(app.id) { mutableStateOf<String?>(null) }
         val downloadRecords by com.winlator.cmod.app.service.download.DownloadCoordinator.records.collectAsState(
@@ -8549,6 +8551,41 @@ class UnifiedActivity :
                 withContext(Dispatchers.IO) {
                     SteamService.getInstallableSelectedManifestSizes(app.id, selectedDlcIds.toList())
                 }
+        }
+
+        LaunchedEffect(app.id, installed) {
+            if (installed != true) {
+                launchOptions = emptyList()
+                selectedLaunchOption = null
+                return@LaunchedEffect
+            }
+            val (options, selected) =
+                withContext(Dispatchers.IO) {
+                    val appDir = java.io.File(SteamService.getAppDirPath(app.id))
+                    val allOptions =
+                        SteamService
+                            .getWindowsLaunchInfos(app.id)
+                            .map { info ->
+                                StoreLaunchOptionItem(
+                                    executable = info.executable,
+                                    arguments = info.arguments,
+                                    label = info.description.ifBlank { info.executable.substringAfterLast('/') },
+                                )
+                            }.distinctBy { it.executable.lowercase() to it.arguments }
+                    // Hide options whose exe is missing on disk, but if that empties a
+                    // non-empty list (case-sensitivity quirks) keep the unfiltered set.
+                    val onDisk = allOptions.filter { java.io.File(appDir, it.executable).isFile }
+                    val options = onDisk.ifEmpty { allOptions }
+                    val (selectedExe, selectedArgs) = SteamService.getSelectedLaunchOption(context, app.id)
+                    val selected =
+                        options.firstOrNull {
+                            it.executable.equals(selectedExe, ignoreCase = true) && it.arguments == selectedArgs
+                        } ?: options.firstOrNull { it.executable.equals(selectedExe, ignoreCase = true) }
+                            ?: options.firstOrNull()
+                    options to selected
+                }
+            launchOptions = options
+            selectedLaunchOption = selected
         }
 
         val totalDownloadSize = selectedManifestSizes.downloadSize
@@ -8671,6 +8708,30 @@ class UnifiedActivity :
                     showWorkshop = isReallyInstalled,
                     showVerifyFiles = isReallyInstalled,
                     areSteamActionsEnabled = !hasBlockingSteamDownload,
+                    launchOptions = launchOptions,
+                    selectedLaunchOption = selectedLaunchOption,
+                    onSelectLaunchOption = { option ->
+                        scope.launch(Dispatchers.IO) {
+                            val saved =
+                                SteamService.setSelectedLaunchOption(
+                                    applicationContext,
+                                    app.id,
+                                    option.executable,
+                                    option.arguments,
+                                )
+                            withContext(Dispatchers.Main) {
+                                if (saved) {
+                                    selectedLaunchOption = option
+                                } else {
+                                    com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                        context,
+                                        getString(R.string.store_game_launch_option_failed),
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    )
+                                }
+                            }
+                        }
+                    },
                     dlcs = dlcItems,
                     selectedDlcIds = selectedDlcIds.toSet(),
                     isDlcSelectionEnabled = steamDownloadRecord == null,

--- a/app/src/main/feature/stores/steam/data/LaunchInfo.kt
+++ b/app/src/main/feature/stores/steam/data/LaunchInfo.kt
@@ -11,6 +11,8 @@ data class LaunchInfo(
     val workingDir: String,
     val description: String,
     val type: String,
+    // Default keeps already-cached appinfo JSON (without this key) decodable.
+    val arguments: String = "",
     @Serializable(with = OsEnumSetSerializer::class)
     val configOS: java.util.EnumSet<OS>,
     val configArch: OSArch,

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -2306,6 +2306,62 @@ class SteamService : Service() {
             return container.executablePath.ifEmpty { getInstalledExe(gameId) }
         }
 
+        private fun findSteamShortcut(
+            context: Context,
+            appId: Int,
+        ) = ContainerManager(context).loadShortcuts().find {
+            it.getExtra("game_source") == "STEAM" && it.getExtra("app_id") == appId.toString()
+        }
+
+        /**
+         * Persists the user's launch-option choice (an appinfo `config.launch` entry) on
+         * the game's shortcut + container, matching resolveRelativeGameExe's priority:
+         * shortcut `launch_exe_path` first, container.executablePath as the synced
+         * fallback. The option's own arguments go to `launch_exe_args`, kept separate
+         * from the user-editable custom args (`execArgs`). Call on an IO dispatcher.
+         */
+        fun setSelectedLaunchOption(
+            context: Context,
+            appId: Int,
+            executable: String,
+            arguments: String,
+        ): Boolean {
+            var shortcut = findSteamShortcut(context, appId)
+            if (shortcut == null) {
+                // Installs from older builds may predate shortcut creation on download.
+                createSteamShortcut(context, appId)
+                shortcut = findSteamShortcut(context, appId)
+            }
+            if (shortcut == null) {
+                Timber.w("setSelectedLaunchOption: no shortcut for appId=$appId")
+                return false
+            }
+            shortcut.putExtra("launch_exe_path", executable)
+            shortcut.putExtra("launch_exe_args", arguments.ifBlank { null })
+            shortcut.saveData()
+            shortcut.container?.let {
+                it.executablePath = executable
+                it.saveData()
+            }
+            return true
+        }
+
+        /**
+         * Currently effective launch option as (executable, arguments), resolved in the
+         * same order the launch path uses. Call on an IO dispatcher.
+         */
+        fun getSelectedLaunchOption(
+            context: Context,
+            appId: Int,
+        ): Pair<String, String> {
+            val shortcut = findSteamShortcut(context, appId)
+            val exe =
+                shortcut?.getExtra("launch_exe_path").orEmpty().ifBlank {
+                    shortcut?.container?.executablePath.orEmpty().ifBlank { getInstalledExe(appId) }
+                }
+            return exe.replace('\\', '/') to shortcut?.getExtra("launch_exe_args").orEmpty()
+        }
+
         suspend fun deleteApp(appId: Int): Boolean =
             withContext(Dispatchers.IO) {
                 val appDirPath = getAppDirPath(appId)

--- a/app/src/main/feature/stores/steam/utils/KeyValueUtils.kt
+++ b/app/src/main/feature/stores/steam/utils/KeyValueUtils.kt
@@ -198,6 +198,7 @@ fun WnKeyValue.generateSteamApp(): SteamApp =
                             workingDir = it["workingdir"].value?.replace('\\', '/').orEmpty(),
                             description = it["description"].value.orEmpty(),
                             type = it["type"].value.orEmpty(),
+                            arguments = it["arguments"].value.orEmpty(),
                             configOS = OS.from(it["config"]["oslist"].value),
                             configArch = OSArch.from(it["config"]["osarch"].value),
                         )

--- a/app/src/main/feature/stores/steam/utils/SteamUtils.kt
+++ b/app/src/main/feature/stores/steam/utils/SteamUtils.kt
@@ -1399,15 +1399,39 @@ object SteamUtils {
         }
     }
 
+    /**
+     * Combines a launch option's own arguments (appinfo `config.launch` entry, persisted
+     * as the shortcut's `launch_exe_args` extra) with the user's custom args. Honors
+     * Steam's `%command%` placeholder in the custom args: the option args stay attached
+     * to the command itself so a user wrapper like `FOO=1 %command% -windowed` keeps
+     * working.
+     */
+    @JvmStatic
+    fun combineSteamLaunchArgs(
+        selectedArgs: String?,
+        customArgs: String?,
+    ): String {
+        val selected = selectedArgs.orEmpty().trim()
+        val custom = customArgs.orEmpty().trim()
+        if (selected.isEmpty()) return custom
+        if (custom.isEmpty()) return selected
+        return if (custom.contains("%command%")) {
+            custom.replace("%command%", "%command% $selected")
+        } else {
+            "$selected $custom"
+        }
+    }
+
     @JvmStatic
     fun updateOrModifyLocalConfig(
         imageFs: ImageFs,
         container: Container,
         appId: String,
         steamUserId64: String,
+        selectedLaunchArgs: String = "",
     ) {
         try {
-            val exeCommandLine = container.execArgs
+            val exeCommandLine = combineSteamLaunchArgs(selectedLaunchArgs, container.execArgs)
 
             com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient
                 .setLaunchCommandLine(exeCommandLine)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="store_game_update_check_failed">Update check failed</string>
     <string name="store_game_update">Update</string>
     <string name="store_game_workshop">Workshop</string>
+    <string name="store_game_launch_options">Launch Options</string>
+    <string name="store_game_launch_option_failed">Couldn\'t save launch option</string>
     <string name="store_game_verify_files">Verify Files</string>
     <string name="store_game_verify_started">Verifying %1$s — check the Downloads tab</string>
     <string name="store_game_steam_options">Steam options</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6888,8 +6888,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 int appId = Integer.parseInt(shortcut.getExtra("app_id"));
                 // Reset per launch; set below once the launch exe is resolved.
                 wnSteamDirectExeOverride = false;
-                String steamExtraArgs = shortcut.getSettingExtra("execArgs", container.getExecArgs());
-                steamExtraArgs = (steamExtraArgs != null && !steamExtraArgs.isEmpty()) ? " " + steamExtraArgs : "";
+                String steamExtraArgs = SteamUtils.combineSteamLaunchArgs(
+                        shortcut.getExtra("launch_exe_args"),
+                        shortcut.getSettingExtra("execArgs", container.getExecArgs()));
+                steamExtraArgs = !steamExtraArgs.isEmpty() ? " " + steamExtraArgs : "";
 
                 boolean useColdClient = parseBoolean(getShortcutSetting("useColdClient", container.isUseColdClient() ? "1" : "0"));
                 boolean launchBionicSteam = isBionicSteamEnabledForShortcut();
@@ -7275,7 +7277,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
 
         String perGameExecArgs = shortcut != null ? shortcut.getSettingExtra("execArgs", container.getExecArgs()) : container.getExecArgs();
-        String exeCommandLine = perGameExecArgs != null ? perGameExecArgs : "";
+        String exeCommandLine = SteamUtils.combineSteamLaunchArgs(
+                shortcut != null ? shortcut.getExtra("launch_exe_args") : "", perGameExecArgs);
 
         String iniContent = buildColdClientIni(appId, exePath, exeRunDir, exeCommandLine, runtimePatcher);
 
@@ -7351,7 +7354,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
 
         String perGameExecArgs = shortcut != null ? shortcut.getSettingExtra("execArgs", container.getExecArgs()) : container.getExecArgs();
-        String exeCommandLine = perGameExecArgs != null ? perGameExecArgs : "";
+        String exeCommandLine = SteamUtils.combineSteamLaunchArgs(
+                shortcut != null ? shortcut.getExtra("launch_exe_args") : "", perGameExecArgs);
 
         String iniContent = buildColdClientIni(appId, exePath, exeRunDir, exeCommandLine, runtimePatcher);
 
@@ -9064,10 +9068,16 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             // Stamp-cache the registry edits + userdata reconcile + local-config
             // edit so warm launches of the same game in the same container skip
             // the per-launch file-copy / VDF-parse work. Stamp key is
-            // appId|userDataId — change either and the work re-runs.
+            // appId|userDataId|launchOptionsHash — change any and the work re-runs.
             File steamEnvStamp = new File(winePrefix,
                     ".wine/drive_c/.wn-steamenv-" + appId + "-" + steamUserDataId + ".stamp");
-            String expectedStamp = "v1|" + appId + "|" + steamUserDataId;
+            String selectedLaunchArgs = shortcut != null ? shortcut.getExtra("launch_exe_args") : "";
+            // The effective LaunchOptions line is part of the stamp so a changed
+            // launch-option selection (or custom args) re-runs the localconfig edit.
+            String effectiveLaunchOptions =
+                    SteamUtils.combineSteamLaunchArgs(selectedLaunchArgs, container.getExecArgs());
+            String expectedStamp = "v2|" + appId + "|" + steamUserDataId
+                    + "|" + effectiveLaunchOptions.hashCode();
             String existingStamp = steamEnvStamp.exists()
                     ? FileUtils.readString(steamEnvStamp).trim() : "";
             boolean steamEnvWarm = expectedStamp.equals(existingStamp);
@@ -9082,7 +9092,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
                 skipFirstTimeSteamSetup(winePrefix);
                 reconcileSteamUserdata(steamDir, steamUserDataId, steamId64);
-                SteamUtils.updateOrModifyLocalConfig(imageFs, container, String.valueOf(appId), steamUserDataId);
+                SteamUtils.updateOrModifyLocalConfig(imageFs, container, String.valueOf(appId), steamUserDataId,
+                        selectedLaunchArgs);
                 setupLightweightSteamConfig(steamDir, steamUserDataId);
 
                 try {
@@ -9092,6 +9103,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                             "Failed to write steam-env stamp at " + steamEnvStamp.getPath(), e);
                 }
             } else {
+                // localconfig.vdf is already up to date, but the pushed launch command
+                // line is per-process native state — re-push it on warm launches too.
+                com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient.INSTANCE
+                        .setLaunchCommandLine(effectiveLaunchOptions);
                 Log.d("XServerDisplayActivity",
                         "Steam env warm-cache hit (appId=" + appId
                                 + ", userId=" + steamUserDataId + ") — skipping reconcile + autoLogin");


### PR DESCRIPTION
Adds a "Launch Options" item to the STEAM menu on the game detail screen that lists the game's appinfo config.launch entries (e.g. ARK's "Launch ARK (No BattlEye)") with a checkmark on the current choice. Selecting one persists as the game's default:

- exe -> shortcut extra launch_exe_path + container.executablePath (the priority resolveRelativeGameExe already honors; non-default exes ride the existing WN_STEAM_DIRECT_EXE override)
- the option's own arguments -> new shortcut extra launch_exe_args, kept separate from the user's custom execArgs

LaunchInfo gains an `arguments` field (defaulted, so cached appinfo JSON stays decodable) parsed from appinfo config/launch/arguments.

A shared SteamUtils.combineSteamLaunchArgs joins option args with custom args across all three launch channels (direct command line, ColdClientLoader.ini ExeCommandLine, localconfig.vdf LaunchOptions / GetLaunchCommandLine). It honors Steam's %command% placeholder in custom args. The steam-env warm stamp now includes the effective LaunchOptions line so a changed selection re-runs the localconfig edit, and warm launches re-push the per-process launch command line.

The submenu reuses the existing StoreSourceActionPopup surface and StoreSourceMenuItem styling; hidden unless the game is installed and has 2+ distinct options.

https://claude.ai/code/session_01EUsZxzAWCjSh8LYRS9W3vT