### PR TITLE
Settings: rename 2 strings in other settings

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -732,7 +732,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_general_share_android_clipboard">Del Android-udklipsholder med Wine</string>
     <string name="settings_general_paths_title">Sti-indstillinger</string>
     <string name="settings_general_paths_summary">Administrer hvor Winlator gemmer sine arbejdsdata og hvor eksporterede genveje skrives.</string>
-    <string name="settings_general_winlator_path_title">Winlator-sti</string>
+    <string name="settings_general_winlator_path_title">Lagringssti</string>
     <string name="settings_general_shortcut_export_path_title">Genvejs-eksportsti</string>
     <string name="settings_general_choose_path">Vælg sti</string>
     <string name="settings_general_xserver_cursor_summary">Juster markørhastighed for touch, trackpad og museinput i XServer-sessionen.</string>
@@ -740,7 +740,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_general_cursor_lock_summary">Holder direkte museopfangning aktiveret for spil der kræver rå markørinput. Deaktiver med Lydstyrke ned.</string>
     <string name="settings_general_xinput_toggle_title">Deaktiver XInput</string>
     <string name="settings_general_xinput_toggle_summary">Slår XInput-håndtering fra når du ønsker eksklusiv mus- og tastaturkontrol.</string>
-    <string name="settings_general_file_provider_summary">Gør Winlator-filer tilgængelige for Android-dokumentvælgere og filhåndtering.</string>
+    <string name="settings_general_file_provider_summary">Gør WinNative-filer tilgængelige for Android-dokumentvælgere og filhåndtering.</string>
     <string name="settings_general_open_browser_summary">Åbn understøttede weblinks i Android-browseren i stedet for inde i Wine.</string>
     <string name="settings_general_clipboard_summary">Tillad kopiering og indsættelse mellem Android og Wine-sessioner.</string>
     <string name="settings_general_imagefs_summary">Gendan medfølgende systemfiler uden at fjerne dine eksisterende containere.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -732,7 +732,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_general_share_android_clipboard">Android-Zwischenablage mit Wine teilen</string>
     <string name="settings_general_paths_title">Pfadeinstellungen</string>
     <string name="settings_general_paths_summary">Verwalte, wo Winlator seine Arbeitsdaten speichert und wohin exportierte Verknüpfungen geschrieben werden.</string>
-    <string name="settings_general_winlator_path_title">Winlator-Pfad</string>
+    <string name="settings_general_winlator_path_title">Speicherpfad</string>
     <string name="settings_general_shortcut_export_path_title">Verknüpfungs-Exportpfad</string>
     <string name="settings_general_choose_path">Pfad auswählen</string>
     <string name="settings_general_xserver_cursor_summary">Zeigergeschwindigkeit für Touch-, Trackpad- und Mauseingabe innerhalb der XServer-Sitzung anpassen.</string>
@@ -740,7 +740,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_general_cursor_lock_summary">Hält die direkte Mauserfassung für Spiele aktiv, die Rohdaten-Zeigereingabe benötigen. Mit Leiser-Taste deaktivieren.</string>
     <string name="settings_general_xinput_toggle_title">XInput deaktivieren</string>
     <string name="settings_general_xinput_toggle_summary">Schaltet die XInput-Behandlung aus, wenn du exklusive Maus- und Tastatursteuerung möchtest.</string>
-    <string name="settings_general_file_provider_summary">Winlator-Dateien für Android-Dokumentenauswahl und Dateimanager bereitstellen.</string>
+    <string name="settings_general_file_provider_summary">WinNative-Dateien für Android-Dokumentenauswahl und Dateimanager bereitstellen.</string>
     <string name="settings_general_open_browser_summary">Unterstützte Weblinks im Android-Browser statt in Wine öffnen.</string>
     <string name="settings_general_clipboard_summary">Kopieren und Einfügen zwischen Android und Wine-Sitzungen erlauben.</string>
     <string name="settings_general_imagefs_summary">Mitgelieferte Systemdateien wiederherstellen, ohne vorhandene Container zu entfernen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -732,7 +732,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_general_share_android_clipboard">Compartir portapapeles de Android con Wine</string>
     <string name="settings_general_paths_title">Ajustes de rutas</string>
     <string name="settings_general_paths_summary">Gestionar dónde Winlator almacena sus datos de trabajo y dónde se escriben los accesos directos exportados.</string>
-    <string name="settings_general_winlator_path_title">Ruta de Winlator</string>
+    <string name="settings_general_winlator_path_title">Ruta de almacenamiento</string>
     <string name="settings_general_shortcut_export_path_title">Ruta de exportación de accesos directos</string>
     <string name="settings_general_choose_path">Elegir ruta</string>
     <string name="settings_general_xserver_cursor_summary">Ajustar la velocidad del puntero para entrada táctil, trackpad y ratón dentro de la sesión de XServer.</string>
@@ -740,7 +740,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantiene la captura directa del ratón activada para juegos que necesitan entrada de puntero sin procesar. Desactívalo con Bajar Volumen.</string>
     <string name="settings_general_xinput_toggle_title">Desactivar XInput</string>
     <string name="settings_general_xinput_toggle_summary">Desactiva el manejo de XInput cuando quieras control exclusivo de ratón y teclado.</string>
-    <string name="settings_general_file_provider_summary">Exponer los archivos de Winlator a los selectores de documentos y administradores de archivos de Android.</string>
+    <string name="settings_general_file_provider_summary">Exponer los archivos de WinNative a los selectores de documentos y administradores de archivos de Android.</string>
     <string name="settings_general_open_browser_summary">Abrir enlaces web compatibles en el navegador de Android en lugar de dentro de Wine.</string>
     <string name="settings_general_clipboard_summary">Permitir copiar y pegar entre Android y las sesiones de Wine.</string>
     <string name="settings_general_imagefs_summary">Restaurar los archivos del sistema incluidos sin eliminar tus contenedores existentes.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -732,7 +732,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_general_share_android_clipboard">Partager le presse-papiers Android avec Wine</string>
     <string name="settings_general_paths_title">Paramètres des chemins</string>
     <string name="settings_general_paths_summary">Gérer l\'emplacement des données de travail de Winlator et l\'emplacement d\'exportation des raccourcis.</string>
-    <string name="settings_general_winlator_path_title">Chemin de Winlator</string>
+    <string name="settings_general_winlator_path_title">Chemin de stockage</string>
     <string name="settings_general_shortcut_export_path_title">Chemin d\'exportation des raccourcis</string>
     <string name="settings_general_choose_path">Choisir un chemin</string>
     <string name="settings_general_xserver_cursor_summary">Ajuster la vitesse du pointeur pour la saisie tactile, le trackpad et la souris dans la session XServer.</string>
@@ -740,7 +740,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_general_cursor_lock_summary">Maintient la capture directe de la souris activée pour les jeux nécessitant une saisie brute du pointeur. Désactivez avec Volume Bas.</string>
     <string name="settings_general_xinput_toggle_title">Désactiver XInput</string>
     <string name="settings_general_xinput_toggle_summary">Désactive la gestion XInput lorsque vous souhaitez un contrôle exclusif au clavier et à la souris.</string>
-    <string name="settings_general_file_provider_summary">Exposer les fichiers de Winlator aux sélecteurs de documents et gestionnaires de fichiers Android.</string>
+    <string name="settings_general_file_provider_summary">Exposer les fichiers de WinNative aux sélecteurs de documents et gestionnaires de fichiers Android.</string>
     <string name="settings_general_open_browser_summary">Ouvrir les liens web pris en charge dans le navigateur Android au lieu de les ouvrir dans Wine.</string>
     <string name="settings_general_clipboard_summary">Permettre le copier-coller entre Android et les sessions Wine.</string>
     <string name="settings_general_imagefs_summary">Restaurer les fichiers système fournis sans supprimer vos conteneurs existants.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -840,7 +840,7 @@
     <string name="settings_general_share_android_clipboard">Android क्लिपबोर्ड को Wine के साथ साझा करें</string>
     <string name="settings_general_paths_title">पथ सेटिंग्स</string>
     <string name="settings_general_paths_summary">प्रबंधित करें कि Winlator अपना कार्यशील डेटा कहां संग्रहीत करता है और निर्यात किए गए शॉर्टकट कहां लिखे गए हैं।</string>
-    <string name="settings_general_winlator_path_title">Winlator पथ</string>
+    <string name="settings_general_winlator_path_title">संग्रहण पथ</string>
     <string name="settings_general_shortcut_export_path_title">शॉर्टकट निर्यात पथ</string>
     <string name="settings_general_choose_path">पथ चुनें</string>
     <string name="settings_general_xserver_cursor_summary">XServer सत्र के अंदर टच, ट्रैकपैड और माउस इनपुट के लिए पॉइंटर गति समायोजित करें।</string>
@@ -848,7 +848,7 @@
     <string name="settings_general_cursor_lock_summary">उन खेलों के लिए सीधे माउस कैप्चर को सक्षम रखता है जिन्हें रॉ पॉइंटर इनपुट की आवश्यकता होती है। इसे वॉल्यूम डाउन के साथ अक्षम करें।</string>
     <string name="settings_general_xinput_toggle_title">XInput अक्षम करें</string>
     <string name="settings_general_xinput_toggle_summary">जब आप विशेष माउस और कीबोर्ड नियंत्रण चाहते हैं तो XInput हैंडलिंग बंद कर देता है।</string>
-    <string name="settings_general_file_provider_summary">Winlator फ़ाइलों को Android दस्तावेज़ चयनकर्ताओं और फ़ाइल प्रबंधकों के सामने उजागर करें।</string>
+    <string name="settings_general_file_provider_summary">WinNative फ़ाइलों को Android दस्तावेज़ चयनकर्ताओं और फ़ाइल प्रबंधकों के सामने उजागर करें।</string>
     <string name="settings_general_open_browser_summary">समर्थित वेब लिंक को Wine के बजाय Android ब्राउज़र में खोलें।</string>
     <string name="settings_general_clipboard_summary">Android और Wine सत्रों के बीच कॉपी और पेस्ट करने की अनुमति दें।</string>
     <string name="settings_general_imagefs_summary">अपने मौजूदा कंटेनरों को हटाए बिना बंडल सिस्टम फ़ाइलों को पुनर्स्थापित करें।</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -732,7 +732,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_general_share_android_clipboard">Condividi appunti Android con Wine</string>
     <string name="settings_general_paths_title">Impostazioni percorso</string>
     <string name="settings_general_paths_summary">Gestisci dove Winlator memorizza i dati di lavoro e dove vengono scritte le scorciatoie esportate.</string>
-    <string name="settings_general_winlator_path_title">Percorso Winlator</string>
+    <string name="settings_general_winlator_path_title">Percorso di archiviazione</string>
     <string name="settings_general_shortcut_export_path_title">Percorso esportazione scorciatoie</string>
     <string name="settings_general_choose_path">Scegli percorso</string>
     <string name="settings_general_xserver_cursor_summary">Regola la velocità del puntatore per input touch, trackpad e mouse all\'interno della sessione XServer.</string>
@@ -740,7 +740,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantiene la cattura diretta del mouse abilitata per i giochi che necessitano di input raw del puntatore. Disabilitalo con Volume Giù.</string>
     <string name="settings_general_xinput_toggle_title">Disabilita XInput</string>
     <string name="settings_general_xinput_toggle_summary">Disattiva la gestione XInput quando vuoi il controllo esclusivo di mouse e tastiera.</string>
-    <string name="settings_general_file_provider_summary">Esponi i file di Winlator ai selettori di documenti e file manager di Android.</string>
+    <string name="settings_general_file_provider_summary">Esponi i file di WinNative ai selettori di documenti e file manager di Android.</string>
     <string name="settings_general_open_browser_summary">Apri i link web supportati nel browser Android invece che all\'interno di Wine.</string>
     <string name="settings_general_clipboard_summary">Consenti copia e incolla tra Android e le sessioni Wine.</string>
     <string name="settings_general_imagefs_summary">Ripristina i file di sistema inclusi senza rimuovere i contenitori esistenti.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -732,7 +732,7 @@
     <string name="settings_general_share_android_clipboard">Wine과 Android 클립보드 공유</string>
     <string name="settings_general_paths_title">경로 설정</string>
     <string name="settings_general_paths_summary">Winlator가 작업 데이터를 저장하는 위치와 내보낸 바로가기가 기록되는 위치를 관리합니다.</string>
-    <string name="settings_general_winlator_path_title">Winlator 경로</string>
+    <string name="settings_general_winlator_path_title">저장소 경로</string>
     <string name="settings_general_shortcut_export_path_title">바로가기 내보내기 경로</string>
     <string name="settings_general_choose_path">경로 선택</string>
     <string name="settings_general_xserver_cursor_summary">XServer 세션 내 터치, 트랙패드 및 마우스 입력의 포인터 속도를 조정합니다.</string>
@@ -740,7 +740,7 @@
     <string name="settings_general_cursor_lock_summary">원시 포인터 입력이 필요한 게임에서 직접 마우스 캡처를 유지합니다. 볼륨 다운으로 비활성화할 수 있습니다.</string>
     <string name="settings_general_xinput_toggle_title">XInput 비활성화</string>
     <string name="settings_general_xinput_toggle_summary">마우스와 키보드만 사용하려는 경우 XInput 처리를 끕니다.</string>
-    <string name="settings_general_file_provider_summary">Android 문서 선택기 및 파일 관리자에 Winlator 파일을 노출합니다.</string>
+    <string name="settings_general_file_provider_summary">Android 문서 선택기 및 파일 관리자에 WinNative 파일을 노출합니다.</string>
     <string name="settings_general_open_browser_summary">지원되는 웹 링크를 Wine 내부 대신 Android 브라우저에서 엽니다.</string>
     <string name="settings_general_clipboard_summary">Android와 Wine 세션 간에 복사 및 붙여넣기를 허용합니다.</string>
     <string name="settings_general_imagefs_summary">기존 컨테이너를 제거하지 않고 번들된 시스템 파일을 복원합니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -738,7 +738,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_general_share_android_clipboard">Udostępnij schowek Androida w Wine</string>
     <string name="settings_general_paths_title">Ustawienia ścieżek</string>
     <string name="settings_general_paths_summary">Zarządzaj miejscami przechowywania danych roboczych Winlator i eksportowanych skrótów.</string>
-    <string name="settings_general_winlator_path_title">Ścieżka Winlator</string>
+    <string name="settings_general_winlator_path_title">Ścieżka pamięci masowej</string>
     <string name="settings_general_shortcut_export_path_title">Ścieżka eksportu skrótów</string>
     <string name="settings_general_choose_path">Wybierz ścieżkę</string>
     <string name="settings_general_xserver_cursor_summary">Dostosuj prędkość wskaźnika dla dotyku, gładzika i myszy w sesji XServer.</string>
@@ -746,7 +746,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_general_cursor_lock_summary">Utrzymuje bezpośrednie przechwytywanie myszy dla gier wymagających surowego wejścia wskaźnika. Wyłącz przyciskiem Ciszej.</string>
     <string name="settings_general_xinput_toggle_title">Wyłącz XInput</string>
     <string name="settings_general_xinput_toggle_summary">Wyłącza obsługę XInput, gdy chcesz wyłącznej kontroli myszy i klawiatury.</string>
-    <string name="settings_general_file_provider_summary">Udostępnij pliki Winlator selektorom dokumentów i menedżerom plików Androida.</string>
+    <string name="settings_general_file_provider_summary">Udostępnij pliki WinNative selektorom dokumentów i menedżerom plików Androida.</string>
     <string name="settings_general_open_browser_summary">Otwieraj obsługiwane linki w przeglądarce Androida zamiast w Wine.</string>
     <string name="settings_general_clipboard_summary">Umożliw kopiowanie i wklejanie między Androidem a sesjami Wine.</string>
     <string name="settings_general_imagefs_summary">Przywróć dołączone pliki systemowe bez usuwania istniejących kontenerów.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -732,7 +732,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_general_share_android_clipboard">Compartilhar Area de Transferencia do Android com o Wine</string>
     <string name="settings_general_paths_title">Configuracoes de Caminho</string>
     <string name="settings_general_paths_summary">Gerenciar onde o Winlator armazena seus dados de trabalho e onde os atalhos exportados sao gravados.</string>
-    <string name="settings_general_winlator_path_title">Caminho do Winlator</string>
+    <string name="settings_general_winlator_path_title">Caminho de armazenamento</string>
     <string name="settings_general_shortcut_export_path_title">Caminho de Exportacao de Atalhos</string>
     <string name="settings_general_choose_path">Escolher Caminho</string>
     <string name="settings_general_xserver_cursor_summary">Ajustar a velocidade do ponteiro para entrada por toque, trackpad e mouse dentro da sessao XServer.</string>
@@ -740,7 +740,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantem a captura direta do mouse ativada para jogos que precisam de entrada bruta do ponteiro. Desative com Volume Baixo.</string>
     <string name="settings_general_xinput_toggle_title">Desativar XInput</string>
     <string name="settings_general_xinput_toggle_summary">Desliga o tratamento XInput quando voce quer controle exclusivo de mouse e teclado.</string>
-    <string name="settings_general_file_provider_summary">Expor arquivos do Winlator para seletores de documentos e gerenciadores de arquivos do Android.</string>
+    <string name="settings_general_file_provider_summary">Expor arquivos do WinNative para seletores de documentos e gerenciadores de arquivos do Android.</string>
     <string name="settings_general_open_browser_summary">Abrir links da web compativeis no navegador Android em vez de dentro do Wine.</string>
     <string name="settings_general_clipboard_summary">Permitir copiar e colar entre o Android e sessoes do Wine.</string>
     <string name="settings_general_imagefs_summary">Restaurar arquivos do sistema inclusos sem remover seus containers existentes.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -732,7 +732,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_general_share_android_clipboard">Partajeaza clipboard-ul Android cu Wine</string>
     <string name="settings_general_paths_title">Setari cai</string>
     <string name="settings_general_paths_summary">Gestioneaza unde Winlator stocheaza datele de lucru si unde sunt scrise comenzile rapide exportate.</string>
-    <string name="settings_general_winlator_path_title">Cale Winlator</string>
+    <string name="settings_general_winlator_path_title">Cale de stocare</string>
     <string name="settings_general_shortcut_export_path_title">Cale export comenzi rapide</string>
     <string name="settings_general_choose_path">Alege calea</string>
     <string name="settings_general_xserver_cursor_summary">Ajusteaza viteza cursorului pentru intrarea tactila, trackpad si mouse in sesiunea XServer.</string>
@@ -740,7 +740,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mentine captura directa a mouse-ului activata pentru jocuri care necesita intrare bruta de cursor. Dezactiveaza cu Volum Jos.</string>
     <string name="settings_general_xinput_toggle_title">Dezactiveaza XInput</string>
     <string name="settings_general_xinput_toggle_summary">Opreste gestionarea XInput cand doresti control exclusiv cu mouse-ul si tastatura.</string>
-    <string name="settings_general_file_provider_summary">Expune fisierele Winlator catre selectoarele de documente si managerii de fisiere Android.</string>
+    <string name="settings_general_file_provider_summary">Expune fisierele WinNative catre selectoarele de documente si managerii de fisiere Android.</string>
     <string name="settings_general_open_browser_summary">Deschide link-urile web compatibile in browserul Android in loc de Wine.</string>
     <string name="settings_general_clipboard_summary">Permite copierea si lipirea intre Android si sesiunile Wine.</string>
     <string name="settings_general_imagefs_summary">Restaureaza fisierele de sistem incluse fara a elimina containerele existente.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -799,7 +799,7 @@
     <string name="settings_general_share_android_clipboard">Общий буфер обмена Android с Wine</string>
     <string name="settings_general_paths_title">Настройки пути</string>
     <string name="settings_general_paths_summary">Управляйте тем, где Winlator хранит свои рабочие данные и куда записываются экспортированные ярлыки.</string>
-    <string name="settings_general_winlator_path_title">Путь Winlator</string>
+    <string name="settings_general_winlator_path_title">Путь хранилища</string>
     <string name="settings_general_shortcut_export_path_title">Путь экспорта ярлыков</string>
     <string name="settings_general_choose_path">Выберите путь</string>
     <string name="settings_general_xserver_cursor_summary">Настройте скорость указателя для сенсорного ввода, трекпада и мыши внутри сеанса XServer.</string>
@@ -807,7 +807,7 @@
     <string name="settings_general_cursor_lock_summary">Сохраняет прямой захват мыши включенным для игр, которым требуется необработанный ввод указателя. Отключите его с помощью Volume Down.</string>
     <string name="settings_general_xinput_toggle_title">Отключить XInput</string>
     <string name="settings_general_xinput_toggle_summary">Отключает обработку XInput, если вам требуется единоличное управление мышью и клавиатурой.</string>
-    <string name="settings_general_file_provider_summary">Предоставляйте файлы Winlator средствам выбора документов и файловым менеджерам Android.</string>
+    <string name="settings_general_file_provider_summary">Предоставляйте файлы WinNative средствам выбора документов и файловым менеджерам Android.</string>
     <string name="settings_general_open_browser_summary">Открывайте поддерживаемые веб-ссылки в браузере Android, а не внутри Wine.</string>
     <string name="settings_general_clipboard_summary">Разрешить копирование и вставку между сеансами Android и Wine.</string>
     <string name="settings_general_imagefs_summary">Восстановите связанные системные файлы, не удаляя существующие контейнеры.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -738,7 +738,7 @@
     <string name="settings_general_share_android_clipboard">Спільний буфер обміну Android з Wine</string>
     <string name="settings_general_paths_title">Налаштування шляхів</string>
     <string name="settings_general_paths_summary">Керувати місцем зберігання робочих даних Winlator та шляхом експорту ярликів.</string>
-    <string name="settings_general_winlator_path_title">Шлях Winlator</string>
+    <string name="settings_general_winlator_path_title">Шлях сховища</string>
     <string name="settings_general_shortcut_export_path_title">Шлях експорту ярликів</string>
     <string name="settings_general_choose_path">Вибрати шлях</string>
     <string name="settings_general_xserver_cursor_summary">Налаштуйте швидкість вказівника для сенсорного, трекпада та миші у сесії XServer.</string>
@@ -746,7 +746,7 @@
     <string name="settings_general_cursor_lock_summary">Підтримує пряме захоплення миші для ігор, що потребують необробленого введення вказівника. Вимкніть кнопкою гучності вниз.</string>
     <string name="settings_general_xinput_toggle_title">Вимкнути XInput</string>
     <string name="settings_general_xinput_toggle_summary">Вимикає обробку XInput, коли потрібне ексклюзивне керування мишею та клавіатурою.</string>
-    <string name="settings_general_file_provider_summary">Надати доступ до файлів Winlator для засобів вибору документів та файлових менеджерів Android.</string>
+    <string name="settings_general_file_provider_summary">Надати доступ до файлів WinNative для засобів вибору документів та файлових менеджерів Android.</string>
     <string name="settings_general_open_browser_summary">Відкривати підтримувані веб-посилання у браузері Android замість Wine.</string>
     <string name="settings_general_clipboard_summary">Дозволити копіювання та вставку між Android та сесіями Wine.</string>
     <string name="settings_general_imagefs_summary">Відновити системні файли з пакета без видалення існуючих контейнерів.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -732,7 +732,7 @@
     <string name="settings_general_share_android_clipboard">与 Wine 共享 Android 剪贴板</string>
     <string name="settings_general_paths_title">路径设置</string>
     <string name="settings_general_paths_summary">管理 Winlator 存储工作数据的位置以及导出快捷方式的写入位置。</string>
-    <string name="settings_general_winlator_path_title">Winlator 路径</string>
+    <string name="settings_general_winlator_path_title">存储路径</string>
     <string name="settings_general_shortcut_export_path_title">快捷方式导出路径</string>
     <string name="settings_general_choose_path">选择路径</string>
     <string name="settings_general_xserver_cursor_summary">调整 XServer 会话中触摸、触控板和鼠标输入的指针速度。</string>
@@ -740,7 +740,7 @@
     <string name="settings_general_cursor_lock_summary">为需要原始指针输入的游戏保持直接鼠标捕获。按音量减键禁用。</string>
     <string name="settings_general_xinput_toggle_title">禁用 XInput</string>
     <string name="settings_general_xinput_toggle_summary">在需要独占鼠标和键盘控制时关闭 XInput 处理。</string>
-    <string name="settings_general_file_provider_summary">向 Android 文档选择器和文件管理器公开 Winlator 文件。</string>
+    <string name="settings_general_file_provider_summary">向 Android 文档选择器和文件管理器公开 WinNative 文件。</string>
     <string name="settings_general_open_browser_summary">在 Android 浏览器中打开支持的网页链接，而非在 Wine 内部打开。</string>
     <string name="settings_general_clipboard_summary">允许在 Android 和 Wine 会话之间复制和粘贴。</string>
     <string name="settings_general_imagefs_summary">恢复捆绑的系统文件而不删除现有容器。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -732,7 +732,7 @@
     <string name="settings_general_share_android_clipboard">與 Wine 共用 Android 剪貼簿</string>
     <string name="settings_general_paths_title">路徑設定</string>
     <string name="settings_general_paths_summary">管理 Winlator 儲存工作資料的位置以及匯出捷徑的寫入位置。</string>
-    <string name="settings_general_winlator_path_title">Winlator 路徑</string>
+    <string name="settings_general_winlator_path_title">儲存路徑</string>
     <string name="settings_general_shortcut_export_path_title">捷徑匯出路徑</string>
     <string name="settings_general_choose_path">選擇路徑</string>
     <string name="settings_general_xserver_cursor_summary">調整 XServer 工作階段中觸控、觸控板和滑鼠輸入的指標速度。</string>
@@ -740,7 +740,7 @@
     <string name="settings_general_cursor_lock_summary">為需要原始指標輸入的遊戲保持直接滑鼠擷取。使用音量降低鍵停用。</string>
     <string name="settings_general_xinput_toggle_title">停用 XInput</string>
     <string name="settings_general_xinput_toggle_summary">當您想要獨佔滑鼠和鍵盤控制時，關閉 XInput 處理。</string>
-    <string name="settings_general_file_provider_summary">將 Winlator 檔案公開給 Android 文件選取器和檔案管理員。</string>
+    <string name="settings_general_file_provider_summary">將 WinNative 檔案公開給 Android 文件選取器和檔案管理員。</string>
     <string name="settings_general_open_browser_summary">在 Android 瀏覽器中開啟支援的網頁連結，而非在 Wine 內開啟。</string>
     <string name="settings_general_clipboard_summary">允許在 Android 和 Wine 工作階段之間複製和貼上。</string>
     <string name="settings_general_imagefs_summary">還原捆綁的系統檔案，而不移除您現有的容器。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -892,7 +892,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_general_share_android_clipboard">Share Android Clipboard with Wine</string>
     <string name="settings_general_paths_title">Path Settings</string>
     <string name="settings_general_paths_summary">Manage where Winlator stores its working data and where exported shortcuts are written.</string>
-    <string name="settings_general_winlator_path_title">Winlator Path</string>
+    <string name="settings_general_winlator_path_title">Storage Path</string>
     <string name="settings_general_shortcut_export_path_title">Shortcut Export Path</string>
     <string name="settings_general_choose_path">Choose Path</string>
     <string name="settings_general_xserver_cursor_summary">Adjust pointer speed for touch, trackpad, and mouse input inside the XServer session.</string>
@@ -900,7 +900,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_general_cursor_lock_summary">Keeps direct mouse capture enabled for games that need raw pointer input. Disable it with Volume Down.</string>
     <string name="settings_general_xinput_toggle_title">Disable XInput</string>
     <string name="settings_general_xinput_toggle_summary">Turns off XInput handling when you want exclusive mouse and keyboard control.</string>
-    <string name="settings_general_file_provider_summary">Expose Winlator files to Android document pickers and file managers.</string>
+    <string name="settings_general_file_provider_summary">Expose WinNative files to Android document pickers and file managers.</string>
     <string name="settings_general_open_browser_summary">Open supported web links in the Android browser instead of inside Wine.</string>
     <string name="settings_general_clipboard_summary">Allow copy and paste between Android and Wine sessions.</string>
     <string name="settings_general_imagefs_summary">Restore bundled system files without removing your existing containers.</string>


### PR DESCRIPTION
Changed Winlator Path -> Storage Path
Changed Enable File Provider description to read WinNative