### PR TITLE
Resize xserver menu drawer; fill menu cards to height

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalViewConfiguration
@@ -54,7 +53,7 @@ const val XSERVER_DRAWER_OPEN_TRIGGER_DP = 32
 // Open only on a clearly rightward swipe: dx must exceed this * |dy| (~27deg of horizontal).
 const val XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO = 2f
 
-private val DrawerWidth = 312.dp
+private val DrawerWidth = 290.dp
 private val DrawerStartPadding = 6.dp
 private val DrawerVerticalPadding = 6.dp
 private const val DrawerSettleAnimationMs = 200
@@ -105,15 +104,6 @@ private fun XServerDisplayHost(
 ) {
     val animationScope = rememberCoroutineScope()
     val density = LocalDensity.current
-    val context = LocalContext.current
-    // systemBars insets are zeroed on this view, so read the real status-bar height.
-    val statusBarHeight =
-        remember(context, density) {
-            val res = context.resources
-            val id = res.getIdentifier("status_bar_height", "dimen", "android")
-            val px = if (id > 0) res.getDimensionPixelSize(id) else 0
-            with(density) { px.toDp() }.coerceIn(24.dp, 56.dp)
-        }
     val viewConfiguration = LocalViewConfiguration.current
     val closedFallbackPx = with(density) { -(DrawerWidth + DrawerStartPadding).toPx() }
     var drawerOffsetPx by remember { mutableFloatStateOf(closedFallbackPx) }
@@ -277,7 +267,7 @@ private fun XServerDisplayHost(
                         }
                     },
         ) {
-            val drawerTopInset = statusBarHeight + 2.dp
+            val drawerTopInset = DrawerVerticalPadding
             val originalHeight = maxHeight - DrawerVerticalPadding * 2
             val drawerHeight = maxHeight - drawerTopInset - DrawerVerticalPadding
             val evenScale =

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -280,8 +280,8 @@ private val PINNED_BOTTOM_ITEM_IDS = setOf(R.id.main_menu_pause, R.id.main_menu_
 
 private val TopRailTileMinWidth = 60.dp
 private val TopRailTileHorizontalPadding = 10.dp
-private val TopRailTileTopPadding = 6.dp
-private val TopRailTileBottomPadding = 4.dp
+private val TopRailTileTopPadding = 10.dp
+private val TopRailTileBottomPadding = 7.dp
 private val TopRailTileSpacing = 6.dp
 
 private const val ActionCardColumns = 3
@@ -1177,45 +1177,52 @@ private fun ActionCardGrid(
             it.itemId !in RAIL_PANE_ITEM_IDS && it.itemId !in PINNED_BOTTOM_ITEM_IDS
         }
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = (10f * paneScale).dp, vertical = (10f * paneScale).dp),
-    ) {
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(ActionCardSpacing),
-            verticalArrangement = Arrangement.spacedBy(ActionCardSpacing),
-            maxItemsInEachRow = ActionCardColumns,
+    val verticalPadding = (10f * paneScale).dp
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val rows = ((cards.size + ActionCardColumns - 1) / ActionCardColumns).coerceAtLeast(1)
+        val rowHeight =
+            ((maxHeight - verticalPadding * 2 - ActionCardSpacing * (rows - 1)) / rows)
+                .coerceAtLeast(ActionCardMinHeight * paneScale)
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = (10f * paneScale).dp, vertical = verticalPadding),
         ) {
-            cards.forEachIndexed { index, item ->
-                val label = railLabelResFor(item.itemId)?.let { stringResource(it) } ?: item.title
-                ActionCard(
-                    item = item,
-                    label = label,
-                    revealIndex = index,
-                    revealed = cardsRevealed,
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .heightIn(min = ActionCardMinHeight * paneScale),
-                    onClick = {
-                        when (item.itemId) {
-                            R.id.main_menu_task_manager -> onOpenTaskManager()
-                            R.id.main_menu_logs -> onOpenLogs()
-                            R.id.main_menu_relative_mouse_movement,
-                            R.id.main_menu_disable_mouse,
-                            R.id.main_menu_toggle_fullscreen -> listener.onActionSelected(item.itemId)
-                            else -> listener.onActionSelected(item.itemId)
-                        }
-                    },
-                )
-            }
-            val trailing = (ActionCardColumns - cards.size % ActionCardColumns) % ActionCardColumns
-            repeat(trailing) {
-                Spacer(modifier = Modifier.weight(1f))
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(ActionCardSpacing),
+                verticalArrangement = Arrangement.spacedBy(ActionCardSpacing),
+                maxItemsInEachRow = ActionCardColumns,
+            ) {
+                cards.forEachIndexed { index, item ->
+                    val label = railLabelResFor(item.itemId)?.let { stringResource(it) } ?: item.title
+                    ActionCard(
+                        item = item,
+                        label = label,
+                        revealIndex = index,
+                        revealed = cardsRevealed,
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .height(rowHeight),
+                        onClick = {
+                            when (item.itemId) {
+                                R.id.main_menu_task_manager -> onOpenTaskManager()
+                                R.id.main_menu_logs -> onOpenLogs()
+                                R.id.main_menu_relative_mouse_movement,
+                                R.id.main_menu_disable_mouse,
+                                R.id.main_menu_toggle_fullscreen -> listener.onActionSelected(item.itemId)
+                                else -> listener.onActionSelected(item.itemId)
+                            }
+                        },
+                    )
+                }
+                val trailing = (ActionCardColumns - cards.size % ActionCardColumns) % ActionCardColumns
+                repeat(trailing) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
             }
         }
     }


### PR DESCRIPTION
- Symmetric 6dp top/bottom drawer margins for a taller sheet; width 290dp.
- Taller top-row rail tiles.
- Menu action cards size to the available body height so there is no empty gap below them.