### PR TITLE
Auto-hide touchscreen controls when a controller is connected

### DIFF
--- a/app/src/main/feature/settings/input/InputControlsFragment.kt
+++ b/app/src/main/feature/settings/input/InputControlsFragment.kt
@@ -127,6 +127,12 @@ class InputControlsFragment : Fragment() {
                                 onChoiceDialogSelect = ::selectChoiceDialog,
                                 onMultiChoiceDialogConfirm = ::confirmMultiChoiceDialog,
                                 onOverlayOpacityChanged = ::setOverlayOpacity,
+                                onAutoHideTouchOnControllerChanged = { enabled ->
+                                    preferences.edit()
+                                        .putBoolean("auto_hide_touch_on_controller", enabled)
+                                        .apply()
+                                    publishUiState()
+                                },
                                 onGyroscopeEnabledChanged = { enabled ->
                                     val editor = preferences.edit()
                                     editor.putBoolean("gyro_enabled", enabled)
@@ -293,6 +299,7 @@ class InputControlsFragment : Fragment() {
                 selectedProfileElementCount = profile?.elementCountFromFile ?: 0,
                 selectedProfileCanReset = profile != null && manager.canResetProfile(profile),
                 overlayOpacity = (preferences.getFloat("overlay_opacity", InputControlsView.DEFAULT_OVERLAY_OPACITY) * 100).toInt(),
+                autoHideTouchOnController = preferences.getBoolean("auto_hide_touch_on_controller", false),
                 gyroscopeEnabled = preferences.getBoolean("gyro_enabled", false),
                 gyroscopeModeIndex = preferences.getInt("gyro_mode", 0),
                 gyroOrientationEnabled = preferences.getBoolean("gyro_orientation_enabled", false),

--- a/app/src/main/feature/settings/input/InputControlsScreen.kt
+++ b/app/src/main/feature/settings/input/InputControlsScreen.kt
@@ -141,6 +141,7 @@ data class InputControlsScreenState(
     val selectedProfileElementCount: Int = 0,
     val selectedProfileCanReset: Boolean = false,
     val overlayOpacity: Int = 40,
+    val autoHideTouchOnController: Boolean = false,
     val gyroscopeEnabled: Boolean = false,
     val gyroscopeModeIndex: Int = 0,
     val gyroOrientationEnabled: Boolean = false,
@@ -228,6 +229,7 @@ data class InputControlsScreenActions(
     val onChoiceDialogSelect: (Int) -> Unit,
     val onMultiChoiceDialogConfirm: (Set<Int>) -> Unit,
     val onOverlayOpacityChanged: (Int) -> Unit,
+    val onAutoHideTouchOnControllerChanged: (Boolean) -> Unit,
     val onGyroscopeEnabledChanged: (Boolean) -> Unit,
     val onGyroscopeModeSelected: (Int) -> Unit,
     val onGyroOrientationModeChanged: (Boolean) -> Unit,
@@ -285,6 +287,8 @@ fun InputControlsScreen(
                 ),
             verticalArrangement = Arrangement.spacedBy(InputCompactGap),
         ) {
+            item("auto-hide-label") { SectionLabel(stringResource(R.string.input_controls_auto_hide_section)) }
+            item("auto-hide-card") { AutoHideTouchCard(state, actions) }
             item("profile-card") { ProfileCard(state, actions) }
             item("overlay-label") { SectionLabel(stringResource(R.string.input_controls_editor_overlay_opacity)) }
             item("overlay-card") { OverlayOpacityCard(state, actions) }
@@ -1503,6 +1507,41 @@ private fun ProfileActionMenuItem(
         },
         onClick = onClick,
     )
+}
+
+@Composable
+private fun AutoHideTouchCard(
+    state: InputControlsScreenState,
+    actions: InputControlsScreenActions,
+) {
+    CardShell {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconBox(Icons.Outlined.SportsEsports, InputTextSecondary)
+            Spacer(Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.input_controls_auto_hide_on_controller_title),
+                    color = InputTextPrimary,
+                    fontSize = InputPrimaryTextSize,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(1.dp))
+                Text(
+                    text = stringResource(R.string.input_controls_auto_hide_on_controller_summary),
+                    color = InputTextSecondary,
+                    fontSize = InputSecondaryTextSize,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            AppSwitch(
+                checked = state.autoHideTouchOnController,
+                onCheckedChange = actions.onAutoHideTouchOnControllerChanged,
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -683,6 +683,9 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="session_gamepad_error_loading_profile">Fejl ved indlæsning af profil</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Berøringskontroller</string>
+    <string name="input_controls_auto_hide_on_controller_title">Skjul automatisk ved controller</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Skjul skærmkontroller, når en controller er tilsluttet</string>
     <string name="session_gyroscope_title">Gyroskop</string>
     <string name="session_gyroscope_calibrate">Kalibrer gyroskop</string>
     <string name="session_gyroscope_enable_right_stick">Aktiver gyroskopisk bevægelse for højre stick</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -683,6 +683,9 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="session_gamepad_error_loading_profile">Fehler beim Laden des Profils</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Touchscreen-Steuerung</string>
+    <string name="input_controls_auto_hide_on_controller_title">Bei Controller automatisch ausblenden</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Touchscreen-Steuerung ausblenden, wenn ein Controller verbunden ist</string>
     <string name="session_gyroscope_title">Gyroskop</string>
     <string name="session_gyroscope_calibrate">Gyroskop kalibrieren</string>
     <string name="session_gyroscope_enable_right_stick">Gyroskopische Bewegung des rechten Sticks aktivieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -683,6 +683,9 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="session_gamepad_error_loading_profile">Error al cargar el perfil</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Controles táctiles</string>
+    <string name="input_controls_auto_hide_on_controller_title">Ocultar automáticamente con mando</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Oculta los controles táctiles cuando se conecta un mando</string>
     <string name="session_gyroscope_title">Giroscopio</string>
     <string name="session_gyroscope_calibrate">Calibrar giroscopio</string>
     <string name="session_gyroscope_enable_right_stick">Activar movimiento giroscópico del joystick derecho</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -683,6 +683,9 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="session_gamepad_error_loading_profile">Erreur lors du chargement du profil</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Commandes tactiles</string>
+    <string name="input_controls_auto_hide_on_controller_title">Masquer automatiquement avec une manette</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Masquer les commandes tactiles lorsqu\'une manette est connectée</string>
     <string name="session_gyroscope_title">Gyroscope</string>
     <string name="session_gyroscope_calibrate">Calibrer le gyroscope</string>
     <string name="session_gyroscope_enable_right_stick">Activer le mouvement gyroscopique du stick droit</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -790,6 +790,9 @@
     <string name="session_gamepad_profile_name_empty">प्रोफ़ाइल नाम खाली नहीं हो सकता</string>
     <string name="session_gamepad_no_profiles">-- कोई प्रोफ़ाइल नहीं --</string>
     <string name="session_gamepad_error_loading_profile">प्रोफ़ाइल लोड करने में त्रुटि</string>
+    <string name="input_controls_auto_hide_section">टचस्क्रीन नियंत्रण</string>
+    <string name="input_controls_auto_hide_on_controller_title">कंट्रोलर पर अपने आप छिपाएँ</string>
+    <string name="input_controls_auto_hide_on_controller_summary">कंट्रोलर कनेक्ट होने पर टचस्क्रीन नियंत्रण छिपाएँ</string>
     <string name="session_gyroscope_title">जाइरोस्कोप</string>
     <string name="session_gyroscope_calibrate">जाइरोस्कोप कैलिब्रेट करें</string>
     <string name="session_gyroscope_enable_right_stick">राइट स्टिक जाइरोस्कोपिक मोशन सक्षम करें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -683,6 +683,9 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="session_gamepad_error_loading_profile">Errore nel caricamento del profilo</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Controlli touchscreen</string>
+    <string name="input_controls_auto_hide_on_controller_title">Nascondi automaticamente con controller</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Nascondi i controlli touchscreen quando è collegato un controller</string>
     <string name="session_gyroscope_title">Giroscopio</string>
     <string name="session_gyroscope_calibrate">Calibra giroscopio</string>
     <string name="session_gyroscope_enable_right_stick">Abilita movimento giroscopico sulla levetta destra</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -683,6 +683,9 @@
     <string name="session_gamepad_error_loading_profile">프로필 불러오기 오류</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">터치스크린 컨트롤</string>
+    <string name="input_controls_auto_hide_on_controller_title">컨트롤러 연결 시 자동 숨김</string>
+    <string name="input_controls_auto_hide_on_controller_summary">컨트롤러가 연결되면 터치스크린 컨트롤 숨기기</string>
     <string name="session_gyroscope_title">자이로스코프</string>
     <string name="session_gyroscope_calibrate">자이로스코프 보정</string>
     <string name="session_gyroscope_enable_right_stick">오른쪽 스틱 자이로스코프 모션 활성화</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -689,6 +689,9 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="session_gamepad_error_loading_profile">Błąd wczytywania profilu</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Sterowanie dotykowe</string>
+    <string name="input_controls_auto_hide_on_controller_title">Ukryj automatycznie przy kontrolerze</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Ukryj sterowanie dotykowe, gdy podłączony jest kontroler</string>
     <string name="session_gyroscope_title">Żyroskop</string>
     <string name="session_gyroscope_calibrate">Kalibruj żyroskop</string>
     <string name="session_gyroscope_enable_right_stick">Włącz ruch żyroskopowy prawej gałki</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -683,6 +683,9 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="session_gamepad_error_loading_profile">Erro ao carregar perfil</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Controles de toque</string>
+    <string name="input_controls_auto_hide_on_controller_title">Ocultar automaticamente com controle</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Ocultar os controles de toque quando um controle estiver conectado</string>
     <string name="session_gyroscope_title">Giroscopio</string>
     <string name="session_gyroscope_calibrate">Calibrar Giroscopio</string>
     <string name="session_gyroscope_enable_right_stick">Ativar Movimento Giroscopico do Analogico Direito</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -683,6 +683,9 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="session_gamepad_error_loading_profile">Eroare la incarcarea profilului</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Comenzi tactile</string>
+    <string name="input_controls_auto_hide_on_controller_title">Ascunde automat la controler</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Ascunde comenzile tactile când este conectat un controler</string>
     <string name="session_gyroscope_title">Giroscop</string>
     <string name="session_gyroscope_calibrate">Calibreaza giroscopul</string>
     <string name="session_gyroscope_enable_right_stick">Activeaza miscarea giroscopica pe stick-ul drept</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -748,6 +748,9 @@
     <string name="session_gamepad_no_profiles">-- Нет профилей --</string>
     <string name="session_gamepad_error_loading_profile">Ошибка загрузки профиля.</string>
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Сенсорное управление</string>
+    <string name="input_controls_auto_hide_on_controller_title">Автоскрытие при контроллере</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Скрывать сенсорное управление при подключении контроллера</string>
     <string name="session_gyroscope_title">Гироскоп</string>
     <string name="session_gyroscope_calibrate">Калибровка гироскопа</string>
     <string name="session_gyroscope_enable_right_stick">Включить управление правым стиком через гироскоп</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -689,6 +689,9 @@
     <string name="session_gamepad_error_loading_profile">Помилка завантаження профілю</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">Сенсорне керування</string>
+    <string name="input_controls_auto_hide_on_controller_title">Автоприховування з контролером</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Приховувати сенсорне керування, коли під\'єднано контролер</string>
     <string name="session_gyroscope_title">Гіроскоп</string>
     <string name="session_gyroscope_calibrate">Калібрувати гіроскоп</string>
     <string name="session_gyroscope_enable_right_stick">Увімкнути гіроскопічний рух правого стіка</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -683,6 +683,9 @@
     <string name="session_gamepad_error_loading_profile">加载配置文件时出错</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">触摸屏控制</string>
+    <string name="input_controls_auto_hide_on_controller_title">连接手柄时自动隐藏</string>
+    <string name="input_controls_auto_hide_on_controller_summary">连接手柄时隐藏触摸屏控制</string>
     <string name="session_gyroscope_title">陀螺仪</string>
     <string name="session_gyroscope_calibrate">校准陀螺仪</string>
     <string name="session_gyroscope_enable_right_stick">启用右摇杆陀螺仪运动</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -683,6 +683,9 @@
     <string name="session_gamepad_error_loading_profile">載入設定檔時發生錯誤</string>
 
     <!-- Session > Gyroscope -->
+    <string name="input_controls_auto_hide_section">觸控螢幕控制</string>
+    <string name="input_controls_auto_hide_on_controller_title">連接控制器時自動隱藏</string>
+    <string name="input_controls_auto_hide_on_controller_summary">連接控制器時隱藏觸控螢幕控制</string>
     <string name="session_gyroscope_title">陀螺儀</string>
     <string name="session_gyroscope_calibrate">校準陀螺儀</string>
     <string name="session_gyroscope_enable_right_stick">啟用右搖桿陀螺儀動態感應</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -838,6 +838,11 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_gamepad_no_profiles">-- No Profiles --</string>
     <string name="session_gamepad_error_loading_profile">Error loading profile</string>
 
+    <!-- Input controls > Auto-hide on controller -->
+    <string name="input_controls_auto_hide_section">Touchscreen Controls</string>
+    <string name="input_controls_auto_hide_on_controller_title">Auto-hide on Controller</string>
+    <string name="input_controls_auto_hide_on_controller_summary">Hide touchscreen controls when a controller is connected</string>
+
     <!-- Session > Gyroscope -->
     <string name="session_gyroscope_title">Gyroscope</string>
     <string name="session_gyroscope_calibrate">Calibrate Gyroscope</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -244,8 +244,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     // Auto-hide touchscreen controls while a game controller is connected.
     private InputManager autoHideInputManager;
     private InputManager.InputDeviceListener autoHideDeviceListener;
-    private final HashSet<Integer> connectedControllerIds = new HashSet<>();
-    private boolean autoHiddenByController = false;
+    private boolean controllerAutoHidden = false;
     private boolean userOverrodeAutoHide = false;
     private XEnvironment environment;
     private ComposeView displayHostComposeView;
@@ -2263,6 +2262,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             if (activeProfile == null) activeProfile = resolvePreferredStartupProfile();
             if (activeProfile != null) showInputControls(activeProfile);
             else startTouchscreenTimeout();
+            evaluateControllerAutoHide();
         }
 
         startTime = System.currentTimeMillis();
@@ -4169,13 +4169,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
                     @Override
                     public void onInputControlsShowOverlayChanged(boolean enabled) {
-                        if (inputControlsView != null) inputControlsView.setShowTouchscreenControls(enabled);
                         preferences.edit().putBoolean("show_touchscreen_controls_enabled", enabled).commit();
                         // Manual re-enable while a controller is connected wins over auto-hide.
-                        if (enabled && !connectedControllerIds.isEmpty()) {
+                        if (enabled && isAnyGameControllerConnected()) {
                             userOverrodeAutoHide = true;
-                            autoHiddenByController = false;
+                            controllerAutoHidden = false;
                         }
+                        applyTouchscreenOverlayPreference();
                         renderDrawerMenu();
                     }
 
@@ -6234,7 +6234,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         boolean showTouchscreenControls =
                 preferences.getBoolean("show_touchscreen_controls_enabled", false);
-        inputControlsView.setShowTouchscreenControls(showTouchscreenControls);
+        inputControlsView.setShowTouchscreenControls(showTouchscreenControls && !controllerAutoHidden);
     }
 
     private void registerControllerAutoHideListener() {
@@ -6242,24 +6242,15 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         autoHideInputManager = (InputManager) getSystemService(Context.INPUT_SERVICE);
         if (autoHideInputManager == null) return;
 
-        for (int deviceId : autoHideInputManager.getInputDeviceIds()) {
-            if (ExternalController.isGameController(autoHideInputManager.getInputDevice(deviceId))) {
-                connectedControllerIds.add(deviceId);
-            }
-        }
-
         autoHideDeviceListener = new InputManager.InputDeviceListener() {
             @Override
             public void onInputDeviceAdded(int deviceId) {
-                if (ExternalController.isGameController(autoHideInputManager.getInputDevice(deviceId))) {
-                    connectedControllerIds.add(deviceId);
-                    evaluateControllerAutoHide();
-                }
+                evaluateControllerAutoHide();
             }
 
             @Override
             public void onInputDeviceRemoved(int deviceId) {
-                if (connectedControllerIds.remove(deviceId)) evaluateControllerAutoHide();
+                evaluateControllerAutoHide();
             }
 
             @Override
@@ -6273,29 +6264,41 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             autoHideInputManager.unregisterInputDeviceListener(autoHideDeviceListener);
         }
         autoHideDeviceListener = null;
-        connectedControllerIds.clear();
     }
 
-    // Hide touch overlay while a controller is connected; restore on last disconnect.
+    private boolean isAnyGameControllerConnected() {
+        InputManager im = autoHideInputManager != null
+                ? autoHideInputManager
+                : (InputManager) getSystemService(Context.INPUT_SERVICE);
+        if (im == null) return false;
+        for (int deviceId : im.getInputDeviceIds()) {
+            if (ExternalController.isGameController(im.getInputDevice(deviceId))) return true;
+        }
+        return false;
+    }
+
     private void evaluateControllerAutoHide() {
-        if (!preferences.getBoolean("auto_hide_touch_on_controller", false)) return;
         if (inputControlsView == null) return;
 
-        if (!connectedControllerIds.isEmpty()) {
-            if (userOverrodeAutoHide) return;
-            if (preferences.getBoolean("show_touchscreen_controls_enabled", false)) {
-                preferences.edit().putBoolean("show_touchscreen_controls_enabled", false).apply();
+        if (!preferences.getBoolean("auto_hide_touch_on_controller", false)) {
+            if (controllerAutoHidden) {
+                controllerAutoHidden = false;
                 applyTouchscreenOverlayPreference();
-                autoHiddenByController = true;
-                renderDrawerMenu();
+            }
+            return;
+        }
+
+        if (isAnyGameControllerConnected()) {
+            if (userOverrodeAutoHide) return;
+            if (!controllerAutoHidden) {
+                controllerAutoHidden = true;
+                applyTouchscreenOverlayPreference();
             }
         } else {
             userOverrodeAutoHide = false;
-            if (autoHiddenByController) {
-                preferences.edit().putBoolean("show_touchscreen_controls_enabled", true).apply();
+            if (controllerAutoHidden) {
+                controllerAutoHidden = false;
                 applyTouchscreenOverlayPreference();
-                autoHiddenByController = false;
-                renderDrawerMenu();
             }
         }
     }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -240,6 +240,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private InputControlsView inputControlsView;
     private boolean inputControlsRevealAllowed = false;
     private TouchpadView touchpadView;
+
+    // Auto-hide touchscreen controls while a game controller is connected.
+    private InputManager autoHideInputManager;
+    private InputManager.InputDeviceListener autoHideDeviceListener;
+    private final HashSet<Integer> connectedControllerIds = new HashSet<>();
+    private boolean autoHiddenByController = false;
+    private boolean userOverrodeAutoHide = false;
     private XEnvironment environment;
     private ComposeView displayHostComposeView;
     private FrameLayout xServerDisplayFrame;
@@ -875,6 +882,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 ViewGroup.LayoutParams.MATCH_PARENT));
 
         ControllerManager.getInstance().init(this);
+        registerControllerAutoHideListener();
 
         preloaderDialog = new PreloaderDialog(this);
 
@@ -3605,6 +3613,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     protected void onDestroy() {
         activityDestroyed.set(true);
         unregisterDisplayChangeListener();
+        unregisterControllerAutoHideListener();
         if (preloaderDialog != null) {
             preloaderDialog.close();
         }
@@ -4162,6 +4171,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     public void onInputControlsShowOverlayChanged(boolean enabled) {
                         if (inputControlsView != null) inputControlsView.setShowTouchscreenControls(enabled);
                         preferences.edit().putBoolean("show_touchscreen_controls_enabled", enabled).commit();
+                        // Manual re-enable while a controller is connected wins over auto-hide.
+                        if (enabled && !connectedControllerIds.isEmpty()) {
+                            userOverrodeAutoHide = true;
+                            autoHiddenByController = false;
+                        }
                         renderDrawerMenu();
                     }
 
@@ -6216,6 +6230,69 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         inputControlsView.setShowTouchscreenControls(showTouchscreenControls);
     }
 
+    private void registerControllerAutoHideListener() {
+        if (autoHideDeviceListener != null) return;
+        autoHideInputManager = (InputManager) getSystemService(Context.INPUT_SERVICE);
+        if (autoHideInputManager == null) return;
+
+        for (int deviceId : autoHideInputManager.getInputDeviceIds()) {
+            if (ExternalController.isGameController(autoHideInputManager.getInputDevice(deviceId))) {
+                connectedControllerIds.add(deviceId);
+            }
+        }
+
+        autoHideDeviceListener = new InputManager.InputDeviceListener() {
+            @Override
+            public void onInputDeviceAdded(int deviceId) {
+                if (ExternalController.isGameController(autoHideInputManager.getInputDevice(deviceId))) {
+                    connectedControllerIds.add(deviceId);
+                    evaluateControllerAutoHide();
+                }
+            }
+
+            @Override
+            public void onInputDeviceRemoved(int deviceId) {
+                if (connectedControllerIds.remove(deviceId)) evaluateControllerAutoHide();
+            }
+
+            @Override
+            public void onInputDeviceChanged(int deviceId) {}
+        };
+        autoHideInputManager.registerInputDeviceListener(autoHideDeviceListener, null);
+    }
+
+    private void unregisterControllerAutoHideListener() {
+        if (autoHideInputManager != null && autoHideDeviceListener != null) {
+            autoHideInputManager.unregisterInputDeviceListener(autoHideDeviceListener);
+        }
+        autoHideDeviceListener = null;
+        connectedControllerIds.clear();
+    }
+
+    // Hide touch overlay while a controller is connected; restore on last disconnect.
+    private void evaluateControllerAutoHide() {
+        if (!preferences.getBoolean("auto_hide_touch_on_controller", false)) return;
+        if (inputControlsView == null) return;
+
+        if (!connectedControllerIds.isEmpty()) {
+            if (userOverrodeAutoHide) return;
+            if (preferences.getBoolean("show_touchscreen_controls_enabled", false)) {
+                preferences.edit().putBoolean("show_touchscreen_controls_enabled", false).apply();
+                applyTouchscreenOverlayPreference();
+                autoHiddenByController = true;
+                renderDrawerMenu();
+            }
+        } else {
+            userOverrodeAutoHide = false;
+            if (autoHiddenByController) {
+                preferences.edit().putBoolean("show_touchscreen_controls_enabled", true).apply();
+                applyTouchscreenOverlayPreference();
+                autoHiddenByController = false;
+                renderDrawerMenu();
+            }
+        }
+    }
+
     private void persistSelectedProfile(ControlsProfile profile) {
         SharedPreferences.Editor editor = preferences.edit();
         if (profile != null) {
@@ -6306,6 +6383,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         Log.d("XServerDisplayActivity", "Input controls simulated confirmation executed. startupProfile=" + (startupProfile != null ? startupProfile.getName() : "none"));
 
+        evaluateControllerAutoHide();
         controllerAutoSwitchRunnable = null;
     }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4245,10 +4245,17 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                         intent.putExtra("return_to_game_on_back", true);
                         final ControlsProfile editingProfile = activeProfile;
                         editInputControlsCallback = () -> {
+                            boolean wasShowingTouch = preferences.getBoolean("show_touchscreen_controls_enabled", false);
                             hideInputControls();
                             if (inputControlsManager != null) inputControlsManager.loadProfiles(true);
                             ControlsProfile reactivated = editingProfile != null && inputControlsManager != null ? inputControlsManager.getProfile(editingProfile.id) : null;
-                            if (reactivated != null) showInputControls(reactivated);
+                            if (reactivated != null) {
+                                showInputControls(reactivated);
+                                if (wasShowingTouch) {
+                                    preferences.edit().putBoolean("show_touchscreen_controls_enabled", true).apply();
+                                    applyTouchscreenOverlayPreference();
+                                }
+                            }
                             renderDrawerMenu();
                         };
                         controlsEditorActivityResultLauncher.launch(intent);


### PR DESCRIPTION
Add an opt-in input-controls toggle (off by default) that hides the on-screen touch controls while a game controller is connected and restores them when it disconnects. Only acts when the touch overlay is enabled; a manual re-enable while a controller is connected is respected.