### PR TITLE
fix: skip C: drive symlink for custom games

### DIFF
--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -234,6 +234,7 @@ public abstract class WineUtils {
   public static File ensureDriveCGameSymlink(
       Container container, String source, String gameInstallPath) {
     if (container == null || gameInstallPath == null || gameInstallPath.isEmpty()) return null;
+    if ("CUSTOM".equalsIgnoreCase(source)) return null;
 
     File gameDir = new File(gameInstallPath);
     if (!gameDir.exists()) return null;


### PR DESCRIPTION
Custom games (game_source=CUSTOM) now boot from their real install location instead of a drive_c symlink, fixing custom imports that failed to launch. Store games keep the existing symlink behavior.