### PR TITLE
feat: Extend Fx tab with more effects

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SHADER_LIST
     "effect_natural:frag:effect_natural_frag"
     "effect_toon:frag:effect_toon_frag"
     "effect_ntsc:frag:effect_ntsc_frag"
+    "effect_ntsc2:frag:effect_ntsc2_frag"
     "effect_coloradj:frag:effect_coloradj_frag"
     "effect_colorgrade:frag:effect_colorgrade_frag"
     "effect_sharpen:frag:effect_sharpen_frag"

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -82,6 +82,8 @@ set(SHADER_LIST
     "effect_colorgrade:frag:effect_colorgrade_frag"
     "effect_sharpen:frag:effect_sharpen_frag"
     "effect_scanlines:frag:effect_scanlines_frag"
+    "effect_colorblind:frag:effect_colorblind_frag"
+    "effect_pixelate:frag:effect_pixelate_frag"
     "sgsr1:frag:sgsr1_frag"
 )
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -78,6 +78,9 @@ set(SHADER_LIST
     "effect_toon:frag:effect_toon_frag"
     "effect_ntsc:frag:effect_ntsc_frag"
     "effect_coloradj:frag:effect_coloradj_frag"
+    "effect_colorgrade:frag:effect_colorgrade_frag"
+    "effect_sharpen:frag:effect_sharpen_frag"
+    "effect_scanlines:frag:effect_scanlines_frag"
     "sgsr1:frag:sgsr1_frag"
 )
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -75,6 +75,9 @@ set(SHADER_LIST
     "effect_vivid:frag:effect_vivid_frag"
     "effect_hdr:frag:effect_hdr_frag"
     "effect_natural:frag:effect_natural_frag"
+    "effect_toon:frag:effect_toon_frag"
+    "effect_ntsc:frag:effect_ntsc_frag"
+    "effect_coloradj:frag:effect_coloradj_frag"
     "sgsr1:frag:sgsr1_frag"
 )
 

--- a/app/src/main/cpp/winlator/vk/shaders/effect_coloradj.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_coloradj.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float brightness;
+    float contrast;
+    float gamma;
+} pc;
+
+void main() {
+    vec3 color = texture(screenTexture, vUV).rgb;
+    vec3 adjusted = color + vec3(pc.brightness);
+    adjusted = (adjusted - 0.5) * (1.0 + pc.contrast) + 0.5;
+    adjusted = pow(clamp(adjusted, 0.0, 1.0), vec3(1.0 / max(pc.gamma, 0.01)));
+    outColor = vec4(clamp(adjusted, 0.0, 1.0), 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_colorblind.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_colorblind.frag
@@ -1,0 +1,37 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float mode;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec3 c = texture(screenTexture, vUV).rgb;
+    int m = int(pc.mode + 0.5);
+    mat3 sim;
+    if (m == 1) {
+        sim = mat3(0.567, 0.558, 0.0,
+                   0.433, 0.442, 0.242,
+                   0.0,   0.0,   0.758);
+    } else if (m == 2) {
+        sim = mat3(0.625, 0.70, 0.0,
+                   0.375, 0.30, 0.30,
+                   0.0,   0.0,  0.70);
+    } else {
+        sim = mat3(0.95, 0.0,   0.0,
+                   0.05, 0.433, 0.475,
+                   0.0,  0.567, 0.525);
+    }
+    vec3 err = c - sim * c;
+    vec3 corrected = c;
+    corrected.g += 0.7 * err.r + err.g;
+    corrected.b += 0.7 * err.r + err.b;
+    outColor = vec4(clamp(corrected, 0.0, 1.0), 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_colorblind.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_colorblind.frag
@@ -13,25 +13,40 @@ layout(push_constant) uniform PC {
 } pc;
 
 void main() {
-    vec3 c = texture(screenTexture, vUV).rgb;
+    vec3 src = texture(screenTexture, vUV).rgb;
     int m = int(pc.mode + 0.5);
-    mat3 sim;
+
+    vec3 c = pow(src, vec3(2.2));
+
+    float L = 17.8824   * c.r + 43.5161  * c.g + 4.11935 * c.b;
+    float M = 3.45565   * c.r + 27.1554  * c.g + 3.86714 * c.b;
+    float S = 0.0299566 * c.r + 0.184309 * c.g + 1.46709 * c.b;
+
+    float dL = L;
+    float dM = M;
+    float dS = S;
     if (m == 1) {
-        sim = mat3(0.567, 0.558, 0.0,
-                   0.433, 0.442, 0.242,
-                   0.0,   0.0,   0.758);
+        dL = 2.02344 * M - 2.52581 * S;
     } else if (m == 2) {
-        sim = mat3(0.625, 0.70, 0.0,
-                   0.375, 0.30, 0.30,
-                   0.0,   0.0,  0.70);
+        dM = 0.494207 * L + 1.24827 * S;
     } else {
-        sim = mat3(0.95, 0.0,   0.0,
-                   0.05, 0.433, 0.475,
-                   0.0,  0.567, 0.525);
+        dS = -0.395913 * L + 0.801109 * M;
     }
-    vec3 err = c - sim * c;
+
+    vec3 sim;
+    sim.r =  0.0809444479    * dL - 0.130504409   * dM + 0.116721066  * dS;
+    sim.g = -0.0102485335    * dL + 0.0540193266  * dM - 0.113614708  * dS;
+    sim.b = -0.000365296938  * dL - 0.00412161469 * dM + 0.693511405  * dS;
+
+    vec3 err = c - sim;
     vec3 corrected = c;
-    corrected.g += 0.7 * err.r + err.g;
-    corrected.b += 0.7 * err.r + err.b;
-    outColor = vec4(clamp(corrected, 0.0, 1.0), 1.0);
+    if (m == 3) {
+        corrected.r += err.r + 0.7 * err.b;
+        corrected.g += err.g + 0.7 * err.b;
+    } else {
+        corrected.g += 0.7 * err.r + err.g;
+        corrected.b += 0.7 * err.r + err.b;
+    }
+    corrected = clamp(corrected, 0.0, 1.0);
+    outColor = vec4(pow(corrected, vec3(1.0 / 2.2)), 1.0);
 }

--- a/app/src/main/cpp/winlator/vk/shaders/effect_colorgrade.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_colorgrade.frag
@@ -1,0 +1,23 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float saturation;
+    float temperature;
+    float tint;
+} pc;
+
+void main() {
+    vec3 c = texture(screenTexture, vUV).rgb;
+    c.r *= 1.0 + pc.temperature * 0.30;
+    c.b *= 1.0 - pc.temperature * 0.30;
+    c.g *= 1.0 + pc.tint * 0.20;
+    float luma = dot(c, vec3(0.299, 0.587, 0.114));
+    c = mix(vec3(luma), c, pc.saturation);
+    outColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_ntsc.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_ntsc.frag
@@ -1,0 +1,27 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float p0;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec2 res = pc.resolution.x > 0.0 ? pc.resolution : vec2(1280.0, 720.0);
+    vec2 texel = 1.0 / max(res, vec2(1.0));
+
+    vec3 color = texture(screenTexture, vUV).rgb;
+    vec3 shifted = color;
+    shifted.r = texture(screenTexture, vUV + vec2(texel.x * 1.25, 0.0)).r;
+    shifted.b = texture(screenTexture, vUV - vec2(texel.x * 1.25, 0.0)).b;
+
+    float bleed = sin((vUV.y * max(res.y, 1.0) + vUV.x * 24.0) * 0.45) * 0.018;
+    vec3 ntsc = clamp(mix(color, shifted + vec3(bleed), 0.65), 0.0, 1.0);
+    outColor = vec4(ntsc, 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_ntsc2.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_ntsc2.frag
@@ -18,10 +18,10 @@ void main() {
 
     vec3 color = texture(screenTexture, vUV).rgb;
     vec3 shifted = color;
-    shifted.r = texture(screenTexture, vUV + vec2(0.0, texel.y * 1.25)).r;
-    shifted.b = texture(screenTexture, vUV - vec2(0.0, texel.y * 1.25)).b;
+    shifted.r = texture(screenTexture, vUV + vec2(texel.x * 1.25, 0.0)).r;
+    shifted.b = texture(screenTexture, vUV - vec2(texel.x * 1.25, 0.0)).b;
 
-    float bleed = sin((vUV.x * max(res.x, 1.0) + vUV.y * 24.0) * 0.45) * 0.018;
+    float bleed = sin((vUV.y * max(res.y, 1.0) + vUV.x * 24.0) * 0.45) * 0.018;
     vec3 ntsc = clamp(mix(color, shifted + vec3(bleed), 0.65), 0.0, 1.0);
     outColor = vec4(ntsc, 1.0);
 }

--- a/app/src/main/cpp/winlator/vk/shaders/effect_pixelate.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_pixelate.frag
@@ -1,0 +1,21 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float blockSize;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec2 res = pc.resolution.x > 0.0 ? pc.resolution : vec2(1280.0, 720.0);
+    float bs = max(pc.blockSize, 1.0);
+    vec2 grid = max(res / bs, vec2(1.0));
+    vec2 uv = (floor(vUV * grid) + 0.5) / grid;
+    outColor = vec4(texture(screenTexture, uv).rgb, 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_scanlines.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_scanlines.frag
@@ -15,8 +15,7 @@ layout(push_constant) uniform PC {
 void main() {
     vec2 res = pc.resolution.x > 0.0 ? pc.resolution : vec2(1280.0, 720.0);
     vec3 c = texture(screenTexture, vUV).rgb;
-    float s = sin(vUV.y * res.y * (3.14159265 / 3.0));
-    float scan = s * s;
-    c *= 1.0 - pc.intensity * (1.0 - scan);
+    float band = 0.5 + 0.5 * sin(vUV.y * res.y * 1.5708);
+    c *= 1.0 - pc.intensity * (1.0 - band);
     outColor = vec4(clamp(c, 0.0, 1.0), 1.0);
 }

--- a/app/src/main/cpp/winlator/vk/shaders/effect_scanlines.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_scanlines.frag
@@ -1,0 +1,22 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float intensity;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec2 res = pc.resolution.x > 0.0 ? pc.resolution : vec2(1280.0, 720.0);
+    vec3 c = texture(screenTexture, vUV).rgb;
+    float s = sin(vUV.y * res.y * (3.14159265 / 3.0));
+    float scan = s * s;
+    c *= 1.0 - pc.intensity * (1.0 - scan);
+    outColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_sharpen.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_sharpen.frag
@@ -1,0 +1,29 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float strength;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec2 res = pc.resolution.x > 0.0 ? pc.resolution : vec2(1280.0, 720.0);
+    vec2 t = 1.0 / max(res, vec2(1.0));
+
+    vec3 c = texture(screenTexture, vUV).rgb;
+    vec3 blur = (
+        texture(screenTexture, vUV + vec2(0.0, -t.y)).rgb +
+        texture(screenTexture, vUV + vec2(0.0,  t.y)).rgb +
+        texture(screenTexture, vUV + vec2(-t.x, 0.0)).rgb +
+        texture(screenTexture, vUV + vec2( t.x, 0.0)).rgb
+    ) * 0.25;
+
+    vec3 sharp = c + (c - blur) * (pc.strength * 1.5);
+    outColor = vec4(clamp(sharp, 0.0, 1.0), 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/shaders/effect_toon.frag
+++ b/app/src/main/cpp/winlator/vk/shaders/effect_toon.frag
@@ -1,0 +1,20 @@
+#version 450
+
+layout(location = 0) in vec2 vUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D screenTexture;
+
+layout(push_constant) uniform PC {
+    vec2 resolution;
+    float p0;
+    float p1;
+    float p2;
+} pc;
+
+void main() {
+    vec3 c = texture(screenTexture, vUV).rgb;
+    float levels = 6.0;
+    vec3 toon = floor(clamp(c, 0.0, 1.0) * levels + 0.5) / levels;
+    outColor = vec4(toon, 1.0);
+}

--- a/app/src/main/cpp/winlator/vk/vk_image.c
+++ b/app/src/main/cpp/winlator/vk/vk_image.c
@@ -352,6 +352,24 @@ static void write_descriptor_set(VkRenderer* r, VkDescriptorSet set, VkImageView
     vkUpdateDescriptorSets(r->device, 1, &w, 0, NULL);
 }
 
+static VkSampler active_shared_sampler(VkRenderer* r) {
+    return r->scale_filter_nearest ? r->shared_sampler_nearest : r->shared_sampler;
+}
+
+// Caller must hold render_mutex with in-flight frames drained.
+void vkr_retarget_shared_sampler(VkRenderer* r) {
+    VkSampler s = active_shared_sampler(r);
+    if (s == VK_NULL_HANDLE) return;
+    pthread_mutex_lock(&r->texture_mutex);
+    for (uint32_t i = 0; i < r->live_texture_count; i++) {
+        VkTexture* t = r->live_textures[i];
+        if (!t || t->descriptor_set == VK_NULL_HANDLE || t->view == VK_NULL_HANDLE) continue;
+        if (t->ycbcr != VK_NULL_HANDLE) continue;
+        write_descriptor_set(r, t->descriptor_set, t->view, s);
+    }
+    pthread_mutex_unlock(&r->texture_mutex);
+}
+
 static void destroy_texture_resources(VkRenderer* r, VkTexture* tex) {
     if (!tex) return;
     if (tex->descriptor_set != VK_NULL_HANDLE) {
@@ -761,7 +779,7 @@ VkTexture* vkr_texture_create_uploaded(VkRenderer* r, uint32_t width, uint32_t h
         destroy_texture_resources(r, t);
         return NULL;
     }
-    write_descriptor_set(r, t->descriptor_set, t->view, r->shared_sampler);
+    write_descriptor_set(r, t->descriptor_set, t->view, active_shared_sampler(r));
 
     if (data && data_size > 0) {
         vkr_texture_update(r, t, width, height, data, data_size, stride_pixels,
@@ -1251,7 +1269,7 @@ VkTexture* vkr_texture_import_ahb(VkRenderer* r, AHardwareBuffer* ahb, bool tran
         }
         sampler_for_descriptor = t->sampler;
     } else if (r->shared_sampler != VK_NULL_HANDLE) {
-        sampler_for_descriptor = r->shared_sampler;
+        sampler_for_descriptor = active_shared_sampler(r);
     } else {
         VK_LOGE("AHB import: shared_sampler not initialized");
         vkDestroyImageView(r->device, t->view, NULL);

--- a/app/src/main/cpp/winlator/vk/vk_image.c
+++ b/app/src/main/cpp/winlator/vk/vk_image.c
@@ -353,7 +353,11 @@ static void write_descriptor_set(VkRenderer* r, VkDescriptorSet set, VkImageView
 }
 
 static VkSampler active_shared_sampler(VkRenderer* r) {
-    return r->scale_filter_nearest ? r->shared_sampler_nearest : r->shared_sampler;
+    switch (r->scale_filter) {
+        case 1:  return r->shared_sampler_nearest;
+        case 3:  return r->ext_filter_cubic ? r->shared_sampler_cubic : r->shared_sampler;
+        default: return r->shared_sampler;
+    }
 }
 
 // Caller must hold render_mutex with in-flight frames drained.

--- a/app/src/main/cpp/winlator/vk/vk_renderer.c
+++ b/app/src/main/cpp/winlator/vk/vk_renderer.c
@@ -34,6 +34,9 @@
 #include "shaders/effect_vivid_frag.spv.h"
 #include "shaders/effect_hdr_frag.spv.h"
 #include "shaders/effect_natural_frag.spv.h"
+#include "shaders/effect_toon_frag.spv.h"
+#include "shaders/effect_ntsc_frag.spv.h"
+#include "shaders/effect_coloradj_frag.spv.h"
 #include "shaders/sgsr1_frag.spv.h"
 
 // ============================================================
@@ -842,9 +845,13 @@ static bool create_pipelines(VkRenderer* r) {
     VkShaderModule fs_vivid  = load_shader_module(r, effect_vivid_frag,  effect_vivid_frag_size);
     VkShaderModule fs_hdr    = load_shader_module(r, effect_hdr_frag,    effect_hdr_frag_size);
     VkShaderModule fs_natural= load_shader_module(r, effect_natural_frag,effect_natural_frag_size);
+    VkShaderModule fs_toon   = load_shader_module(r, effect_toon_frag,   effect_toon_frag_size);
+    VkShaderModule fs_ntsc   = load_shader_module(r, effect_ntsc_frag,   effect_ntsc_frag_size);
+    VkShaderModule fs_coloradj = load_shader_module(r, effect_coloradj_frag, effect_coloradj_frag_size);
     VkShaderModule fs_sgsr1 = load_shader_module(r, sgsr1_frag, sgsr1_frag_size);
     if (!vs_window || !fs_window || !fs_cursor || !vs_quad || !fs_blit
         || !fs_crt || !fs_vivid || !fs_hdr || !fs_natural
+        || !fs_toon || !fs_ntsc || !fs_coloradj
         || !fs_sgsr1) {
         return false;
     }
@@ -873,6 +880,15 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.effect_pipelines[VK_EFFECT_SGSR1] = create_graphics_pipeline(
         r, vs_quad, fs_sgsr1, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
         false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_TOON] = create_graphics_pipeline(
+        r, vs_quad, fs_toon, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_NTSC] = create_graphics_pipeline(
+        r, vs_quad, fs_ntsc, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_COLORADJ] = create_graphics_pipeline(
+        r, vs_quad, fs_coloradj, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
     r->pipelines.offscreen_window_pipeline = create_graphics_pipeline(
         r, vs_window, fs_window, r->pipelines.window_layout, r->pipelines.offscreen_pass,
         true, false, NULL);
@@ -897,6 +913,15 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.offscreen_effect_pipelines[VK_EFFECT_SGSR1] = create_graphics_pipeline(
         r, vs_quad, fs_sgsr1, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
         false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_TOON] = create_graphics_pipeline(
+        r, vs_quad, fs_toon, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_NTSC] = create_graphics_pipeline(
+        r, vs_quad, fs_ntsc, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_COLORADJ] = create_graphics_pipeline(
+        r, vs_quad, fs_coloradj, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
 
     vkDestroyShaderModule(r->device, vs_window, NULL);
     vkDestroyShaderModule(r->device, fs_window, NULL);
@@ -907,6 +932,9 @@ static bool create_pipelines(VkRenderer* r) {
     vkDestroyShaderModule(r->device, fs_vivid, NULL);
     vkDestroyShaderModule(r->device, fs_hdr, NULL);
     vkDestroyShaderModule(r->device, fs_natural, NULL);
+    vkDestroyShaderModule(r->device, fs_toon, NULL);
+    vkDestroyShaderModule(r->device, fs_ntsc, NULL);
+    vkDestroyShaderModule(r->device, fs_coloradj, NULL);
     vkDestroyShaderModule(r->device, fs_sgsr1, NULL);
 
     if (!r->pipelines.window_pipeline || !r->pipelines.cursor_pipeline
@@ -2033,6 +2061,18 @@ JNIEXPORT jlong JNICALL JNI_FN(nativeCreate)(JNIEnv* env, jclass clazz,
     if (!create_descriptor_pool(r, r->caps.descriptor_pool_capacity)) goto fail;
     if (!create_quad_vbo(r)) goto fail;
     if (!vkr_create_sampler(r, VK_NULL_HANDLE, &r->shared_sampler)) goto fail;
+    {
+        VkSamplerCreateInfo nsi = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+        nsi.magFilter = VK_FILTER_NEAREST;
+        nsi.minFilter = VK_FILTER_NEAREST;
+        nsi.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        nsi.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        nsi.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        nsi.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+        nsi.unnormalizedCoordinates = VK_FALSE;
+        nsi.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        if (vkCreateSampler(r->device, &nsi, NULL, &r->shared_sampler_nearest) != VK_SUCCESS) goto fail;
+    }
     if (!vkr_staging_pool_init(r)) goto fail;
     vkr_suballoc_init(r);
 
@@ -2044,6 +2084,7 @@ fail:
     vkr_staging_pool_destroy(r);
     vkr_suballoc_destroy(r);  // safe if never initialized
     if (r->shared_sampler) vkDestroySampler(r->device, r->shared_sampler, NULL);
+    if (r->shared_sampler_nearest) vkDestroySampler(r->device, r->shared_sampler_nearest, NULL);
     if (r->cmd_pool) vkDestroyCommandPool(r->device, r->cmd_pool, NULL);
     free(r->descriptor_free_list); r->descriptor_free_list = NULL; r->descriptor_free_count = 0;
     if (r->descriptor_pool) vkDestroyDescriptorPool(r->device, r->descriptor_pool, NULL);
@@ -2098,6 +2139,7 @@ JNIEXPORT void JNICALL JNI_FN(nativeDestroy)(JNIEnv* env, jclass clazz, jlong ha
     }
 
     if (r->shared_sampler) vkDestroySampler(r->device, r->shared_sampler, NULL);
+    if (r->shared_sampler_nearest) vkDestroySampler(r->device, r->shared_sampler_nearest, NULL);
     if (r->cmd_pool) vkDestroyCommandPool(r->device, r->cmd_pool, NULL);
     free(r->descriptor_free_list); r->descriptor_free_list = NULL; r->descriptor_free_count = 0;
     if (r->descriptor_pool) vkDestroyDescriptorPool(r->device, r->descriptor_pool, NULL);
@@ -2381,6 +2423,22 @@ JNIEXPORT void JNICALL JNI_FN(nativeSetScene)(JNIEnv* env, jclass clazz, jlong h
 // entry point is kept as a no-op for Java-side ABI compatibility.
 JNIEXPORT void JNICALL JNI_FN(nativeSetFpsLimit)(JNIEnv* env, jclass clazz, jlong handle, jint fps) {
     (void)env; (void)clazz; (void)handle; (void)fps;
+}
+
+// Java passes 0=off/linear, 1=nearest, 2=linear; only 1 selects nearest scaling.
+JNIEXPORT void JNICALL JNI_FN(nativeSetScaleFilter)(JNIEnv* env, jclass clazz, jlong handle, jint mode) {
+    (void)env; (void)clazz;
+    VkRenderer* r = (VkRenderer*)(intptr_t)handle;
+    if (!r) return;
+
+    bool nearest = (mode == 1);
+    if (r->scale_filter_nearest == nearest) return;
+
+    pthread_mutex_lock(&r->render_mutex);
+    wait_inflight_frames(r);
+    r->scale_filter_nearest = nearest;
+    vkr_retarget_shared_sampler(r);
+    pthread_mutex_unlock(&r->render_mutex);
 }
 
 // Set the compositor present mode. Java passes 0=FIFO, 1=MAILBOX, 2=IMMEDIATE; anything else

--- a/app/src/main/cpp/winlator/vk/vk_renderer.c
+++ b/app/src/main/cpp/winlator/vk/vk_renderer.c
@@ -41,6 +41,8 @@
 #include "shaders/effect_colorgrade_frag.spv.h"
 #include "shaders/effect_sharpen_frag.spv.h"
 #include "shaders/effect_scanlines_frag.spv.h"
+#include "shaders/effect_colorblind_frag.spv.h"
+#include "shaders/effect_pixelate_frag.spv.h"
 #include "shaders/sgsr1_frag.spv.h"
 
 // ============================================================
@@ -859,11 +861,14 @@ static bool create_pipelines(VkRenderer* r) {
     VkShaderModule fs_colorgrade = load_shader_module(r, effect_colorgrade_frag, effect_colorgrade_frag_size);
     VkShaderModule fs_sharpen = load_shader_module(r, effect_sharpen_frag, effect_sharpen_frag_size);
     VkShaderModule fs_scanlines = load_shader_module(r, effect_scanlines_frag, effect_scanlines_frag_size);
+    VkShaderModule fs_colorblind = load_shader_module(r, effect_colorblind_frag, effect_colorblind_frag_size);
+    VkShaderModule fs_pixelate = load_shader_module(r, effect_pixelate_frag, effect_pixelate_frag_size);
     VkShaderModule fs_sgsr1 = load_shader_module(r, sgsr1_frag, sgsr1_frag_size);
     if (!vs_window || !fs_window || !fs_cursor || !vs_quad || !fs_blit
         || !fs_crt || !fs_vivid || !fs_hdr || !fs_natural
         || !fs_toon || !fs_ntsc || !fs_ntsc2 || !fs_coloradj
         || !fs_colorgrade || !fs_sharpen || !fs_scanlines
+        || !fs_colorblind || !fs_pixelate
         || !fs_sgsr1) {
         return false;
     }
@@ -913,6 +918,12 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.effect_pipelines[VK_EFFECT_NTSC2] = create_graphics_pipeline(
         r, vs_quad, fs_ntsc2, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
         false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_COLORBLIND] = create_graphics_pipeline(
+        r, vs_quad, fs_colorblind, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_PIXELATE] = create_graphics_pipeline(
+        r, vs_quad, fs_pixelate, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
     r->pipelines.offscreen_window_pipeline = create_graphics_pipeline(
         r, vs_window, fs_window, r->pipelines.window_layout, r->pipelines.offscreen_pass,
         true, false, NULL);
@@ -958,6 +969,12 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.offscreen_effect_pipelines[VK_EFFECT_NTSC2] = create_graphics_pipeline(
         r, vs_quad, fs_ntsc2, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
         false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_COLORBLIND] = create_graphics_pipeline(
+        r, vs_quad, fs_colorblind, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_PIXELATE] = create_graphics_pipeline(
+        r, vs_quad, fs_pixelate, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
 
     vkDestroyShaderModule(r->device, vs_window, NULL);
     vkDestroyShaderModule(r->device, fs_window, NULL);
@@ -975,6 +992,8 @@ static bool create_pipelines(VkRenderer* r) {
     vkDestroyShaderModule(r->device, fs_colorgrade, NULL);
     vkDestroyShaderModule(r->device, fs_sharpen, NULL);
     vkDestroyShaderModule(r->device, fs_scanlines, NULL);
+    vkDestroyShaderModule(r->device, fs_colorblind, NULL);
+    vkDestroyShaderModule(r->device, fs_pixelate, NULL);
     vkDestroyShaderModule(r->device, fs_sgsr1, NULL);
 
     if (!r->pipelines.window_pipeline || !r->pipelines.cursor_pipeline

--- a/app/src/main/cpp/winlator/vk/vk_renderer.c
+++ b/app/src/main/cpp/winlator/vk/vk_renderer.c
@@ -36,6 +36,7 @@
 #include "shaders/effect_natural_frag.spv.h"
 #include "shaders/effect_toon_frag.spv.h"
 #include "shaders/effect_ntsc_frag.spv.h"
+#include "shaders/effect_ntsc2_frag.spv.h"
 #include "shaders/effect_coloradj_frag.spv.h"
 #include "shaders/effect_colorgrade_frag.spv.h"
 #include "shaders/effect_sharpen_frag.spv.h"
@@ -853,6 +854,7 @@ static bool create_pipelines(VkRenderer* r) {
     VkShaderModule fs_natural= load_shader_module(r, effect_natural_frag,effect_natural_frag_size);
     VkShaderModule fs_toon   = load_shader_module(r, effect_toon_frag,   effect_toon_frag_size);
     VkShaderModule fs_ntsc   = load_shader_module(r, effect_ntsc_frag,   effect_ntsc_frag_size);
+    VkShaderModule fs_ntsc2  = load_shader_module(r, effect_ntsc2_frag,  effect_ntsc2_frag_size);
     VkShaderModule fs_coloradj = load_shader_module(r, effect_coloradj_frag, effect_coloradj_frag_size);
     VkShaderModule fs_colorgrade = load_shader_module(r, effect_colorgrade_frag, effect_colorgrade_frag_size);
     VkShaderModule fs_sharpen = load_shader_module(r, effect_sharpen_frag, effect_sharpen_frag_size);
@@ -860,7 +862,7 @@ static bool create_pipelines(VkRenderer* r) {
     VkShaderModule fs_sgsr1 = load_shader_module(r, sgsr1_frag, sgsr1_frag_size);
     if (!vs_window || !fs_window || !fs_cursor || !vs_quad || !fs_blit
         || !fs_crt || !fs_vivid || !fs_hdr || !fs_natural
-        || !fs_toon || !fs_ntsc || !fs_coloradj
+        || !fs_toon || !fs_ntsc || !fs_ntsc2 || !fs_coloradj
         || !fs_colorgrade || !fs_sharpen || !fs_scanlines
         || !fs_sgsr1) {
         return false;
@@ -908,6 +910,9 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.effect_pipelines[VK_EFFECT_SCANLINES] = create_graphics_pipeline(
         r, vs_quad, fs_scanlines, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
         false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_NTSC2] = create_graphics_pipeline(
+        r, vs_quad, fs_ntsc2, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
     r->pipelines.offscreen_window_pipeline = create_graphics_pipeline(
         r, vs_window, fs_window, r->pipelines.window_layout, r->pipelines.offscreen_pass,
         true, false, NULL);
@@ -950,6 +955,9 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.offscreen_effect_pipelines[VK_EFFECT_SCANLINES] = create_graphics_pipeline(
         r, vs_quad, fs_scanlines, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
         false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_NTSC2] = create_graphics_pipeline(
+        r, vs_quad, fs_ntsc2, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
 
     vkDestroyShaderModule(r->device, vs_window, NULL);
     vkDestroyShaderModule(r->device, fs_window, NULL);
@@ -962,6 +970,7 @@ static bool create_pipelines(VkRenderer* r) {
     vkDestroyShaderModule(r->device, fs_natural, NULL);
     vkDestroyShaderModule(r->device, fs_toon, NULL);
     vkDestroyShaderModule(r->device, fs_ntsc, NULL);
+    vkDestroyShaderModule(r->device, fs_ntsc2, NULL);
     vkDestroyShaderModule(r->device, fs_coloradj, NULL);
     vkDestroyShaderModule(r->device, fs_colorgrade, NULL);
     vkDestroyShaderModule(r->device, fs_sharpen, NULL);

--- a/app/src/main/cpp/winlator/vk/vk_renderer.c
+++ b/app/src/main/cpp/winlator/vk/vk_renderer.c
@@ -37,6 +37,9 @@
 #include "shaders/effect_toon_frag.spv.h"
 #include "shaders/effect_ntsc_frag.spv.h"
 #include "shaders/effect_coloradj_frag.spv.h"
+#include "shaders/effect_colorgrade_frag.spv.h"
+#include "shaders/effect_sharpen_frag.spv.h"
+#include "shaders/effect_scanlines_frag.spv.h"
 #include "shaders/sgsr1_frag.spv.h"
 
 // ============================================================
@@ -343,6 +346,7 @@ static bool create_device(VkRenderer* r) {
     bool has_ycbcr = has_extension(exts, ext_count, VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     bool has_extmem_caps = has_extension(exts, ext_count, VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
     bool has_queue_fam = has_extension(exts, ext_count, VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME);
+    bool has_cubic = has_extension(exts, ext_count, VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
 
     free(exts);
 
@@ -359,10 +363,12 @@ static bool create_device(VkRenderer* r) {
         if (has_queue_fam) enable[enable_n++] = VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME;
     }
     if (has_ycbcr) enable[enable_n++] = VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME;
+    if (has_cubic) enable[enable_n++] = VK_EXT_FILTER_CUBIC_EXTENSION_NAME;
     (void)has_extmem_caps;
 
     r->ext_ahb = ahb_ok;
     r->ext_ycbcr = has_ycbcr;
+    r->ext_filter_cubic = has_cubic;
     VK_LOGI("AHB Vulkan device support: android_hardware_buffer=%d external_memory=%d dedicated=%d get_memory_requirements2=%d queue_family_foreign=%d enabled=%d",
             has_ahb, has_extmem, has_dedicated, has_get_mem_req2, has_queue_fam, r->ext_ahb);
     if (!r->ext_ahb) {
@@ -848,10 +854,14 @@ static bool create_pipelines(VkRenderer* r) {
     VkShaderModule fs_toon   = load_shader_module(r, effect_toon_frag,   effect_toon_frag_size);
     VkShaderModule fs_ntsc   = load_shader_module(r, effect_ntsc_frag,   effect_ntsc_frag_size);
     VkShaderModule fs_coloradj = load_shader_module(r, effect_coloradj_frag, effect_coloradj_frag_size);
+    VkShaderModule fs_colorgrade = load_shader_module(r, effect_colorgrade_frag, effect_colorgrade_frag_size);
+    VkShaderModule fs_sharpen = load_shader_module(r, effect_sharpen_frag, effect_sharpen_frag_size);
+    VkShaderModule fs_scanlines = load_shader_module(r, effect_scanlines_frag, effect_scanlines_frag_size);
     VkShaderModule fs_sgsr1 = load_shader_module(r, sgsr1_frag, sgsr1_frag_size);
     if (!vs_window || !fs_window || !fs_cursor || !vs_quad || !fs_blit
         || !fs_crt || !fs_vivid || !fs_hdr || !fs_natural
         || !fs_toon || !fs_ntsc || !fs_coloradj
+        || !fs_colorgrade || !fs_sharpen || !fs_scanlines
         || !fs_sgsr1) {
         return false;
     }
@@ -889,6 +899,15 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.effect_pipelines[VK_EFFECT_COLORADJ] = create_graphics_pipeline(
         r, vs_quad, fs_coloradj, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
         false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_COLORGRADE] = create_graphics_pipeline(
+        r, vs_quad, fs_colorgrade, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_SHARPEN] = create_graphics_pipeline(
+        r, vs_quad, fs_sharpen, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
+    r->pipelines.effect_pipelines[VK_EFFECT_SCANLINES] = create_graphics_pipeline(
+        r, vs_quad, fs_scanlines, r->pipelines.effect_layout, r->pipelines.swapchain_pass,
+        false, false, NULL);
     r->pipelines.offscreen_window_pipeline = create_graphics_pipeline(
         r, vs_window, fs_window, r->pipelines.window_layout, r->pipelines.offscreen_pass,
         true, false, NULL);
@@ -922,6 +941,15 @@ static bool create_pipelines(VkRenderer* r) {
     r->pipelines.offscreen_effect_pipelines[VK_EFFECT_COLORADJ] = create_graphics_pipeline(
         r, vs_quad, fs_coloradj, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
         false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_COLORGRADE] = create_graphics_pipeline(
+        r, vs_quad, fs_colorgrade, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_SHARPEN] = create_graphics_pipeline(
+        r, vs_quad, fs_sharpen, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
+    r->pipelines.offscreen_effect_pipelines[VK_EFFECT_SCANLINES] = create_graphics_pipeline(
+        r, vs_quad, fs_scanlines, r->pipelines.effect_layout, r->pipelines.offscreen_pass,
+        false, false, NULL);
 
     vkDestroyShaderModule(r->device, vs_window, NULL);
     vkDestroyShaderModule(r->device, fs_window, NULL);
@@ -935,6 +963,9 @@ static bool create_pipelines(VkRenderer* r) {
     vkDestroyShaderModule(r->device, fs_toon, NULL);
     vkDestroyShaderModule(r->device, fs_ntsc, NULL);
     vkDestroyShaderModule(r->device, fs_coloradj, NULL);
+    vkDestroyShaderModule(r->device, fs_colorgrade, NULL);
+    vkDestroyShaderModule(r->device, fs_sharpen, NULL);
+    vkDestroyShaderModule(r->device, fs_scanlines, NULL);
     vkDestroyShaderModule(r->device, fs_sgsr1, NULL);
 
     if (!r->pipelines.window_pipeline || !r->pipelines.cursor_pipeline
@@ -2073,6 +2104,21 @@ JNIEXPORT jlong JNICALL JNI_FN(nativeCreate)(JNIEnv* env, jclass clazz,
         nsi.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
         if (vkCreateSampler(r->device, &nsi, NULL, &r->shared_sampler_nearest) != VK_SUCCESS) goto fail;
     }
+    if (r->ext_filter_cubic) {
+        VkSamplerCreateInfo csi = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+        csi.magFilter = VK_FILTER_CUBIC_EXT;
+        csi.minFilter = VK_FILTER_LINEAR;
+        csi.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        csi.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        csi.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        csi.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+        csi.unnormalizedCoordinates = VK_FALSE;
+        csi.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        if (vkCreateSampler(r->device, &csi, NULL, &r->shared_sampler_cubic) != VK_SUCCESS) {
+            r->shared_sampler_cubic = VK_NULL_HANDLE;
+            r->ext_filter_cubic = false;
+        }
+    }
     if (!vkr_staging_pool_init(r)) goto fail;
     vkr_suballoc_init(r);
 
@@ -2085,6 +2131,7 @@ fail:
     vkr_suballoc_destroy(r);  // safe if never initialized
     if (r->shared_sampler) vkDestroySampler(r->device, r->shared_sampler, NULL);
     if (r->shared_sampler_nearest) vkDestroySampler(r->device, r->shared_sampler_nearest, NULL);
+    if (r->shared_sampler_cubic) vkDestroySampler(r->device, r->shared_sampler_cubic, NULL);
     if (r->cmd_pool) vkDestroyCommandPool(r->device, r->cmd_pool, NULL);
     free(r->descriptor_free_list); r->descriptor_free_list = NULL; r->descriptor_free_count = 0;
     if (r->descriptor_pool) vkDestroyDescriptorPool(r->device, r->descriptor_pool, NULL);
@@ -2140,6 +2187,7 @@ JNIEXPORT void JNICALL JNI_FN(nativeDestroy)(JNIEnv* env, jclass clazz, jlong ha
 
     if (r->shared_sampler) vkDestroySampler(r->device, r->shared_sampler, NULL);
     if (r->shared_sampler_nearest) vkDestroySampler(r->device, r->shared_sampler_nearest, NULL);
+    if (r->shared_sampler_cubic) vkDestroySampler(r->device, r->shared_sampler_cubic, NULL);
     if (r->cmd_pool) vkDestroyCommandPool(r->device, r->cmd_pool, NULL);
     free(r->descriptor_free_list); r->descriptor_free_list = NULL; r->descriptor_free_count = 0;
     if (r->descriptor_pool) vkDestroyDescriptorPool(r->device, r->descriptor_pool, NULL);
@@ -2425,18 +2473,17 @@ JNIEXPORT void JNICALL JNI_FN(nativeSetFpsLimit)(JNIEnv* env, jclass clazz, jlon
     (void)env; (void)clazz; (void)handle; (void)fps;
 }
 
-// Java passes 0=off/linear, 1=nearest, 2=linear; only 1 selects nearest scaling.
+// 0=off/linear, 1=nearest, 2=linear, 3=bicubic (linear fallback when cubic unsupported).
 JNIEXPORT void JNICALL JNI_FN(nativeSetScaleFilter)(JNIEnv* env, jclass clazz, jlong handle, jint mode) {
     (void)env; (void)clazz;
     VkRenderer* r = (VkRenderer*)(intptr_t)handle;
     if (!r) return;
 
-    bool nearest = (mode == 1);
-    if (r->scale_filter_nearest == nearest) return;
+    if (r->scale_filter == mode) return;
 
     pthread_mutex_lock(&r->render_mutex);
     wait_inflight_frames(r);
-    r->scale_filter_nearest = nearest;
+    r->scale_filter = mode;
     vkr_retarget_shared_sampler(r);
     pthread_mutex_unlock(&r->render_mutex);
 }

--- a/app/src/main/cpp/winlator/vk/vk_state.h
+++ b/app/src/main/cpp/winlator/vk/vk_state.h
@@ -110,6 +110,8 @@ typedef enum VkEffectType {
     VK_EFFECT_SHARPEN = 9,
     VK_EFFECT_SCANLINES = 10,
     VK_EFFECT_NTSC2 = 11,
+    VK_EFFECT_COLORBLIND = 12,
+    VK_EFFECT_PIXELATE = 13,
     VK_EFFECT_COUNT
 } VkEffectType;
 

--- a/app/src/main/cpp/winlator/vk/vk_state.h
+++ b/app/src/main/cpp/winlator/vk/vk_state.h
@@ -106,6 +106,9 @@ typedef enum VkEffectType {
     VK_EFFECT_TOON = 5,
     VK_EFFECT_NTSC = 6,
     VK_EFFECT_COLORADJ = 7,
+    VK_EFFECT_COLORGRADE = 8,
+    VK_EFFECT_SHARPEN = 9,
+    VK_EFFECT_SCANLINES = 10,
     VK_EFFECT_COUNT
 } VkEffectType;
 
@@ -370,7 +373,9 @@ typedef struct VkRenderer {
     // every texture its own sampler is a non-trivial CPU+GPU tax during pixmap churn.
     VkSampler        shared_sampler;
     VkSampler        shared_sampler_nearest;
-    bool             scale_filter_nearest;
+    VkSampler        shared_sampler_cubic;
+    bool             ext_filter_cubic;
+    int              scale_filter;
 
     // Per-frame
     VkCommandPool    cmd_pool;

--- a/app/src/main/cpp/winlator/vk/vk_state.h
+++ b/app/src/main/cpp/winlator/vk/vk_state.h
@@ -103,6 +103,9 @@ typedef enum VkEffectType {
     VK_EFFECT_HDR = 2,
     VK_EFFECT_NATURAL = 3,
     VK_EFFECT_SGSR1 = 4,
+    VK_EFFECT_TOON = 5,
+    VK_EFFECT_NTSC = 6,
+    VK_EFFECT_COLORADJ = 7,
     VK_EFFECT_COUNT
 } VkEffectType;
 
@@ -366,6 +369,8 @@ typedef struct VkRenderer {
     // conversion. Created once at init; vkCreateSampler costs ~50-200µs on Adreno, so giving
     // every texture its own sampler is a non-trivial CPU+GPU tax during pixmap churn.
     VkSampler        shared_sampler;
+    VkSampler        shared_sampler_nearest;
+    bool             scale_filter_nearest;
 
     // Per-frame
     VkCommandPool    cmd_pool;
@@ -450,6 +455,7 @@ void       vkr_image_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout f
                              VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage,
                              VkAccessFlags src_access, VkAccessFlags dst_access);
 bool       vkr_create_sampler(VkRenderer* r, VkSamplerYcbcrConversion ycbcr, VkSampler* out);
+void       vkr_retarget_shared_sampler(VkRenderer* r);
 // Async layout transition through the staging pool. Submits a tiny command buffer that runs
 // the requested barrier, but does NOT wait for the GPU. The barrier is ordered before all
 // subsequent submits on the same queue per Vulkan spec, so callers can sample the image as

--- a/app/src/main/cpp/winlator/vk/vk_state.h
+++ b/app/src/main/cpp/winlator/vk/vk_state.h
@@ -109,6 +109,7 @@ typedef enum VkEffectType {
     VK_EFFECT_COLORGRADE = 8,
     VK_EFFECT_SHARPEN = 9,
     VK_EFFECT_SCANLINES = 10,
+    VK_EFFECT_NTSC2 = 11,
     VK_EFFECT_COUNT
 } VkEffectType;
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -717,6 +717,15 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_scale">Scale</string>
     <string name="session_drawer_scale_nearest">Nearest</string>
     <string name="session_drawer_scale_linear">Linear</string>
+    <string name="session_drawer_scale_bicubic">Bicubic</string>
+    <string name="session_drawer_saturation">Saturation</string>
+    <string name="session_drawer_temperature">Temperature</string>
+    <string name="session_drawer_tint">Tint</string>
+    <string name="session_drawer_sharpen">Sharpen</string>
+    <string name="session_drawer_scanlines">Scanlines</string>
+    <string name="session_drawer_strength">Strength</string>
+    <string name="session_drawer_intensity">Intensity</string>
+    <string name="session_drawer_reset_effects">Reset effects</string>
     <string name="session_drawer_calibrate_advanced">Advanced calibration</string>
     <string name="session_drawer_rail_label_hud">HUD</string>
     <string name="session_drawer_rail_label_gyro">Gyro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -709,6 +709,14 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_color_profile_hdr">HDR</string>
     <string name="session_drawer_color_profile_natural">Natural</string>
     <string name="session_drawer_color_profile_crt">CRT Effect</string>
+    <string name="session_drawer_color_profile_toon">Toon</string>
+    <string name="session_drawer_color_profile_ntsc">NTSC</string>
+    <string name="session_drawer_brightness">Brightness</string>
+    <string name="session_drawer_contrast">Contrast</string>
+    <string name="session_drawer_gamma">Gamma</string>
+    <string name="session_drawer_scale">Scale</string>
+    <string name="session_drawer_scale_nearest">Nearest</string>
+    <string name="session_drawer_scale_linear">Linear</string>
     <string name="session_drawer_calibrate_advanced">Advanced calibration</string>
     <string name="session_drawer_rail_label_hud">HUD</string>
     <string name="session_drawer_rail_label_gyro">Gyro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -710,7 +710,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_color_profile_natural">Natural</string>
     <string name="session_drawer_color_profile_crt">CRT Effect</string>
     <string name="session_drawer_color_profile_toon">Toon</string>
-    <string name="session_drawer_color_profile_ntsc">NTSC</string>
+    <string name="session_drawer_color_profile_ntsc">Ntsc</string>
+    <string name="session_drawer_color_profile_ntsc2">Ntsc2</string>
     <string name="session_drawer_brightness">Brightness</string>
     <string name="session_drawer_contrast">Contrast</string>
     <string name="session_drawer_gamma">Gamma</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -724,8 +724,14 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_tint">Tint</string>
     <string name="session_drawer_sharpen">Sharpen</string>
     <string name="session_drawer_scanlines">Scanlines</string>
+    <string name="session_drawer_pixelate">Pixelate</string>
+    <string name="session_drawer_block_size">Block size</string>
     <string name="session_drawer_strength">Strength</string>
     <string name="session_drawer_intensity">Intensity</string>
+    <string name="session_drawer_color_blind">Color Blind</string>
+    <string name="session_drawer_color_blind_protan">Protan</string>
+    <string name="session_drawer_color_blind_deutan">Deutan</string>
+    <string name="session_drawer_color_blind_tritan">Tritan</string>
     <string name="session_drawer_reset_effects">Reset effects</string>
     <string name="session_drawer_calibrate_advanced">Advanced calibration</string>
     <string name="session_drawer_rail_label_hud">HUD</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -97,12 +97,14 @@ import com.winlator.cmod.shared.util.StringUtils;
 import com.winlator.cmod.shared.io.TarCompressorUtils;
 import com.winlator.cmod.runtime.display.renderer.EffectComposer;
 import com.winlator.cmod.runtime.display.renderer.effects.ColorAdjustEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.ColorBlindEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.ColorGradeEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.CRTEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.HDREffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NaturalEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NTSC2Effect;
 import com.winlator.cmod.runtime.display.renderer.effects.NTSCEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.PixelateEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.ScanlinesEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.SGSRUpscaler;
 import com.winlator.cmod.runtime.display.renderer.effects.SharpenEffect;
@@ -371,6 +373,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private int sharpenStrength = 50;
     private boolean scanlinesEnabled = false;
     private int scanlinesIntensity = 50;
+    private boolean pixelateEnabled = false;
+    private int pixelateBlock = 6;
+    private int colorBlind = 0;
     private boolean gyroscopeCardExpanded = false;
     private XServerDrawerStateHolder drawerStateHolder;
     private XServerDrawerActionListener drawerActionListener;
@@ -3874,6 +3879,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 sharpenStrength,
                 scanlinesEnabled,
                 scanlinesIntensity,
+                pixelateEnabled,
+                pixelateBlock,
+                colorBlind,
                 inputProfileNames,
                 inputSelectedIndex,
                 styleNames,
@@ -4206,6 +4214,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onScanlinesEnabledChanged(boolean enabled) {
                         scanlinesEnabled = enabled;
+                        if (enabled) pixelateEnabled = false;
                         saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
@@ -4214,6 +4223,31 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onScanlinesIntensityChanged(int value) {
                         scanlinesIntensity = Math.max(0, Math.min(100, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onPixelateEnabledChanged(boolean enabled) {
+                        pixelateEnabled = enabled;
+                        if (enabled) scanlinesEnabled = false;
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onPixelateBlockChanged(int value) {
+                        pixelateBlock = Math.max(2, Math.min(14, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onColorBlindSelected(int mode) {
+                        colorBlind = mode;
                         saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
@@ -4235,6 +4269,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                         sharpenStrength = 50;
                         scanlinesEnabled = false;
                         scanlinesIntensity = 50;
+                        pixelateEnabled = false;
+                        pixelateBlock = 6;
+                        colorBlind = 0;
                         saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
@@ -4701,6 +4738,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         // Rebuilt in a fixed order each call so toggle sequence can't reorder the chain.
         composer.removeEffect(composer.getEffect(ColorAdjustEffect.class));
         composer.removeEffect(composer.getEffect(ColorGradeEffect.class));
+        composer.removeEffect(composer.getEffect(PixelateEffect.class));
         composer.removeEffect(composer.getEffect(SharpenEffect.class));
         composer.removeEffect(composer.getEffect(HDREffect.class));
         composer.removeEffect(composer.getEffect(NaturalEffect.class));
@@ -4709,6 +4747,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         composer.removeEffect(composer.getEffect(NTSCEffect.class));
         composer.removeEffect(composer.getEffect(NTSC2Effect.class));
         composer.removeEffect(composer.getEffect(VividEffect.class));
+        composer.removeEffect(composer.getEffect(ColorBlindEffect.class));
         composer.removeEffect(composer.getEffect(ScanlinesEffect.class));
 
         if (brightness != 0 || contrast != 0 || gammaPercent != 100) {
@@ -4721,6 +4760,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             ColorGradeEffect colorGrade = new ColorGradeEffect();
             colorGrade.set(saturation / 100.0f, temperature / 100.0f, tint / 100.0f);
             composer.addEffect(colorGrade);
+        }
+
+        if (pixelateEnabled) {
+            PixelateEffect pixelate = new PixelateEffect();
+            pixelate.setBlockSize(pixelateBlock);
+            composer.addEffect(pixelate);
         }
 
         if (sharpenEnabled) {
@@ -4742,6 +4787,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             VividEffect vivid = new VividEffect();
             vivid.setLevel((vividStrength / 25.0f) + 1.0f);
             composer.addEffect(vivid);
+        }
+
+        if (colorBlind != 0) {
+            ColorBlindEffect colorBlindEffect = new ColorBlindEffect();
+            colorBlindEffect.setMode(colorBlind);
+            composer.addEffect(colorBlindEffect);
         }
 
         if (scanlinesEnabled) {
@@ -4789,6 +4840,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         sharpenStrength = 50;
         scanlinesEnabled = false;
         scanlinesIntensity = 50;
+        pixelateEnabled = false;
+        pixelateBlock = 6;
+        colorBlind = 0;
         if (container == null) return;
         String json = container.getExtra("screenEffectsSettings");
         if (json == null || json.isEmpty()) return;
@@ -4808,6 +4862,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             sharpenStrength = Math.max(0, Math.min(100, o.optInt("sharpenStrength", 50)));
             scanlinesEnabled = o.optBoolean("scanlinesEnabled", false);
             scanlinesIntensity = Math.max(0, Math.min(100, o.optInt("scanlinesIntensity", 50)));
+            pixelateEnabled = o.optBoolean("pixelateEnabled", false);
+            pixelateBlock = Math.max(2, Math.min(14, o.optInt("pixelateBlock", 6)));
+            colorBlind = Math.max(0, Math.min(3, o.optInt("colorBlind", 0)));
         } catch (JSONException e) {
             Log.e("XServerDisplayActivity", "Failed to load screen effects", e);
         }
@@ -4831,6 +4888,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             o.put("sharpenStrength", sharpenStrength);
             o.put("scanlinesEnabled", scanlinesEnabled);
             o.put("scanlinesIntensity", scanlinesIntensity);
+            o.put("pixelateEnabled", pixelateEnabled);
+            o.put("pixelateBlock", pixelateBlock);
+            o.put("colorBlind", colorBlind);
             container.putExtra("screenEffectsSettings", o.toString());
             container.saveData();
         } catch (JSONException e) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -97,11 +97,14 @@ import com.winlator.cmod.shared.util.StringUtils;
 import com.winlator.cmod.shared.io.TarCompressorUtils;
 import com.winlator.cmod.runtime.display.renderer.EffectComposer;
 import com.winlator.cmod.runtime.display.renderer.effects.ColorAdjustEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.ColorGradeEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.CRTEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.HDREffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NaturalEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NTSCEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.ScanlinesEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.SGSRUpscaler;
+import com.winlator.cmod.runtime.display.renderer.effects.SharpenEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.ToonEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.VividEffect;
 import com.winlator.cmod.runtime.wine.WineInfo;
@@ -360,6 +363,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private int contrast = 0;
     private int gammaPercent = 100;
     private int scaleFilter = 0;
+    private int saturation = 100;
+    private int temperature = 0;
+    private int tint = 0;
+    private boolean sharpenEnabled = false;
+    private int sharpenStrength = 50;
+    private boolean scanlinesEnabled = false;
+    private int scanlinesIntensity = 50;
     private boolean gyroscopeCardExpanded = false;
     private XServerDrawerStateHolder drawerStateHolder;
     private XServerDrawerActionListener drawerActionListener;
@@ -3856,6 +3866,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 contrast,
                 gammaPercent,
                 scaleFilter,
+                saturation,
+                temperature,
+                tint,
+                sharpenEnabled,
+                sharpenStrength,
+                scanlinesEnabled,
+                scanlinesIntensity,
                 inputProfileNames,
                 inputSelectedIndex,
                 styleNames,
@@ -4092,7 +4109,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onVividEnabledChanged(boolean enabled) {
                         vividEnabled = enabled;
-                        preferences.edit().putBoolean("vivid_enabled", enabled).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4100,7 +4117,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onVividStrengthChanged(int strength) {
                         vividStrength = strength;
-                        preferences.edit().putInt("vivid_strength", strength).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4108,7 +4125,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onColorProfileSelected(int profile) {
                         colorProfile = profile;
-                        preferences.edit().putInt("color_profile", profile).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4116,7 +4133,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onBrightnessChanged(int value) {
                         brightness = Math.max(-100, Math.min(100, value));
-                        preferences.edit().putInt("color_brightness", brightness).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4124,7 +4141,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onContrastChanged(int value) {
                         contrast = Math.max(-100, Math.min(100, value));
-                        preferences.edit().putInt("color_contrast", contrast).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4132,7 +4149,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onGammaChanged(int value) {
                         gammaPercent = Math.max(50, Math.min(250, value));
-                        preferences.edit().putInt("color_gamma", gammaPercent).apply();
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4140,7 +4157,84 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onScaleFilterSelected(int mode) {
                         scaleFilter = mode;
-                        preferences.edit().putInt("scale_filter", mode).apply();
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onSaturationChanged(int value) {
+                        saturation = Math.max(0, Math.min(200, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onTemperatureChanged(int value) {
+                        temperature = Math.max(-100, Math.min(100, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onTintChanged(int value) {
+                        tint = Math.max(-100, Math.min(100, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onSharpenEnabledChanged(boolean enabled) {
+                        sharpenEnabled = enabled;
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onSharpenStrengthChanged(int value) {
+                        sharpenStrength = Math.max(0, Math.min(100, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onScanlinesEnabledChanged(boolean enabled) {
+                        scanlinesEnabled = enabled;
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onScanlinesIntensityChanged(int value) {
+                        scanlinesIntensity = Math.max(0, Math.min(100, value));
+                        saveScreenEffectsSettings();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onResetEffects() {
+                        vividEnabled = false;
+                        vividStrength = 100;
+                        colorProfile = 0;
+                        brightness = 0;
+                        contrast = 0;
+                        gammaPercent = 100;
+                        scaleFilter = 0;
+                        saturation = 100;
+                        temperature = 0;
+                        tint = 0;
+                        sharpenEnabled = false;
+                        sharpenStrength = 50;
+                        scanlinesEnabled = false;
+                        scanlinesIntensity = 50;
+                        saveScreenEffectsSettings();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4649,6 +4743,39 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             composer.removeEffect(colorAdj);
         }
 
+        ColorGradeEffect colorGrade = composer.getEffect(ColorGradeEffect.class);
+        if (saturation != 100 || temperature != 0 || tint != 0) {
+            if (colorGrade == null) {
+                colorGrade = new ColorGradeEffect();
+            }
+            colorGrade.set(saturation / 100.0f, temperature / 100.0f, tint / 100.0f);
+            composer.addEffect(colorGrade);
+        } else if (colorGrade != null) {
+            composer.removeEffect(colorGrade);
+        }
+
+        SharpenEffect sharpen = composer.getEffect(SharpenEffect.class);
+        if (sharpenEnabled) {
+            if (sharpen == null) {
+                sharpen = new SharpenEffect();
+            }
+            sharpen.setStrength(sharpenStrength / 100.0f);
+            composer.addEffect(sharpen);
+        } else if (sharpen != null) {
+            composer.removeEffect(sharpen);
+        }
+
+        ScanlinesEffect scanlines = composer.getEffect(ScanlinesEffect.class);
+        if (scanlinesEnabled) {
+            if (scanlines == null) {
+                scanlines = new ScanlinesEffect();
+            }
+            scanlines.setIntensity(scanlinesIntensity / 100.0f);
+            composer.addEffect(scanlines);
+        } else if (scanlines != null) {
+            composer.removeEffect(scanlines);
+        }
+
         renderer.setScaleFilter(scaleFilter);
     }
 
@@ -4670,15 +4797,71 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             sgsrUpscaleMode = clampSGSRUpscaleMode(preferences.getInt("sgsr_upscale_mode", 1));
             sgsrSharpness = preferences.getInt("sgsr_sharpness", legacyStrength);
         }
-        vividEnabled = preferences.contains("vivid_enabled")
-                ? preferences.getBoolean("vivid_enabled", false)
-                : legacyEnabled && legacyMode == 1;
-        vividStrength = preferences.getInt("vivid_strength", legacyStrength);
-        colorProfile = preferences.getInt("color_profile", 0);
-        brightness = Math.max(-100, Math.min(100, preferences.getInt("color_brightness", 0)));
-        contrast = Math.max(-100, Math.min(100, preferences.getInt("color_contrast", 0)));
-        gammaPercent = Math.max(50, Math.min(250, preferences.getInt("color_gamma", 100)));
-        scaleFilter = preferences.getInt("scale_filter", 0);
+        loadScreenEffectsFromContainer();
+    }
+
+    private void loadScreenEffectsFromContainer() {
+        vividEnabled = false;
+        vividStrength = 100;
+        colorProfile = 0;
+        brightness = 0;
+        contrast = 0;
+        gammaPercent = 100;
+        scaleFilter = 0;
+        saturation = 100;
+        temperature = 0;
+        tint = 0;
+        sharpenEnabled = false;
+        sharpenStrength = 50;
+        scanlinesEnabled = false;
+        scanlinesIntensity = 50;
+        if (container == null) return;
+        String json = container.getExtra("screenEffectsSettings");
+        if (json == null || json.isEmpty()) return;
+        try {
+            JSONObject o = new JSONObject(json);
+            vividEnabled = o.optBoolean("vividEnabled", false);
+            vividStrength = Math.max(0, Math.min(100, o.optInt("vividStrength", 100)));
+            colorProfile = o.optInt("colorProfile", 0);
+            brightness = Math.max(-100, Math.min(100, o.optInt("brightness", 0)));
+            contrast = Math.max(-100, Math.min(100, o.optInt("contrast", 0)));
+            gammaPercent = Math.max(50, Math.min(250, o.optInt("gammaPercent", 100)));
+            scaleFilter = o.optInt("scaleFilter", 0);
+            saturation = Math.max(0, Math.min(200, o.optInt("saturation", 100)));
+            temperature = Math.max(-100, Math.min(100, o.optInt("temperature", 0)));
+            tint = Math.max(-100, Math.min(100, o.optInt("tint", 0)));
+            sharpenEnabled = o.optBoolean("sharpenEnabled", false);
+            sharpenStrength = Math.max(0, Math.min(100, o.optInt("sharpenStrength", 50)));
+            scanlinesEnabled = o.optBoolean("scanlinesEnabled", false);
+            scanlinesIntensity = Math.max(0, Math.min(100, o.optInt("scanlinesIntensity", 50)));
+        } catch (JSONException e) {
+            Log.e("XServerDisplayActivity", "Failed to load screen effects", e);
+        }
+    }
+
+    private void saveScreenEffectsSettings() {
+        if (container == null) return;
+        try {
+            JSONObject o = new JSONObject();
+            o.put("vividEnabled", vividEnabled);
+            o.put("vividStrength", vividStrength);
+            o.put("colorProfile", colorProfile);
+            o.put("brightness", brightness);
+            o.put("contrast", contrast);
+            o.put("gammaPercent", gammaPercent);
+            o.put("scaleFilter", scaleFilter);
+            o.put("saturation", saturation);
+            o.put("temperature", temperature);
+            o.put("tint", tint);
+            o.put("sharpenEnabled", sharpenEnabled);
+            o.put("sharpenStrength", sharpenStrength);
+            o.put("scanlinesEnabled", scanlinesEnabled);
+            o.put("scanlinesIntensity", scanlinesIntensity);
+            container.putExtra("screenEffectsSettings", o.toString());
+            container.saveData();
+        } catch (JSONException e) {
+            Log.e("XServerDisplayActivity", "Failed to save screen effects", e);
+        }
     }
 
     private static float clampHudAlpha(float v) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -101,6 +101,7 @@ import com.winlator.cmod.runtime.display.renderer.effects.ColorGradeEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.CRTEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.HDREffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NaturalEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.NTSC2Effect;
 import com.winlator.cmod.runtime.display.renderer.effects.NTSCEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.ScanlinesEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.SGSRUpscaler;
@@ -4713,6 +4714,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         composer.removeEffect(composer.getEffect(CRTEffect.class));
         composer.removeEffect(composer.getEffect(ToonEffect.class));
         composer.removeEffect(composer.getEffect(NTSCEffect.class));
+        composer.removeEffect(composer.getEffect(NTSC2Effect.class));
 
         switch (colorProfile) {
             case 1: // HDR
@@ -4727,8 +4729,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             case 4: // Toon
                 composer.addEffect(new ToonEffect());
                 break;
-            case 5: // NTSC
+            case 5: // Ntsc (horizontal)
                 composer.addEffect(new NTSCEffect());
+                break;
+            case 6: // Ntsc2 (vertical)
+                composer.addEffect(new NTSC2Effect());
                 break;
         }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -96,10 +96,13 @@ import com.winlator.cmod.shared.android.RefreshRateUtils;
 import com.winlator.cmod.shared.util.StringUtils;
 import com.winlator.cmod.shared.io.TarCompressorUtils;
 import com.winlator.cmod.runtime.display.renderer.EffectComposer;
+import com.winlator.cmod.runtime.display.renderer.effects.ColorAdjustEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.CRTEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.HDREffect;
 import com.winlator.cmod.runtime.display.renderer.effects.NaturalEffect;
+import com.winlator.cmod.runtime.display.renderer.effects.NTSCEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.SGSRUpscaler;
+import com.winlator.cmod.runtime.display.renderer.effects.ToonEffect;
 import com.winlator.cmod.runtime.display.renderer.effects.VividEffect;
 import com.winlator.cmod.runtime.wine.WineInfo;
 import com.winlator.cmod.runtime.wine.WineRegistryEditor;
@@ -353,6 +356,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private boolean vividEnabled = false;
     private int vividStrength = 100;
     private int colorProfile = 0;
+    private int brightness = 0;
+    private int contrast = 0;
+    private int gammaPercent = 100;
+    private int scaleFilter = 0;
     private boolean gyroscopeCardExpanded = false;
     private XServerDrawerStateHolder drawerStateHolder;
     private XServerDrawerActionListener drawerActionListener;
@@ -3845,6 +3852,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 vividEnabled,
                 vividStrength,
                 colorProfile,
+                brightness,
+                contrast,
+                gammaPercent,
+                scaleFilter,
                 inputProfileNames,
                 inputSelectedIndex,
                 styleNames,
@@ -4098,6 +4109,38 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     public void onColorProfileSelected(int profile) {
                         colorProfile = profile;
                         preferences.edit().putInt("color_profile", profile).apply();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onBrightnessChanged(int value) {
+                        brightness = Math.max(-100, Math.min(100, value));
+                        preferences.edit().putInt("color_brightness", brightness).apply();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onContrastChanged(int value) {
+                        contrast = Math.max(-100, Math.min(100, value));
+                        preferences.edit().putInt("color_contrast", contrast).apply();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onGammaChanged(int value) {
+                        gammaPercent = Math.max(50, Math.min(250, value));
+                        preferences.edit().putInt("color_gamma", gammaPercent).apply();
+                        applyScreenEffects();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onScaleFilterSelected(int mode) {
+                        scaleFilter = mode;
+                        preferences.edit().putInt("scale_filter", mode).apply();
                         applyScreenEffects();
                         renderDrawerMenu();
                     }
@@ -4574,6 +4617,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         composer.removeEffect(composer.getEffect(HDREffect.class));
         composer.removeEffect(composer.getEffect(NaturalEffect.class));
         composer.removeEffect(composer.getEffect(CRTEffect.class));
+        composer.removeEffect(composer.getEffect(ToonEffect.class));
+        composer.removeEffect(composer.getEffect(NTSCEffect.class));
 
         switch (colorProfile) {
             case 1: // HDR
@@ -4585,8 +4630,26 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             case 3: // CRT Effect
                 composer.addEffect(new CRTEffect());
                 break;
+            case 4: // Toon
+                composer.addEffect(new ToonEffect());
+                break;
+            case 5: // NTSC
+                composer.addEffect(new NTSCEffect());
+                break;
         }
 
+        ColorAdjustEffect colorAdj = composer.getEffect(ColorAdjustEffect.class);
+        if (brightness != 0 || contrast != 0 || gammaPercent != 100) {
+            if (colorAdj == null) {
+                colorAdj = new ColorAdjustEffect();
+            }
+            colorAdj.set(brightness / 100.0f, contrast / 100.0f, gammaPercent / 100.0f);
+            composer.addEffect(colorAdj);
+        } else if (colorAdj != null) {
+            composer.removeEffect(colorAdj);
+        }
+
+        renderer.setScaleFilter(scaleFilter);
     }
 
     private void loadScreenEffectsSettings() {
@@ -4612,6 +4675,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 : legacyEnabled && legacyMode == 1;
         vividStrength = preferences.getInt("vivid_strength", legacyStrength);
         colorProfile = preferences.getInt("color_profile", 0);
+        brightness = Math.max(-100, Math.min(100, preferences.getInt("color_brightness", 0)));
+        contrast = Math.max(-100, Math.min(100, preferences.getInt("color_contrast", 0)));
+        gammaPercent = Math.max(50, Math.min(250, preferences.getInt("color_gamma", 100)));
+        scaleFilter = preferences.getInt("scale_filter", 0);
     }
 
     private static float clampHudAlpha(float v) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4698,87 +4698,56 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             Log.d("XServerDisplayActivity", "SGSR inactive");
         }
 
-        VividEffect vivid = composer.getEffect(VividEffect.class);
-        if (vividEnabled) {
-            if (vivid == null) {
-                vivid = new VividEffect();
-            }
-            vivid.setLevel((vividStrength / 25.0f) + 1.0f);
-            composer.addEffect(vivid);
-        } else if (vivid != null) {
-            composer.removeEffect(vivid);
-        }
-
+        // Rebuilt in a fixed order each call so toggle sequence can't reorder the chain.
+        composer.removeEffect(composer.getEffect(ColorAdjustEffect.class));
+        composer.removeEffect(composer.getEffect(ColorGradeEffect.class));
+        composer.removeEffect(composer.getEffect(SharpenEffect.class));
         composer.removeEffect(composer.getEffect(HDREffect.class));
         composer.removeEffect(composer.getEffect(NaturalEffect.class));
         composer.removeEffect(composer.getEffect(CRTEffect.class));
         composer.removeEffect(composer.getEffect(ToonEffect.class));
         composer.removeEffect(composer.getEffect(NTSCEffect.class));
         composer.removeEffect(composer.getEffect(NTSC2Effect.class));
+        composer.removeEffect(composer.getEffect(VividEffect.class));
+        composer.removeEffect(composer.getEffect(ScanlinesEffect.class));
 
-        switch (colorProfile) {
-            case 1: // HDR
-                composer.addEffect(new HDREffect());
-                break;
-            case 2: // Natural
-                composer.addEffect(new NaturalEffect());
-                break;
-            case 3: // CRT Effect
-                composer.addEffect(new CRTEffect());
-                break;
-            case 4: // Toon
-                composer.addEffect(new ToonEffect());
-                break;
-            case 5: // Ntsc (horizontal)
-                composer.addEffect(new NTSCEffect());
-                break;
-            case 6: // Ntsc2 (vertical)
-                composer.addEffect(new NTSC2Effect());
-                break;
-        }
-
-        ColorAdjustEffect colorAdj = composer.getEffect(ColorAdjustEffect.class);
         if (brightness != 0 || contrast != 0 || gammaPercent != 100) {
-            if (colorAdj == null) {
-                colorAdj = new ColorAdjustEffect();
-            }
+            ColorAdjustEffect colorAdj = new ColorAdjustEffect();
             colorAdj.set(brightness / 100.0f, contrast / 100.0f, gammaPercent / 100.0f);
             composer.addEffect(colorAdj);
-        } else if (colorAdj != null) {
-            composer.removeEffect(colorAdj);
         }
 
-        ColorGradeEffect colorGrade = composer.getEffect(ColorGradeEffect.class);
         if (saturation != 100 || temperature != 0 || tint != 0) {
-            if (colorGrade == null) {
-                colorGrade = new ColorGradeEffect();
-            }
+            ColorGradeEffect colorGrade = new ColorGradeEffect();
             colorGrade.set(saturation / 100.0f, temperature / 100.0f, tint / 100.0f);
             composer.addEffect(colorGrade);
-        } else if (colorGrade != null) {
-            composer.removeEffect(colorGrade);
         }
 
-        SharpenEffect sharpen = composer.getEffect(SharpenEffect.class);
         if (sharpenEnabled) {
-            if (sharpen == null) {
-                sharpen = new SharpenEffect();
-            }
+            SharpenEffect sharpen = new SharpenEffect();
             sharpen.setStrength(sharpenStrength / 100.0f);
             composer.addEffect(sharpen);
-        } else if (sharpen != null) {
-            composer.removeEffect(sharpen);
         }
 
-        ScanlinesEffect scanlines = composer.getEffect(ScanlinesEffect.class);
+        switch (colorProfile) {
+            case 1: composer.addEffect(new HDREffect()); break;
+            case 2: composer.addEffect(new NaturalEffect()); break;
+            case 3: composer.addEffect(new CRTEffect()); break;
+            case 4: composer.addEffect(new ToonEffect()); break;
+            case 5: composer.addEffect(new NTSCEffect()); break;
+            case 6: composer.addEffect(new NTSC2Effect()); break;
+        }
+
+        if (vividEnabled) {
+            VividEffect vivid = new VividEffect();
+            vivid.setLevel((vividStrength / 25.0f) + 1.0f);
+            composer.addEffect(vivid);
+        }
+
         if (scanlinesEnabled) {
-            if (scanlines == null) {
-                scanlines = new ScanlinesEffect();
-            }
+            ScanlinesEffect scanlines = new ScanlinesEffect();
             scanlines.setIntensity(scanlinesIntensity / 100.0f);
             composer.addEffect(scanlines);
-        } else if (scanlines != null) {
-            composer.removeEffect(scanlines);
         }
 
         renderer.setScaleFilter(scaleFilter);

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -336,6 +336,13 @@ data class XServerDrawerState(
     val contrast: Int = 0,
     val gammaPercent: Int = 100,
     val scaleFilter: Int = 0,
+    val saturation: Int = 100,
+    val temperature: Int = 0,
+    val tint: Int = 0,
+    val sharpenEnabled: Boolean = false,
+    val sharpenStrength: Int = 50,
+    val scanlinesEnabled: Boolean = false,
+    val scanlinesIntensity: Int = 50,
     val inputControlsProfileNames: List<String> = emptyList(),
     val inputControlsSelectedProfileIndex: Int = 0,
     val inputControlsStyleNames: List<String> = emptyList(),
@@ -534,6 +541,22 @@ interface XServerDrawerActionListener {
 
     fun onScaleFilterSelected(mode: Int)
 
+    fun onSaturationChanged(value: Int)
+
+    fun onTemperatureChanged(value: Int)
+
+    fun onTintChanged(value: Int)
+
+    fun onSharpenEnabledChanged(enabled: Boolean)
+
+    fun onSharpenStrengthChanged(value: Int)
+
+    fun onScanlinesEnabledChanged(enabled: Boolean)
+
+    fun onScanlinesIntensityChanged(value: Int)
+
+    fun onResetEffects()
+
     fun onInputControlsProfileSelected(index: Int)
 
     fun onInputControlsStyleSelected(index: Int)
@@ -619,6 +642,13 @@ fun buildXServerDrawerState(
     contrast: Int = 0,
     gammaPercent: Int = 100,
     scaleFilter: Int = 0,
+    saturation: Int = 100,
+    temperature: Int = 0,
+    tint: Int = 0,
+    sharpenEnabled: Boolean = false,
+    sharpenStrength: Int = 50,
+    scanlinesEnabled: Boolean = false,
+    scanlinesIntensity: Int = 50,
     inputControlsProfileNames: List<String> = emptyList(),
     inputControlsSelectedProfileIndex: Int = 0,
     inputControlsStyleNames: List<String> = emptyList(),
@@ -695,7 +725,9 @@ fun buildXServerDrawerState(
                 subtitle = context.getString(R.string.session_drawer_screen_effects_subtitle),
                 icon = Icons.Outlined.Tune,
                 active = sgsrEnabled || vividEnabled || colorProfile > 0 ||
-                    brightness != 0 || contrast != 0 || gammaPercent != 100 || scaleFilter != 0,
+                    brightness != 0 || contrast != 0 || gammaPercent != 100 || scaleFilter != 0 ||
+                    saturation != 100 || temperature != 0 || tint != 0 ||
+                    sharpenEnabled || scanlinesEnabled,
             ),
             XServerDrawerItem(
                 itemId = R.id.main_menu_pause,
@@ -796,6 +828,13 @@ fun buildXServerDrawerState(
         contrast = contrast,
         gammaPercent = gammaPercent,
         scaleFilter = scaleFilter,
+        saturation = saturation,
+        temperature = temperature,
+        tint = tint,
+        sharpenEnabled = sharpenEnabled,
+        sharpenStrength = sharpenStrength,
+        scanlinesEnabled = scanlinesEnabled,
+        scanlinesIntensity = scanlinesIntensity,
         inputControlsProfileNames = inputControlsProfileNames,
         inputControlsSelectedProfileIndex = inputControlsSelectedProfileIndex,
         inputControlsStyleNames = inputControlsStyleNames,
@@ -1495,6 +1534,31 @@ private fun ThinDivider() {
                 .height(1.dp)
                 .background(BottomDividerColor),
     )
+}
+
+@Composable
+private fun DrawerResetRow(label: String, onClick: () -> Unit) {
+    val paneScale = LocalPaneScale.current
+    val shape = RoundedCornerShape((14f * paneScale).dp)
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(shape)
+                .background(PaneInnerResting)
+                .border(1.dp, RestingCardBorder, shape)
+                .clickable(onClick = onClick)
+                .padding(horizontal = (12f * paneScale).dp, vertical = (10f * paneScale).dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = label,
+            color = DrawerAccent,
+            fontSize = (14f * paneScale).sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
 }
 
 private fun railLabelResFor(itemId: Int): Int? =
@@ -2392,6 +2456,40 @@ private fun ScreenEffectsPaneContent(
                         )
                     }
 
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_sharpen),
+                        checked = state.sharpenEnabled,
+                        onCheckedChange = listener::onSharpenEnabledChanged,
+                    )
+
+                    if (state.sharpenEnabled) {
+                        DrawerSliderRow(
+                            label = stringResource(R.string.session_drawer_strength),
+                            valueText = "${state.sharpenStrength}%",
+                            value = state.sharpenStrength.toFloat(),
+                            valueRange = 0f..100f,
+                            steps = 99,
+                            onValueChange = { listener.onSharpenStrengthChanged(it.roundToInt().coerceIn(0, 100)) },
+                        )
+                    }
+
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_scanlines),
+                        checked = state.scanlinesEnabled,
+                        onCheckedChange = listener::onScanlinesEnabledChanged,
+                    )
+
+                    if (state.scanlinesEnabled) {
+                        DrawerSliderRow(
+                            label = stringResource(R.string.session_drawer_intensity),
+                            valueText = "${state.scanlinesIntensity}%",
+                            value = state.scanlinesIntensity.toFloat(),
+                            valueRange = 0f..100f,
+                            steps = 99,
+                            onValueChange = { listener.onScanlinesIntensityChanged(it.roundToInt().coerceIn(0, 100)) },
+                        )
+                    }
+
                     DrawerSliderRow(
                         label = stringResource(R.string.session_drawer_brightness),
                         valueText = "${state.brightness}",
@@ -2418,6 +2516,33 @@ private fun ScreenEffectsPaneContent(
                         steps = 19,
                         onValueChange = { listener.onGammaChanged(it.roundToInt().coerceIn(50, 250)) },
                     )
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_saturation),
+                        valueText = "${state.saturation}%",
+                        value = state.saturation.toFloat(),
+                        valueRange = 0f..200f,
+                        steps = 39,
+                        onValueChange = { listener.onSaturationChanged(it.roundToInt().coerceIn(0, 200)) },
+                    )
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_temperature),
+                        valueText = "${state.temperature}",
+                        value = state.temperature.toFloat(),
+                        valueRange = -100f..100f,
+                        steps = 39,
+                        onValueChange = { listener.onTemperatureChanged(it.roundToInt().coerceIn(-100, 100)) },
+                    )
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_tint),
+                        valueText = "${state.tint}",
+                        value = state.tint.toFloat(),
+                        valueRange = -100f..100f,
+                        steps = 39,
+                        onValueChange = { listener.onTintChanged(it.roundToInt().coerceIn(-100, 100)) },
+                    )
                 }
 
                 ThinDivider()
@@ -2436,7 +2561,20 @@ private fun ScreenEffectsPaneContent(
                         checked = state.scaleFilter == 2,
                         onCheckedChange = { on -> listener.onScaleFilterSelected(if (on) 2 else 0) },
                     )
+
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_scale_bicubic),
+                        checked = state.scaleFilter == 3,
+                        onCheckedChange = { on -> listener.onScaleFilterSelected(if (on) 3 else 0) },
+                    )
                 }
+
+                ThinDivider()
+
+                DrawerResetRow(
+                    label = stringResource(R.string.session_drawer_reset_effects),
+                    onClick = listener::onResetEffects,
+                )
             }
         }
     }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -2427,6 +2427,7 @@ private fun ScreenEffectsPaneContent(
                             4 to stringResource(R.string.session_drawer_color_profile_toon),
                             3 to stringResource(R.string.session_drawer_color_profile_crt),
                             5 to stringResource(R.string.session_drawer_color_profile_ntsc),
+                            6 to stringResource(R.string.session_drawer_color_profile_ntsc2),
                         )
 
                     ChipFlow {

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -343,6 +343,9 @@ data class XServerDrawerState(
     val sharpenStrength: Int = 50,
     val scanlinesEnabled: Boolean = false,
     val scanlinesIntensity: Int = 50,
+    val pixelateEnabled: Boolean = false,
+    val pixelateBlock: Int = 6,
+    val colorBlind: Int = 0,
     val inputControlsProfileNames: List<String> = emptyList(),
     val inputControlsSelectedProfileIndex: Int = 0,
     val inputControlsStyleNames: List<String> = emptyList(),
@@ -555,6 +558,12 @@ interface XServerDrawerActionListener {
 
     fun onScanlinesIntensityChanged(value: Int)
 
+    fun onPixelateEnabledChanged(enabled: Boolean)
+
+    fun onPixelateBlockChanged(value: Int)
+
+    fun onColorBlindSelected(mode: Int)
+
     fun onResetEffects()
 
     fun onInputControlsProfileSelected(index: Int)
@@ -649,6 +658,9 @@ fun buildXServerDrawerState(
     sharpenStrength: Int = 50,
     scanlinesEnabled: Boolean = false,
     scanlinesIntensity: Int = 50,
+    pixelateEnabled: Boolean = false,
+    pixelateBlock: Int = 6,
+    colorBlind: Int = 0,
     inputControlsProfileNames: List<String> = emptyList(),
     inputControlsSelectedProfileIndex: Int = 0,
     inputControlsStyleNames: List<String> = emptyList(),
@@ -727,7 +739,7 @@ fun buildXServerDrawerState(
                 active = sgsrEnabled || vividEnabled || colorProfile > 0 ||
                     brightness != 0 || contrast != 0 || gammaPercent != 100 || scaleFilter != 0 ||
                     saturation != 100 || temperature != 0 || tint != 0 ||
-                    sharpenEnabled || scanlinesEnabled,
+                    sharpenEnabled || scanlinesEnabled || pixelateEnabled || colorBlind != 0,
             ),
             XServerDrawerItem(
                 itemId = R.id.main_menu_pause,
@@ -835,6 +847,9 @@ fun buildXServerDrawerState(
         sharpenStrength = sharpenStrength,
         scanlinesEnabled = scanlinesEnabled,
         scanlinesIntensity = scanlinesIntensity,
+        pixelateEnabled = pixelateEnabled,
+        pixelateBlock = pixelateBlock,
+        colorBlind = colorBlind,
         inputControlsProfileNames = inputControlsProfileNames,
         inputControlsSelectedProfileIndex = inputControlsSelectedProfileIndex,
         inputControlsStyleNames = inputControlsStyleNames,
@@ -2491,6 +2506,23 @@ private fun ScreenEffectsPaneContent(
                         )
                     }
 
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_pixelate),
+                        checked = state.pixelateEnabled,
+                        onCheckedChange = listener::onPixelateEnabledChanged,
+                    )
+
+                    if (state.pixelateEnabled) {
+                        DrawerSliderRow(
+                            label = stringResource(R.string.session_drawer_block_size),
+                            valueText = "${state.pixelateBlock}px",
+                            value = state.pixelateBlock.toFloat(),
+                            valueRange = 2f..14f,
+                            steps = 11,
+                            onValueChange = { listener.onPixelateBlockChanged(it.roundToInt().coerceIn(2, 14)) },
+                        )
+                    }
+
                     DrawerSliderRow(
                         label = stringResource(R.string.session_drawer_brightness),
                         valueText = "${state.brightness}",
@@ -2544,6 +2576,38 @@ private fun ScreenEffectsPaneContent(
                         steps = 39,
                         onValueChange = { listener.onTintChanged(it.roundToInt().coerceIn(-100, 100)) },
                     )
+
+                    DrawerResetRow(
+                        label = stringResource(R.string.session_drawer_reset_effects),
+                        onClick = listener::onResetEffects,
+                    )
+                }
+
+                ThinDivider()
+
+                Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
+                    PaneSectionLabel(stringResource(R.string.session_drawer_color_blind))
+
+                    Row(horizontalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
+                        HUDToggleChip(
+                            label = stringResource(R.string.session_drawer_color_blind_protan),
+                            checked = state.colorBlind == 1,
+                            onClick = { listener.onColorBlindSelected(if (state.colorBlind == 1) 0 else 1) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        HUDToggleChip(
+                            label = stringResource(R.string.session_drawer_color_blind_deutan),
+                            checked = state.colorBlind == 2,
+                            onClick = { listener.onColorBlindSelected(if (state.colorBlind == 2) 0 else 2) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        HUDToggleChip(
+                            label = stringResource(R.string.session_drawer_color_blind_tritan),
+                            checked = state.colorBlind == 3,
+                            onClick = { listener.onColorBlindSelected(if (state.colorBlind == 3) 0 else 3) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
 
                 ThinDivider()
@@ -2569,13 +2633,6 @@ private fun ScreenEffectsPaneContent(
                         onCheckedChange = { on -> listener.onScaleFilterSelected(if (on) 3 else 0) },
                     )
                 }
-
-                ThinDivider()
-
-                DrawerResetRow(
-                    label = stringResource(R.string.session_drawer_reset_effects),
-                    onClick = listener::onResetEffects,
-                )
             }
         }
     }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -332,6 +332,10 @@ data class XServerDrawerState(
     val vividEnabled: Boolean = false,
     val vividStrength: Int = 100,
     val colorProfile: Int = 0,
+    val brightness: Int = 0,
+    val contrast: Int = 0,
+    val gammaPercent: Int = 100,
+    val scaleFilter: Int = 0,
     val inputControlsProfileNames: List<String> = emptyList(),
     val inputControlsSelectedProfileIndex: Int = 0,
     val inputControlsStyleNames: List<String> = emptyList(),
@@ -522,6 +526,14 @@ interface XServerDrawerActionListener {
 
     fun onColorProfileSelected(profile: Int)
 
+    fun onBrightnessChanged(value: Int)
+
+    fun onContrastChanged(value: Int)
+
+    fun onGammaChanged(value: Int)
+
+    fun onScaleFilterSelected(mode: Int)
+
     fun onInputControlsProfileSelected(index: Int)
 
     fun onInputControlsStyleSelected(index: Int)
@@ -603,6 +615,10 @@ fun buildXServerDrawerState(
     vividEnabled: Boolean = false,
     vividStrength: Int = 100,
     colorProfile: Int = 0,
+    brightness: Int = 0,
+    contrast: Int = 0,
+    gammaPercent: Int = 100,
+    scaleFilter: Int = 0,
     inputControlsProfileNames: List<String> = emptyList(),
     inputControlsSelectedProfileIndex: Int = 0,
     inputControlsStyleNames: List<String> = emptyList(),
@@ -678,7 +694,8 @@ fun buildXServerDrawerState(
                 title = context.getString(R.string.session_drawer_screen_effects),
                 subtitle = context.getString(R.string.session_drawer_screen_effects_subtitle),
                 icon = Icons.Outlined.Tune,
-                active = sgsrEnabled || vividEnabled || colorProfile > 0,
+                active = sgsrEnabled || vividEnabled || colorProfile > 0 ||
+                    brightness != 0 || contrast != 0 || gammaPercent != 100 || scaleFilter != 0,
             ),
             XServerDrawerItem(
                 itemId = R.id.main_menu_pause,
@@ -775,6 +792,10 @@ fun buildXServerDrawerState(
         vividEnabled = vividEnabled,
         vividStrength = vividStrength,
         colorProfile = colorProfile,
+        brightness = brightness,
+        contrast = contrast,
+        gammaPercent = gammaPercent,
+        scaleFilter = scaleFilter,
         inputControlsProfileNames = inputControlsProfileNames,
         inputControlsSelectedProfileIndex = inputControlsSelectedProfileIndex,
         inputControlsStyleNames = inputControlsStyleNames,
@@ -2336,18 +2357,20 @@ private fun ScreenEffectsPaneContent(
 
                     val profiles =
                         listOf(
-                            stringResource(R.string.session_drawer_color_profile_disabled),
-                            stringResource(R.string.session_drawer_color_profile_hdr),
-                            stringResource(R.string.session_drawer_color_profile_natural),
-                            stringResource(R.string.session_drawer_color_profile_crt),
+                            0 to stringResource(R.string.session_drawer_color_profile_disabled),
+                            1 to stringResource(R.string.session_drawer_color_profile_hdr),
+                            2 to stringResource(R.string.session_drawer_color_profile_natural),
+                            4 to stringResource(R.string.session_drawer_color_profile_toon),
+                            3 to stringResource(R.string.session_drawer_color_profile_crt),
+                            5 to stringResource(R.string.session_drawer_color_profile_ntsc),
                         )
 
                     ChipFlow {
-                        profiles.forEachIndexed { index, label ->
+                        profiles.forEach { (id, label) ->
                             HUDToggleChip(
                                 label = label,
-                                checked = state.colorProfile == index,
-                                onClick = { listener.onColorProfileSelected(index) },
+                                checked = state.colorProfile == id,
+                                onClick = { listener.onColorProfileSelected(id) },
                             )
                         }
                     }
@@ -2368,6 +2391,51 @@ private fun ScreenEffectsPaneContent(
                             onValueChange = { listener.onVividStrengthChanged(it.roundToInt()) },
                         )
                     }
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_brightness),
+                        valueText = "${state.brightness}",
+                        value = state.brightness.toFloat(),
+                        valueRange = -100f..100f,
+                        steps = 39,
+                        onValueChange = { listener.onBrightnessChanged(it.roundToInt().coerceIn(-100, 100)) },
+                    )
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_contrast),
+                        valueText = "${state.contrast}",
+                        value = state.contrast.toFloat(),
+                        valueRange = -100f..100f,
+                        steps = 39,
+                        onValueChange = { listener.onContrastChanged(it.roundToInt().coerceIn(-100, 100)) },
+                    )
+
+                    DrawerSliderRow(
+                        label = stringResource(R.string.session_drawer_gamma),
+                        valueText = String.format("%.2fx", state.gammaPercent / 100f),
+                        value = state.gammaPercent.toFloat(),
+                        valueRange = 50f..250f,
+                        steps = 19,
+                        onValueChange = { listener.onGammaChanged(it.roundToInt().coerceIn(50, 250)) },
+                    )
+                }
+
+                ThinDivider()
+
+                Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
+                    PaneSectionLabel(stringResource(R.string.session_drawer_scale))
+
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_scale_nearest),
+                        checked = state.scaleFilter == 1,
+                        onCheckedChange = { on -> listener.onScaleFilterSelected(if (on) 1 else 0) },
+                    )
+
+                    DrawerBooleanRow(
+                        title = stringResource(R.string.session_drawer_scale_linear),
+                        checked = state.scaleFilter == 2,
+                        onCheckedChange = { on -> listener.onScaleFilterSelected(if (on) 2 else 0) },
+                    )
                 }
             }
         }

--- a/app/src/main/runtime/display/renderer/VulkanRenderer.java
+++ b/app/src/main/runtime/display/renderer/VulkanRenderer.java
@@ -206,6 +206,9 @@ public class VulkanRenderer
             if (requestedPresentMode != PRESENT_MODE_FIFO) {
                 nativeSetPresentMode(nativeHandle, requestedPresentMode);
             }
+            if (requestedScaleFilter != SCALE_FILTER_OFF) {
+                nativeSetScaleFilter(nativeHandle, requestedScaleFilter);
+            }
             destroyed.set(false);
             xServer.windowManager.addOnWindowModificationListener(this);
             xServer.pointer.addOnPointerMotionListener(this);
@@ -783,6 +786,21 @@ public class VulkanRenderer
         }
     }
 
+    // Scale-filter constants must mirror the switch in nativeSetScaleFilter.
+    public static final int SCALE_FILTER_OFF     = 0;
+    public static final int SCALE_FILTER_NEAREST = 1;
+    public static final int SCALE_FILTER_LINEAR  = 2;
+
+    private int requestedScaleFilter = SCALE_FILTER_OFF;
+
+    public void setScaleFilter(int mode) {
+        requestedScaleFilter = mode;
+        if (nativeHandle != 0) {
+            nativeSetScaleFilter(nativeHandle, mode);
+            if (xServerView != null) xServerView.requestRender();
+        }
+    }
+
     public void setUnviewableWMClasses(String... names) {
         this.unviewableWMClasses = names;
     }
@@ -805,4 +823,5 @@ public class VulkanRenderer
     private static native void nativeSetScene(long handle, ByteBuffer sceneBuf);
     private static native void nativeSetFpsLimit(long handle, int fps);
     private static native void nativeSetPresentMode(long handle, int mode);
+    private static native void nativeSetScaleFilter(long handle, int mode);
 }

--- a/app/src/main/runtime/display/renderer/VulkanRenderer.java
+++ b/app/src/main/runtime/display/renderer/VulkanRenderer.java
@@ -790,6 +790,7 @@ public class VulkanRenderer
     public static final int SCALE_FILTER_OFF     = 0;
     public static final int SCALE_FILTER_NEAREST = 1;
     public static final int SCALE_FILTER_LINEAR  = 2;
+    public static final int SCALE_FILTER_BICUBIC = 3;
 
     private int requestedScaleFilter = SCALE_FILTER_OFF;
 

--- a/app/src/main/runtime/display/renderer/effects/ColorAdjustEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/ColorAdjustEffect.java
@@ -1,0 +1,31 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class ColorAdjustEffect extends Effect {
+    private float brightness = 0.0f;
+    private float contrast = 0.0f;
+    private float gamma = 1.0f;
+
+    public void set(float brightness, float contrast, float gamma) {
+        this.brightness = brightness;
+        this.contrast = contrast;
+        this.gamma = gamma;
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_COLORADJ;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, brightness, contrast, gamma};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = brightness;
+        out[offset + 2] = contrast;
+        out[offset + 3] = gamma;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/ColorBlindEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/ColorBlindEffect.java
@@ -1,0 +1,27 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class ColorBlindEffect extends Effect {
+    private float mode = 1.0f;
+
+    public void setMode(int mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_COLORBLIND;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, mode, 0f, 0f};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = mode;
+        out[offset + 2] = 0f;
+        out[offset + 3] = 0f;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/ColorGradeEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/ColorGradeEffect.java
@@ -1,0 +1,31 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class ColorGradeEffect extends Effect {
+    private float saturation = 1.0f;
+    private float temperature = 0.0f;
+    private float tint = 0.0f;
+
+    public void set(float saturation, float temperature, float tint) {
+        this.saturation = saturation;
+        this.temperature = temperature;
+        this.tint = tint;
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_COLORGRADE;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, saturation, temperature, tint};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = saturation;
+        out[offset + 2] = temperature;
+        out[offset + 3] = tint;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/Effect.java
+++ b/app/src/main/runtime/display/renderer/effects/Effect.java
@@ -1,11 +1,14 @@
 package com.winlator.cmod.runtime.display.renderer.effects;
 
 public abstract class Effect {
-    public static final int TYPE_CRT     = 0;
-    public static final int TYPE_VIVID   = 1;
-    public static final int TYPE_HDR     = 2;
-    public static final int TYPE_NATURAL = 3;
-    public static final int TYPE_SGSR1   = 4;
+    public static final int TYPE_CRT      = 0;
+    public static final int TYPE_VIVID    = 1;
+    public static final int TYPE_HDR      = 2;
+    public static final int TYPE_NATURAL  = 3;
+    public static final int TYPE_SGSR1    = 4;
+    public static final int TYPE_TOON     = 5;
+    public static final int TYPE_NTSC     = 6;
+    public static final int TYPE_COLORADJ = 7;
 
     public abstract int getNativeType();
 

--- a/app/src/main/runtime/display/renderer/effects/Effect.java
+++ b/app/src/main/runtime/display/renderer/effects/Effect.java
@@ -6,9 +6,12 @@ public abstract class Effect {
     public static final int TYPE_HDR      = 2;
     public static final int TYPE_NATURAL  = 3;
     public static final int TYPE_SGSR1    = 4;
-    public static final int TYPE_TOON     = 5;
-    public static final int TYPE_NTSC     = 6;
-    public static final int TYPE_COLORADJ = 7;
+    public static final int TYPE_TOON      = 5;
+    public static final int TYPE_NTSC      = 6;
+    public static final int TYPE_COLORADJ  = 7;
+    public static final int TYPE_COLORGRADE = 8;
+    public static final int TYPE_SHARPEN   = 9;
+    public static final int TYPE_SCANLINES = 10;
 
     public abstract int getNativeType();
 

--- a/app/src/main/runtime/display/renderer/effects/Effect.java
+++ b/app/src/main/runtime/display/renderer/effects/Effect.java
@@ -12,6 +12,7 @@ public abstract class Effect {
     public static final int TYPE_COLORGRADE = 8;
     public static final int TYPE_SHARPEN   = 9;
     public static final int TYPE_SCANLINES = 10;
+    public static final int TYPE_NTSC2     = 11;
 
     public abstract int getNativeType();
 

--- a/app/src/main/runtime/display/renderer/effects/Effect.java
+++ b/app/src/main/runtime/display/renderer/effects/Effect.java
@@ -13,6 +13,8 @@ public abstract class Effect {
     public static final int TYPE_SHARPEN   = 9;
     public static final int TYPE_SCANLINES = 10;
     public static final int TYPE_NTSC2     = 11;
+    public static final int TYPE_COLORBLIND = 12;
+    public static final int TYPE_PIXELATE  = 13;
 
     public abstract int getNativeType();
 

--- a/app/src/main/runtime/display/renderer/effects/NTSC2Effect.java
+++ b/app/src/main/runtime/display/renderer/effects/NTSC2Effect.java
@@ -1,0 +1,8 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class NTSC2Effect extends Effect {
+    @Override
+    public int getNativeType() {
+        return TYPE_NTSC2;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/NTSCEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/NTSCEffect.java
@@ -1,0 +1,8 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class NTSCEffect extends Effect {
+    @Override
+    public int getNativeType() {
+        return TYPE_NTSC;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/PixelateEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/PixelateEffect.java
@@ -1,0 +1,27 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class PixelateEffect extends Effect {
+    private float blockSize = 6.0f;
+
+    public void setBlockSize(float blockSize) {
+        this.blockSize = Math.max(1.0f, blockSize);
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_PIXELATE;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, blockSize, 0f, 0f};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = blockSize;
+        out[offset + 2] = 0f;
+        out[offset + 3] = 0f;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/ScanlinesEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/ScanlinesEffect.java
@@ -1,0 +1,27 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class ScanlinesEffect extends Effect {
+    private float intensity = 0.5f;
+
+    public void setIntensity(float intensity) {
+        this.intensity = Math.min(1.0f, Math.max(0.0f, intensity));
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_SCANLINES;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, intensity, 0f, 0f};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = intensity;
+        out[offset + 2] = 0f;
+        out[offset + 3] = 0f;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/SharpenEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/SharpenEffect.java
@@ -1,0 +1,27 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class SharpenEffect extends Effect {
+    private float strength = 0.5f;
+
+    public void setStrength(float strength) {
+        this.strength = Math.min(1.0f, Math.max(0.0f, strength));
+    }
+
+    @Override
+    public int getNativeType() {
+        return TYPE_SHARPEN;
+    }
+
+    @Override
+    public float[] getParams() {
+        return new float[]{0f, strength, 0f, 0f};
+    }
+
+    @Override
+    public void writeParams(float[] out, int offset) {
+        out[offset] = 0f;
+        out[offset + 1] = strength;
+        out[offset + 2] = 0f;
+        out[offset + 3] = 0f;
+    }
+}

--- a/app/src/main/runtime/display/renderer/effects/ToonEffect.java
+++ b/app/src/main/runtime/display/renderer/effects/ToonEffect.java
@@ -1,0 +1,8 @@
+package com.winlator.cmod.runtime.display.renderer.effects;
+
+public class ToonEffect extends Effect {
+    @Override
+    public int getNativeType() {
+        return TYPE_TOON;
+    }
+}


### PR DESCRIPTION
Adds a set of new Vulkan post-process effects to the FX tab, each as its own
  fragment shader: some inspired by json derulo  (toon, ntsc) 
Then 10 new effects I created.

  - Toon — posterized cel-shading look.
  - Ntsc / Ntsc2 — horizontal and vertical NTSC-style chroma bleed.
  - Sharpen — unsharp-mask sharpening (strength slider).
  - Scanlines — visible CRT scanline banding (intensity slider).
  - Pixelate — block/mosaic effect (block-size slider, capped at 14px).
  - Color Blind correction — Protan / Deutan / Tritan, LMS-based daltonization so
  each mode is distinct and accurate. Own section, stacks with other profiles.

  New adjustment sliders: Brightness / Contrast / Gamma and Saturation /
  Temperature / Tint.

  Plus:
  - All effects now persist per-container.
  - Reset button for all effects and sliders.
  - Pixelate and Scanlines are mutually exclusive (either can still be turned off
  on its own).
  - Effects apply in a fixed order to avoid order-dependent rendering bugs.