### PR TITLE
chore(build): Add support for dynamic applicationIDs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -106,6 +106,11 @@ jobs:
             -storepass dummypass -keypass dummypass \
             -dname "CN=CI, OU=CI, O=CI, L=CI, ST=CI, C=US"
         fi
+
+        unset CI_PR_NUMBER
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          export CI_PR_NUMBER="${{ github.event.pull_request.number }}"
+        fi
         ./gradlew :app:${{ matrix.flavor.gradleTask }} --build-cache --parallel -x lint
 
     - name: Compute artifact label

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,18 +154,21 @@ android {
 
     flavorDimensions "branding"
 
+    def ciPrNumber = System.getenv("CI_PR_NUMBER")
+    def appIdSuffix = (ciPrNumber != null && !ciPrNumber.isEmpty()) ? ".pr.${ciPrNumber}" : ""
+
     productFlavors {
         standard {
             dimension "branding"
-            applicationId "com.winnative.cmod"
+            applicationId "com.winnative.cmod${appIdSuffix}"
         }
         ludashi {
             dimension "branding"
-            applicationId "com.ludashi.benchmark"
+            applicationId "com.ludashi.benchmark${appIdSuffix}"
         }
         pubg {
             dimension "branding"
-            applicationId "com.tencent.ig"
+            applicationId "com.tencent.ig${appIdSuffix}"
         }
     }
 


### PR DESCRIPTION
If the `CI_PR_NUMBER` environment variable is present and not empty, the built apk package name / applicationId will have ".pr.<CI_PR_NUMBER>" suffix added, so testers will be able to check out multiple APKs from multiple PRs and compare them for regressions, without having to uninstall another.

Notes:
- There's no check about the variable itself. While it's supposed to be a number (and the CI guarantees it'll be), you could very well build locally with your entire name as the suffix.
- This only changes the application id, not the app name; So the users would have like 300 same-looking WinNative APKs. Maybe the debug/PR versions should have the PR number added to their names as well?
- In this PR I've modified the CI to make _all_ built and published APKs to have this suffix thingie, which means that users expecting an update would be pretty frustrated. Should I keep the normal APKs and just add the modified ones as extras? It wouldn't be hard.
- Obviously, the APKs generated by THIS PR won't have those changes, as github will execute the one from the main branch until this gets merged.