### PR TITLE
Add D7VK as an importable ddraw wrapper content type

### DIFF
--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1180,8 +1180,13 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val configStr = initialDxWrapperConfig()
         val config = DXVKConfigUtils.parseConfig(configStr)
         state.dxvkVkd3dFeatureLevelEntries.value = DXVKConfigUtils.VKD3D_FEATURE_LEVEL.toList()
-        state.dxvkDdrawWrapperEntries.value =
-            context.resources.getStringArray(R.array.ddrawrapper_entries).toList()
+        val ddrawWrapperItems =
+            context.resources.getStringArray(R.array.ddrawrapper_entries).toMutableList()
+        for (profile in contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_D7VK)) {
+            ddrawWrapperItems.add(ContentsManager.getEntryName(profile))
+        }
+        if (!isArm64EC) ddrawWrapperItems.removeAll { it.contains("arm64ec") }
+        state.dxvkDdrawWrapperEntries.value = ddrawWrapperItems
         loadDxvkVersions()
         loadVkd3dVersions()
         selectByIdentifier(state.dxvkVkd3dFeatureLevelEntries.value, config.get("vkd3dLevel"), state.dxvkSelectedVkd3dFeatureLevel)

--- a/app/src/main/feature/settings/contents/ComponentsScreen.kt
+++ b/app/src/main/feature/settings/contents/ComponentsScreen.kt
@@ -462,6 +462,7 @@ private fun descriptionResFor(type: ContentProfile.ContentType): Int =
         ContentProfile.ContentType.CONTENT_TYPE_BOX64 -> R.string.settings_content_desc_box64
         ContentProfile.ContentType.CONTENT_TYPE_WOWBOX64 -> R.string.settings_content_desc_wowbox64
         ContentProfile.ContentType.CONTENT_TYPE_FEXCORE -> R.string.settings_content_desc_fexcore
+        ContentProfile.ContentType.CONTENT_TYPE_D7VK -> R.string.settings_content_desc_d7vk
     }
 
 @Composable
@@ -830,6 +831,7 @@ private fun iconFor(type: ContentProfile.ContentType): ImageVector =
 
         ContentProfile.ContentType.CONTENT_TYPE_DXVK,
         ContentProfile.ContentType.CONTENT_TYPE_VKD3D,
+        ContentProfile.ContentType.CONTENT_TYPE_D7VK,
         -> Icons.Outlined.DeveloperBoard
 
         ContentProfile.ContentType.CONTENT_TYPE_BOX64,

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -1948,7 +1948,12 @@ class ShortcutSettingsComposeDialog private constructor(
         state.dxvkVkd3dFeatureLevelEntries.value = DXVKConfigUtils.VKD3D_FEATURE_LEVEL.toList()
 
         // DDraw wrapper from resources
-        state.dxvkDdrawWrapperEntries.value = context.resources.getStringArray(R.array.ddrawrapper_entries).toList()
+        val ddrawWrapperItems = context.resources.getStringArray(R.array.ddrawrapper_entries).toMutableList()
+        for (profile in contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_D7VK)) {
+            ddrawWrapperItems.add(ContentsManager.getEntryName(profile))
+        }
+        if (!isArm64EC) ddrawWrapperItems.removeAll { it.contains("arm64ec") }
+        state.dxvkDdrawWrapperEntries.value = ddrawWrapperItems
 
         loadDxvkVersions(container)
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -829,6 +829,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_content_desc_box64">Oversætter x86_64 Linux-kode, så den kan køre på ARM64-enheder.</string>
     <string name="settings_content_desc_wowbox64">Box64-build brugt af WoW64 til at køre 32-bit Windows-apps i 64-bit Wine.</string>
     <string name="settings_content_desc_fexcore">Oversætter x86- og x86_64-kode, så den kan køre på ARM64-enheder.</string>
+    <string name="settings_content_desc_d7vk">Oversætter DirectDraw-grafikkald (Direct3D 7 og ældre) til Vulkan.</string>
     <string name="settings_content_unable_to_install">Kan ikke installere indhold.</string>
     <string name="settings_content_install_failed">Installation mislykkedes</string>
     <string name="settings_content_file_cannot_be_recognized">Filen kan ikke genkendes.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -829,6 +829,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_content_desc_box64">Übersetzt x86_64-Linux-Code, damit er auf ARM64-Geräten läuft.</string>
     <string name="settings_content_desc_wowbox64">Box64-Build, den WoW64 zum Ausführen von 32-Bit-Windows-Apps in 64-Bit-Wine nutzt.</string>
     <string name="settings_content_desc_fexcore">Übersetzt x86- und x86_64-Code, damit er auf ARM64-Geräten läuft.</string>
+    <string name="settings_content_desc_d7vk">Übersetzt DirectDraw-Grafikaufrufe (Direct3D 7 und älter) nach Vulkan.</string>
     <string name="settings_content_unable_to_install">Inhalt kann nicht installiert werden.</string>
     <string name="settings_content_install_failed">Installation fehlgeschlagen</string>
     <string name="settings_content_file_cannot_be_recognized">Datei kann nicht erkannt werden.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -829,6 +829,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_content_desc_box64">Traduce código Linux x86_64 para que se ejecute en dispositivos ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build de Box64 usado por WoW64 para ejecutar apps Windows de 32 bits en Wine de 64 bits.</string>
     <string name="settings_content_desc_fexcore">Traduce código x86 y x86_64 para que se ejecute en dispositivos ARM64.</string>
+    <string name="settings_content_desc_d7vk">Traduce llamadas gráficas de DirectDraw (Direct3D 7 y anteriores) a Vulkan.</string>
     <string name="settings_content_unable_to_install">No se pudo instalar el contenido.</string>
     <string name="settings_content_install_failed">Error en la instalación</string>
     <string name="settings_content_file_cannot_be_recognized">No se puede reconocer el archivo.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -829,6 +829,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_content_desc_box64">Traduit le code Linux x86_64 pour l’exécuter sur des appareils ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build Box64 utilisé par WoW64 pour exécuter des apps Windows 32 bits dans Wine 64 bits.</string>
     <string name="settings_content_desc_fexcore">Traduit le code x86 et x86_64 pour l’exécuter sur des appareils ARM64.</string>
+    <string name="settings_content_desc_d7vk">Traduit les appels graphiques DirectDraw (Direct3D 7 et antérieurs) vers Vulkan.</string>
     <string name="settings_content_unable_to_install">Impossible d\'installer le contenu.</string>
     <string name="settings_content_install_failed">Échec de l\'installation</string>
     <string name="settings_content_file_cannot_be_recognized">Le fichier ne peut pas être reconnu.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -933,6 +933,7 @@
     <string name="settings_content_desc_box64">x86_64 Linux कोड का अनुवाद करता है ताकि यह ARM64 उपकरणों पर चल सके।</string>
     <string name="settings_content_desc_wowbox64">Box64 बिल्ड का उपयोग WoW64 द्वारा 64-बिट Wine के अंदर 32-बिट Windows ऐप्स चलाने के लिए किया जाता है।</string>
     <string name="settings_content_desc_fexcore">x86 और x86_64 कोड का अनुवाद करता है ताकि यह ARM64 डिवाइस पर चल सके।</string>
+    <string name="settings_content_desc_d7vk">DirectDraw (Direct3D 7 और इससे पुराने) ग्राफ़िक्स कॉल का Vulkan में अनुवाद करता है।</string>
     <string name="settings_content_unable_to_install">कंटेंट इंस्टॉल नहीं किया जा सका।</string>
     <string name="settings_content_install_failed">इंस्टॉल विफल</string>
     <string name="settings_content_file_cannot_be_recognized">फ़ाइल को पहचाना नहीं जा सका.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -829,6 +829,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_content_desc_box64">Traduce codice Linux x86_64 per eseguirlo su dispositivi ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build Box64 usata da WoW64 per eseguire app Windows a 32 bit in Wine a 64 bit.</string>
     <string name="settings_content_desc_fexcore">Traduce codice x86 e x86_64 per eseguirlo su dispositivi ARM64.</string>
+    <string name="settings_content_desc_d7vk">Traduce le chiamate grafiche DirectDraw (Direct3D 7 e precedenti) in Vulkan.</string>
     <string name="settings_content_unable_to_install">Impossibile installare il contenuto.</string>
     <string name="settings_content_install_failed">Installazione fallita</string>
     <string name="settings_content_file_cannot_be_recognized">Impossibile riconoscere il file.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -829,6 +829,7 @@
     <string name="settings_content_desc_box64">x86_64 Linux 코드를 ARM64 기기에서 실행되도록 변환합니다.</string>
     <string name="settings_content_desc_wowbox64">64비트 Wine에서 32비트 Windows 앱을 실행하기 위해 WoW64가 사용하는 Box64 빌드입니다.</string>
     <string name="settings_content_desc_fexcore">x86 및 x86_64 코드를 ARM64 기기에서 실행되도록 변환합니다.</string>
+    <string name="settings_content_desc_d7vk">DirectDraw(Direct3D 7 이하) 그래픽 호출을 Vulkan으로 변환합니다.</string>
     <string name="settings_content_unable_to_install">콘텐츠를 설치할 수 없습니다.</string>
     <string name="settings_content_install_failed">설치 실패</string>
     <string name="settings_content_file_cannot_be_recognized">파일을 인식할 수 없습니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -835,6 +835,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_content_desc_box64">Tłumaczy kod Linuksa x86_64, aby działał na urządzeniach ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build Box64 używany przez WoW64 do uruchamiania 32-bitowych aplikacji Windows w 64-bitowym Wine.</string>
     <string name="settings_content_desc_fexcore">Tłumaczy kod x86 i x86_64, aby działał na urządzeniach ARM64.</string>
+    <string name="settings_content_desc_d7vk">Tłumaczy wywołania graficzne DirectDraw (Direct3D 7 i starsze) na Vulkan.</string>
     <string name="settings_content_unable_to_install">Nie można zainstalować zawartości.</string>
     <string name="settings_content_install_failed">Instalacja nie powiodła się</string>
     <string name="settings_content_file_cannot_be_recognized">Nie można rozpoznać pliku.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -829,6 +829,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_content_desc_box64">Traduz código Linux x86_64 para execução em dispositivos ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build Box64 usado pelo WoW64 para executar apps Windows de 32 bits no Wine de 64 bits.</string>
     <string name="settings_content_desc_fexcore">Traduz código x86 e x86_64 para execução em dispositivos ARM64.</string>
+    <string name="settings_content_desc_d7vk">Traduz chamadas gráficas DirectDraw (Direct3D 7 e anteriores) para Vulkan.</string>
     <string name="settings_content_unable_to_install">Nao foi possivel instalar o conteudo.</string>
     <string name="settings_content_install_failed">Falha na Instalacao</string>
     <string name="settings_content_file_cannot_be_recognized">O arquivo nao pode ser reconhecido.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -829,6 +829,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_content_desc_box64">Traduce cod Linux x86_64 pentru rulare pe dispozitive ARM64.</string>
     <string name="settings_content_desc_wowbox64">Build Box64 folosit de WoW64 pentru a rula aplicații Windows pe 32 de biți în Wine pe 64 de biți.</string>
     <string name="settings_content_desc_fexcore">Traduce cod x86 și x86_64 pentru rulare pe dispozitive ARM64.</string>
+    <string name="settings_content_desc_d7vk">Traduce apelurile grafice DirectDraw (Direct3D 7 și anterioare) în Vulkan.</string>
     <string name="settings_content_unable_to_install">Nu se poate instala continutul.</string>
     <string name="settings_content_install_failed">Instalare esuata</string>
     <string name="settings_content_file_cannot_be_recognized">Fisierul nu poate fi recunoscut.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -895,6 +895,7 @@
     <string name="settings_content_desc_box64">Преобразует код Linux x86_64, чтобы он мог работать на устройствах ARM64.</string>
     <string name="settings_content_desc_wowbox64">Сборка Box64, используемая WoW64 для запуска 32-битных приложений Windows внутри 64-битной версии Wine.</string>
     <string name="settings_content_desc_fexcore">Преобразует код x86 и x86_64, чтобы он мог работать на устройствах ARM64.</string>
+    <string name="settings_content_desc_d7vk">Преобразует графические вызовы DirectDraw (Direct3D 7 и более ранних версий) в Vulkan.</string>
     <string name="settings_content_unable_to_install">Невозможно установить контент.</string>
     <string name="settings_content_install_failed">Установка не удалась</string>
     <string name="settings_content_file_cannot_be_recognized">Файл не может быть распознан.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -835,6 +835,7 @@
     <string name="settings_content_desc_box64">Транслює Linux-код x86_64 для запуску на пристроях ARM64.</string>
     <string name="settings_content_desc_wowbox64">Збірка Box64, яку WoW64 використовує для запуску 32-бітних Windows-застосунків у 64-бітному Wine.</string>
     <string name="settings_content_desc_fexcore">Транслює код x86 і x86_64 для запуску на пристроях ARM64.</string>
+    <string name="settings_content_desc_d7vk">Транслює графічні виклики DirectDraw (Direct3D 7 та раніших версій) у Vulkan.</string>
     <string name="settings_content_unable_to_install">Неможливо встановити контент.</string>
     <string name="settings_content_install_failed">Помилка встановлення</string>
     <string name="settings_content_file_cannot_be_recognized">Файл не розпізнано.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -829,6 +829,7 @@
     <string name="settings_content_desc_box64">转换 x86_64 Linux 代码，使其可在 ARM64 设备上运行。</string>
     <string name="settings_content_desc_wowbox64">WoW64 使用的 Box64 构建，用于在 64 位 Wine 中运行 32 位 Windows 应用。</string>
     <string name="settings_content_desc_fexcore">转换 x86 和 x86_64 代码，使其可在 ARM64 设备上运行。</string>
+    <string name="settings_content_desc_d7vk">将 DirectDraw（Direct3D 7 及更早版本）图形调用转换为 Vulkan。</string>
     <string name="settings_content_unable_to_install">无法安装内容。</string>
     <string name="settings_content_install_failed">安装失败</string>
     <string name="settings_content_file_cannot_be_recognized">无法识别此文件。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -829,6 +829,7 @@
     <string name="settings_content_desc_box64">轉譯 x86_64 Linux 程式碼，使其可在 ARM64 裝置上執行。</string>
     <string name="settings_content_desc_wowbox64">WoW64 使用的 Box64 建置，用於在 64 位元 Wine 中執行 32 位元 Windows 應用程式。</string>
     <string name="settings_content_desc_fexcore">轉譯 x86 與 x86_64 程式碼，使其可在 ARM64 裝置上執行。</string>
+    <string name="settings_content_desc_d7vk">將 DirectDraw（Direct3D 7 與更早版本）圖形呼叫轉譯為 Vulkan。</string>
     <string name="settings_content_unable_to_install">無法安裝內容。</string>
     <string name="settings_content_install_failed">安裝失敗</string>
     <string name="settings_content_file_cannot_be_recognized">無法識別檔案。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -993,6 +993,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_content_desc_box64">Translates x86_64 Linux code so it can run on ARM64 devices.</string>
     <string name="settings_content_desc_wowbox64">Box64 build used by WoW64 to run 32-bit Windows apps inside 64-bit Wine.</string>
     <string name="settings_content_desc_fexcore">Translates x86 and x86_64 code so it can run on ARM64 devices.</string>
+    <string name="settings_content_desc_d7vk">Translates DirectDraw (Direct3D 7 and earlier) graphics calls to Vulkan.</string>
     <string name="settings_content_unable_to_install">Unable to install content.</string>
     <string name="settings_content_install_failed">Install Failed</string>
     <string name="settings_content_file_cannot_be_recognized">File cannot be recognized.</string>

--- a/app/src/main/runtime/content/ContentProfile.java
+++ b/app/src/main/runtime/content/ContentProfile.java
@@ -26,7 +26,8 @@ public class ContentProfile {
     CONTENT_TYPE_VKD3D("VKD3D"),
     CONTENT_TYPE_BOX64("Box64"),
     CONTENT_TYPE_WOWBOX64("WOWBox64"),
-    CONTENT_TYPE_FEXCORE("FEXCore");
+    CONTENT_TYPE_FEXCORE("FEXCore"),
+    CONTENT_TYPE_D7VK("D7VK");
 
     final String typeName;
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6752,7 +6752,23 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             Log.d(TAG, "Extracting nglide wrapper");
             TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this, "ddrawrapper/nglide.tzst", windowsDir, onExtractFileListener);
 
-            if (ddrawrapper.equalsIgnoreCase("none") || ddrawrapper.contains("None")) {
+            // Clear any stale D7VK passthrough DLL left from a previous selection.
+            File syswow64Dir = new File(rootDir, ImageFs.WINEPREFIX + "/drive_c/windows/syswow64");
+            File system32Dir = new File(rootDir, ImageFs.WINEPREFIX + "/drive_c/windows/system32");
+            new File(syswow64Dir, "ddraw_.dll").delete();
+            new File(system32Dir, "ddraw_.dll").delete();
+
+            ContentProfile d7vkProfile = findD7vkProfileForDdrawrapper(ddrawrapper);
+            if (d7vkProfile != null) {
+                Log.d(TAG, "Applying D7VK ddraw wrapper: " + ddrawrapper);
+                // Restore Wine's builtin ddraw.dll, preserve it as ddraw_.dll, then drop D7VK's ddraw.dll on top.
+                WinComponentSetup.restoreWineBuiltinDllFiles(imageFs, wineInfo, "ddraw.dll", "d3dimm.dll");
+                File origDdraw = new File(syswow64Dir, "ddraw.dll");
+                File renamedDdraw = new File(syswow64Dir, "ddraw_.dll");
+                if (origDdraw.exists()) FileUtils.copy(origDdraw, renamedDdraw);
+                contentsManager.applyContent(d7vkProfile);
+            }
+            else if (ddrawrapper.equalsIgnoreCase("none") || ddrawrapper.contains("None")) {
                 Log.d(TAG, "No DDRaw wrapper has been selected, restoring original ddraw files");
                 WinComponentSetup.restoreWineBuiltinDllFiles(imageFs, wineInfo, "ddraw.dll", "d3dimm.dll");
             }
@@ -6792,6 +6808,17 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         } else {
             Log.w(TAG, "VKD3D content profile not installed; no bundled VKD3D archive will be loaded: " + vkd3dWrapper);
         }
+    }
+
+    private ContentProfile findD7vkProfileForDdrawrapper(String ddrawrapper) {
+        if (ddrawrapper == null || contentsManager == null) return null;
+        List<ContentProfile> profiles = contentsManager.getProfiles(ContentProfile.ContentType.CONTENT_TYPE_D7VK);
+        if (profiles == null) return null;
+        for (ContentProfile profile : profiles) {
+            if (StringUtils.parseIdentifier(ContentsManager.getEntryName(profile)).equals(ddrawrapper))
+                return profile;
+        }
+        return null;
     }
 
     private static String findDelimitedWrapper(String value, String prefix) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6761,7 +6761,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             ContentProfile d7vkProfile = findD7vkProfileForDdrawrapper(ddrawrapper);
             if (d7vkProfile != null) {
                 Log.d(TAG, "Applying D7VK ddraw wrapper: " + ddrawrapper);
-                // Restore Wine's builtin ddraw.dll, preserve it as ddraw_.dll, then drop D7VK's ddraw.dll on top.
                 WinComponentSetup.restoreWineBuiltinDllFiles(imageFs, wineInfo, "ddraw.dll", "d3dimm.dll");
                 File origDdraw = new File(syswow64Dir, "ddraw.dll");
                 File renamedDdraw = new File(syswow64Dir, "ddraw_.dll");


### PR DESCRIPTION
D7VK installs from a .wcp like DXVK/VKD3D and shows in the Content Manager. It is selectable from the DDraw Wrapper dropdown in container and shortcut settings. When a D7VK wrapper is selected at launch, imports .dll in syswow64, then D7VK's ddraw.dll is applied over wines. Adds the content description string in all locales.