### PR TITLE
Feat: frontend support 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,7 +102,23 @@
             android:supportsPictureInPicture="true"
             android:screenOrientation="sensorLandscape"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation"
-            android:exported="true" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/x-desktop" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.desktop" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name="com.winlator.cmod.runtime.input.ControlsEditorActivity"

--- a/app/src/main/app/shell/LibraryGameLaunchScreen.kt
+++ b/app/src/main/app/shell/LibraryGameLaunchScreen.kt
@@ -376,9 +376,6 @@ internal fun LibraryGameLaunchScreen(
                         horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        // Order (per user spec): Settings → Shortcut → (Saves) → Cloud Saves → Export → Uninstall.
-                        // Saves is conditional but slots between Shortcut and Cloud Saves because the two
-                        // saves-related buttons read better next to each other.
                         LaunchIconActionButton(
                             icon = Icons.Outlined.Settings,
                             contentDescription = stringResource(R.string.common_ui_settings),
@@ -395,16 +392,16 @@ internal fun LibraryGameLaunchScreen(
                             onClick = onShortcut,
                         )
                         LaunchIconActionButton(
-                            icon = Icons.Outlined.CloudSync,
-                            contentDescription = stringResource(R.string.cloud_saves_title),
-                            size = actionIconSize,
-                            onClick = onCloudSaves,
-                        )
-                        LaunchIconActionButton(
                             icon = Icons.Outlined.IosShare,
                             contentDescription = stringResource(R.string.common_ui_export),
                             size = actionIconSize,
                             onClick = onExport,
+                        )
+                        LaunchIconActionButton(
+                            icon = Icons.Outlined.CloudSync,
+                            contentDescription = stringResource(R.string.cloud_saves_title),
+                            size = actionIconSize,
+                            onClick = onCloudSaves,
                         )
                         Box {
                             LaunchIconActionButton(

--- a/app/src/main/app/shell/LibraryGameLaunchScreen.kt
+++ b/app/src/main/app/shell/LibraryGameLaunchScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.outlined.CloudSync
 import androidx.compose.material.icons.outlined.Construction
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.PlayArrow
@@ -139,6 +140,7 @@ internal fun LibraryGameLaunchScreen(
     onSettings: () -> Unit,
     onShortcut: () -> Unit,
     onCloudSaves: () -> Unit,
+    onExport: () -> Unit,
     onUninstall: () -> Unit,
     onVerifyFiles: () -> Unit = {},
     onCheckForUpdate: () -> Unit = {},
@@ -154,10 +156,10 @@ internal fun LibraryGameLaunchScreen(
         val bottomPadding = 20.dp
         val actionIconSize = 48.dp
         val actionIconSpacing = 8.dp
-        // 5 action icons: Settings, Shortcut, (Saves), CloudSync, Delete.
+        // 6 action icons: Settings, Shortcut, (Saves), CloudSync, Export, Delete.
         // Saves only renders for stores that expose it; layout width tracks the static
         // count to keep the play button centered.
-        val actionWidth = actionIconSize * 5 + actionIconSpacing * 4
+        val actionWidth = actionIconSize * 6 + actionIconSpacing * 5
         val playHeight = 56.dp
         val contentGap = 18.dp
         val horizontalNavInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
@@ -374,7 +376,7 @@ internal fun LibraryGameLaunchScreen(
                         horizontalArrangement = Arrangement.spacedBy(actionIconSpacing),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        // Order (per user spec): Settings → Shortcut → (Saves) → Cloud Saves → Uninstall.
+                        // Order (per user spec): Settings → Shortcut → (Saves) → Cloud Saves → Export → Uninstall.
                         // Saves is conditional but slots between Shortcut and Cloud Saves because the two
                         // saves-related buttons read better next to each other.
                         LaunchIconActionButton(
@@ -397,6 +399,12 @@ internal fun LibraryGameLaunchScreen(
                             contentDescription = stringResource(R.string.cloud_saves_title),
                             size = actionIconSize,
                             onClick = onCloudSaves,
+                        )
+                        LaunchIconActionButton(
+                            icon = Icons.Outlined.IosShare,
+                            contentDescription = stringResource(R.string.common_ui_export),
+                            size = actionIconSize,
+                            onClick = onExport,
                         )
                         Box {
                             LaunchIconActionButton(

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -5067,7 +5067,7 @@ class UnifiedActivity :
                                             scope.launch {
                                                 val exported =
                                                     withContext(Dispatchers.IO) {
-                                                        com.winlator.cmod.feature.shortcuts.FrontendExporter.exportOne(context, shortcut)
+                                                        com.winlator.cmod.feature.shortcuts.FrontendExporter.exportOne(context, shortcut, launchAppName)
                                                     }
                                                 com.winlator.cmod.shared.ui.toast.WinToast.show(
                                                     context,

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -918,7 +918,47 @@ class UnifiedActivity :
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        if (maybeForwardFrontendLaunch()) return
         handleSettingsIntent(intent)
+    }
+
+    private fun maybeForwardFrontendLaunch(): Boolean {
+        val source = intent ?: return false
+        val path = resolveIncomingDesktopPath(source) ?: return false
+        startActivity(
+            Intent(this, XServerDisplayActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                putExtra("shortcut_path", path)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            },
+        )
+        finish()
+        return true
+    }
+
+    private fun resolveIncomingDesktopPath(source: Intent): String? {
+        desktopPathFromUri(source.data)?.let { return it }
+        val extras = source.extras ?: return null
+        for (key in extras.keySet()) {
+            when (val value = extras.get(key)) {
+                is String ->
+                    if (value.endsWith(".desktop") && java.io.File(value).isFile()) return value
+                is android.net.Uri -> desktopPathFromUri(value)?.let { return it }
+                else -> {}
+            }
+        }
+        return null
+    }
+
+    private fun desktopPathFromUri(uri: android.net.Uri?): String? {
+        if (uri == null) return null
+        val path =
+            when (uri.scheme?.lowercase()) {
+                "file" -> uri.path
+                "content" -> com.winlator.cmod.shared.io.FileUtils.getFilePathFromUri(this, uri)
+                else -> null
+            }
+        return if (!path.isNullOrEmpty() && path.endsWith(".desktop")) path else null
     }
 
     private fun bootstrapStartupState() {
@@ -1007,6 +1047,8 @@ class UnifiedActivity :
             finish()
             return
         }
+
+        if (maybeForwardFrontendLaunch()) return
 
         supportFragmentManager.registerFragmentLifecycleCallbacks(inputControlsFragmentTracker, true)
         bootstrapStartupState()

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -937,28 +937,67 @@ class UnifiedActivity :
     }
 
     private fun resolveIncomingDesktopPath(source: Intent): String? {
-        desktopPathFromUri(source.data)?.let { return it }
+        materializeDesktop(source.data)?.let { return it }
+        source.clipData?.let { clip ->
+            for (i in 0 until clip.itemCount) {
+                materializeDesktop(clip.getItemAt(i).uri)?.let { return it }
+                materializeDesktop(clip.getItemAt(i).text?.toString())?.let { return it }
+            }
+        }
         val extras = source.extras ?: return null
         for (key in extras.keySet()) {
-            when (val value = extras.get(key)) {
-                is String ->
-                    if (value.endsWith(".desktop") && java.io.File(value).isFile()) return value
-                is android.net.Uri -> desktopPathFromUri(value)?.let { return it }
-                else -> {}
+            materializeDesktop(extras.get(key))?.let { return it }
+        }
+        return null
+    }
+
+    private fun materializeDesktop(value: Any?): String? =
+        when (value) {
+            is android.net.Uri -> materializeDesktopUri(value)
+            is String ->
+                if (value.startsWith("content://") || value.startsWith("file://")) {
+                    materializeDesktopUri(android.net.Uri.parse(value))
+                } else {
+                    java.io.File(value).takeIf { it.isFile && looksLikeDesktopFile(it) }?.absolutePath
+                }
+            else -> null
+        }
+
+    private fun materializeDesktopUri(uri: android.net.Uri): String? {
+        when (uri.scheme?.lowercase()) {
+            "file" -> {
+                val file = uri.path?.let { java.io.File(it) }
+                if (file != null && file.isFile && looksLikeDesktopFile(file)) return file.absolutePath
+            }
+            "content" -> {
+                val resolved = com.winlator.cmod.shared.io.FileUtils.getFilePathFromUri(this, uri)
+                if (!resolved.isNullOrEmpty()) {
+                    val file = java.io.File(resolved)
+                    if (file.isFile && looksLikeDesktopFile(file)) return file.absolutePath
+                }
+                return copyUriToCacheDesktop(uri)
             }
         }
         return null
     }
 
-    private fun desktopPathFromUri(uri: android.net.Uri?): String? {
-        if (uri == null) return null
-        val path =
-            when (uri.scheme?.lowercase()) {
-                "file" -> uri.path
-                "content" -> com.winlator.cmod.shared.io.FileUtils.getFilePathFromUri(this, uri)
-                else -> null
-            }
-        return if (!path.isNullOrEmpty() && path.endsWith(".desktop")) path else null
+    private fun copyUriToCacheDesktop(uri: android.net.Uri): String? =
+        runCatching {
+            val out = java.io.File(cacheDir, "frontend_launch.desktop")
+            val copied =
+                contentResolver.openInputStream(uri)?.use { input ->
+                    out.outputStream().use { output -> input.copyTo(output) }
+                    true
+                } ?: false
+            if (copied && out.isFile && looksLikeDesktopFile(out)) out.absolutePath else null
+        }.getOrNull()
+
+    private fun looksLikeDesktopFile(file: java.io.File): Boolean {
+        if (!file.isFile || file.length() > 1_000_000L) return false
+        return runCatching {
+            val text = file.readText()
+            text.contains("[Desktop Entry]") || text.contains("container_id")
+        }.getOrDefault(false)
     }
 
     private fun bootstrapStartupState() {

--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -113,6 +113,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -1672,6 +1673,23 @@ class UnifiedActivity :
                     onImmersiveBlurChanged = {
                         immersiveBlur = it
                         PrefManager.libraryImmersiveBlur = it
+                    },
+                    onExportAll = {
+                        scope.launch {
+                            val count =
+                                withContext(Dispatchers.IO) {
+                                    com.winlator.cmod.feature.shortcuts.FrontendExporter.exportAll(context)
+                                }
+                            val dir = com.winlator.cmod.feature.shortcuts.FrontendExporter.resolveExportDir(context)
+                            com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                context,
+                                if (count > 0) {
+                                    context.getString(R.string.shortcuts_export_all_done, count, dir?.path ?: "")
+                                } else {
+                                    context.getString(R.string.shortcuts_export_all_none)
+                                },
+                            )
+                        }
                     },
                     onExitApp = {
                         AppTerminationHelper.exitApplication(this@UnifiedActivity, "hub_drawer_exit")
@@ -4934,6 +4952,35 @@ class UnifiedActivity :
                                         isGog -> gogGame?.title?.takeIf { it.isNotBlank() } ?: app.name
                                         else -> app.name
                                     }
+                                val heroToastAnchor = LocalView.current
+                                val resolveOrCreateShortcut: () -> com.winlator.cmod.runtime.container.Shortcut? = {
+                                    val containerManager = ContainerManager(context)
+                                    when {
+                                        isGog ->
+                                            containerManager.loadShortcuts().find {
+                                                it.getExtra("game_source") == "GOG" &&
+                                                    it.getExtra("gog_id") == gogGame!!.id
+                                            } ?: ShortcutSettingsComposeDialog.createLibraryShortcut(
+                                                context = context,
+                                                containerManager = containerManager,
+                                                source = "GOG",
+                                                appId = gogPseudoId(gogGame!!.id),
+                                                gogId = gogGame.id,
+                                                appName = app.name,
+                                            )
+                                        isCustom -> findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
+                                        else ->
+                                            findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
+                                                ?: ShortcutSettingsComposeDialog.createLibraryShortcut(
+                                                    context = context,
+                                                    containerManager = containerManager,
+                                                    source = if (isEpic) "EPIC" else "STEAM",
+                                                    appId = if (isEpic) epicId else app.id,
+                                                    gogId = null,
+                                                    appName = app.name,
+                                                )
+                                    }
+                                }
                                 LibraryGameLaunchScreen(
                                     appName = launchAppName,
                                     subtitle = subtitle,
@@ -4964,39 +5011,7 @@ class UnifiedActivity :
                                         onDismissRequest()
                                     },
                                     onSettings = {
-                                        val containerManager = ContainerManager(context)
-                                        val shortcut: com.winlator.cmod.runtime.container.Shortcut? =
-                                            when {
-                                                isGog -> {
-                                                    containerManager.loadShortcuts().find {
-                                                        it.getExtra("game_source") == "GOG" &&
-                                                            it.getExtra("gog_id") == gogGame!!.id
-                                                    } ?: ShortcutSettingsComposeDialog.createLibraryShortcut(
-                                                        context = context,
-                                                        containerManager = containerManager,
-                                                        source = "GOG",
-                                                        appId = gogPseudoId(gogGame!!.id),
-                                                        gogId = gogGame.id,
-                                                        appName = app.name,
-                                                    )
-                                                }
-
-                                                isCustom -> {
-                                                    findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
-                                                }
-
-                                                else -> {
-                                                    findLibraryShortcutForGame(containerManager, app, isCustom, isEpic, epicId)
-                                                        ?: ShortcutSettingsComposeDialog.createLibraryShortcut(
-                                                            context = context,
-                                                            containerManager = containerManager,
-                                                            source = if (isEpic) "EPIC" else "STEAM",
-                                                            appId = if (isEpic) epicId else app.id,
-                                                            gogId = null,
-                                                            appName = app.name,
-                                                        )
-                                                }
-                                            }
+                                        val shortcut = resolveOrCreateShortcut()
                                         if (shortcut != null) {
                                             // Layer the settings dialog on top; keep the detail dialog open underneath.
                                             ShortcutSettingsComposeDialog(this@UnifiedActivity, shortcut).show()
@@ -5040,6 +5055,32 @@ class UnifiedActivity :
                                         }
                                     },
                                     onCloudSaves = { activePopup = LibraryDetailPopup.CloudSaves },
+                                    onExport = {
+                                        val shortcut = resolveOrCreateShortcut()
+                                        if (shortcut == null) {
+                                            com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                                context,
+                                                R.string.shortcuts_list_failed_export,
+                                                heroToastAnchor,
+                                            )
+                                        } else {
+                                            scope.launch {
+                                                val exported =
+                                                    withContext(Dispatchers.IO) {
+                                                        com.winlator.cmod.feature.shortcuts.FrontendExporter.exportOne(context, shortcut)
+                                                    }
+                                                com.winlator.cmod.shared.ui.toast.WinToast.show(
+                                                    context,
+                                                    if (exported != null) {
+                                                        context.getString(R.string.shortcuts_list_exported_to, exported.path)
+                                                    } else {
+                                                        context.getString(R.string.shortcuts_list_failed_export)
+                                                    },
+                                                    heroToastAnchor,
+                                                )
+                                            }
+                                        }
+                                    },
                                     onUninstall = uninstallGame,
                                     // Store source tag actions. Steam exposes verify/update/workshop;
                                     // Epic and GOG expose verify/update for installed games.
@@ -10240,6 +10281,7 @@ class UnifiedActivity :
         onContentFiltersChanged: (String, Boolean) -> Unit,
         onImmersiveModeChanged: (Boolean) -> Unit,
         onImmersiveBlurChanged: (Boolean) -> Unit,
+        onExportAll: () -> Unit,
         onExitApp: () -> Unit,
     ) {
         val currentState = persona?.state ?: EPersonaState.Online
@@ -10491,6 +10533,13 @@ class UnifiedActivity :
                     }
                 }
 
+                Spacer(Modifier.height(12.dp))
+                DrawerActionCard(
+                    icon = Icons.Outlined.IosShare,
+                    label = stringResource(R.string.shortcuts_export_to_frontend),
+                    onClick = onExportAll,
+                )
+
                 Spacer(Modifier.height(16.dp))
 
                 // ── Stores ──
@@ -10594,6 +10643,66 @@ class UnifiedActivity :
             Text(
                 text = stringResource(R.string.common_ui_exit_app),
                 color = Color(0xFFFFD6D6),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+
+    @Composable
+    private fun DrawerActionCard(
+        icon: androidx.compose.ui.graphics.vector.ImageVector,
+        label: String,
+        onClick: () -> Unit,
+    ) {
+        val interactionSource = remember { MutableInteractionSource() }
+        val isPressed by interactionSource.collectIsPressedAsState()
+        val scale by animateFloatAsState(
+            targetValue = if (isPressed) 0.97f else 1f,
+            animationSpec = tween(100),
+            label = "drawerActionCardScale",
+        )
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Accent.copy(alpha = 0.14f))
+                    .border(1.dp, Accent.copy(alpha = 0.45f), RoundedCornerShape(12.dp))
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = onClick,
+                    )
+                    .padding(horizontal = 14.dp, vertical = 13.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Accent.copy(alpha = 0.22f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = Accent,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = label,
+                color = TextPrimary,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,

--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -27,6 +27,7 @@ import androidx.preference.PreferenceManager
 import com.winlator.cmod.R
 import com.winlator.cmod.app.config.SettingsConfig
 import com.winlator.cmod.app.update.UpdateChecker
+import com.winlator.cmod.feature.shortcuts.FrontendExporter
 import com.winlator.cmod.feature.setup.SetupWizardActivity
 import com.winlator.cmod.runtime.audio.midi.MidiManager
 import com.winlator.cmod.runtime.display.environment.ImageFsInstaller
@@ -135,6 +136,7 @@ class OtherSettingsFragment : Fragment() {
                                 SettingsConfig.DEFAULT_SHORTCUT_EXPORT_PATH,
                             )
                         },
+                        onExportAll = { exportAllShortcuts(ctx) },
                         onCursorSpeedChanged = { percent ->
                             preferences.edit { putFloat("cursor_speed", percent / 100f) }
                             refresh()
@@ -307,6 +309,20 @@ class OtherSettingsFragment : Fragment() {
             }
             refresh()
         }
+    }
+
+    private fun exportAllShortcuts(ctx: Context) {
+        Thread {
+            val count = FrontendExporter.exportAll(ctx)
+            val dir = FrontendExporter.resolveExportDir(ctx)
+            activity?.runOnUiThread {
+                if (count > 0) {
+                    WinToast.show(ctx, getString(R.string.shortcuts_export_all_done, count, dir?.path ?: ""))
+                } else {
+                    WinToast.show(ctx, R.string.shortcuts_export_all_none)
+                }
+            }
+        }.start()
     }
 
     private fun installSoundFont(uri: Uri) {

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -144,6 +144,7 @@ fun OtherSettingsScreen(
     onRemoveSoundFont: () -> Unit,
     onPickWinlatorPath: () -> Unit,
     onPickShortcutExportPath: () -> Unit,
+    onExportAll: () -> Unit,
     onCursorSpeedChanged: (Int) -> Unit,
     onCursorLockChanged: (Boolean) -> Unit,
     onXinputDisabledChanged: (Boolean) -> Unit,
@@ -244,6 +245,8 @@ fun OtherSettingsScreen(
                 label = stringResource(R.string.settings_general_shortcut_export_path_title),
                 path = state.shortcutExportPath,
                 onBrowse = onPickShortcutExportPath,
+                secondaryLabel = stringResource(R.string.shortcuts_export_all),
+                onSecondary = onExportAll,
             )
         }
 
@@ -795,6 +798,8 @@ private fun FolderPathCard(
     label: String,
     path: String,
     onBrowse: () -> Unit,
+    secondaryLabel: String? = null,
+    onSecondary: (() -> Unit)? = null,
 ) {
     Box(
         modifier =
@@ -838,6 +843,14 @@ private fun FolderPathCard(
                 )
             }
             Spacer(Modifier.width(10.dp))
+            if (secondaryLabel != null && onSecondary != null) {
+                SmallActionButton(
+                    label = secondaryLabel,
+                    textColor = Accent,
+                    onClick = onSecondary,
+                )
+                Spacer(Modifier.width(8.dp))
+            }
             SmallActionButton(
                 label = stringResource(R.string.settings_general_choose_path),
                 textColor = Accent,

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -91,11 +91,6 @@ public final class FrontendExporter {
 
       File out = new File(dir, baseName + ".desktop");
       FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath, resolvedName));
-
-      String uuid = shortcut.getExtra("uuid");
-      if (uuid != null && !uuid.isEmpty()) {
-        FileUtils.writeString(new File(dir, baseName + ".winnative"), uuid);
-      }
       return out;
     } catch (Exception e) {
       Log.e(TAG, "Failed to export shortcut: " + shortcut.name, e);

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -77,7 +77,7 @@ public final class FrontendExporter {
       // Copy the cover/icon next to the .desktop so the frontend can show art.
       String iconPath = null;
       File iconDst = new File(dir, baseName + ".png");
-      File iconSrc = resolveIconFile(shortcut);
+      File iconSrc = resolveIconFile(context, shortcut);
       if (iconSrc != null && iconSrc.isFile()) {
         FileUtils.copy(iconSrc, iconDst);
         iconPath = iconDst.getAbsolutePath();
@@ -125,9 +125,13 @@ public final class FrontendExporter {
     return safe.isEmpty() ? "game" : safe;
   }
 
-  private static File resolveIconFile(Shortcut shortcut) {
+  private static File resolveIconFile(Context context, Shortcut shortcut) {
     String[] candidates = {
       shortcut.getExtra("customLibraryIconPath"),
+      shortcut.getExtra("customLibraryGridArtPath"),
+      shortcut.getExtra("customLibraryCarouselArtPath"),
+      shortcut.getExtra("customLibraryHeroArtPath"),
+      shortcut.getExtra("customLibraryListArtPath"),
       shortcut.getCustomCoverArtPath(),
       shortcut.getExtra("customCoverArtPath"),
     };
@@ -137,8 +141,58 @@ public final class FrontendExporter {
         if (file.isFile()) return file;
       }
     }
+    File storeArt = resolveStoreArtFile(context, shortcut);
+    if (storeArt != null) return storeArt;
     if (shortcut.iconFile != null && shortcut.iconFile.isFile()) return shortcut.iconFile;
     return null;
+  }
+
+  private static File resolveStoreArtFile(Context context, Shortcut shortcut) {
+    String source = shortcut.getExtra("game_source");
+    String store;
+    String gameId;
+    if ("STEAM".equalsIgnoreCase(source)) {
+      store = "steam";
+      gameId = shortcut.getExtra("app_id");
+    } else if ("EPIC".equalsIgnoreCase(source)) {
+      store = "epic";
+      gameId = shortcut.getExtra("app_id");
+    } else if ("GOG".equalsIgnoreCase(source)) {
+      store = "gog";
+      gameId = shortcut.getExtra("gog_id");
+    } else {
+      return null;
+    }
+    if (gameId == null || gameId.isEmpty()) return null;
+
+    File dir =
+        new File(context.getFilesDir(), "library_artwork_cache/" + store + "/" + safeName(gameId));
+    File[] files = dir.listFiles();
+    if (files == null) return null;
+
+    String[] preferred = {"library_capsule_", "capsule_", "cover_", "header_", "small_capsule_", "hero_"};
+    for (String prefix : preferred) {
+      for (File file : files) {
+        if (file.isFile() && file.getName().startsWith(prefix) && isImageFile(file)) return file;
+      }
+    }
+    for (File file : files) {
+      if (file.isFile() && isImageFile(file)) return file;
+    }
+    return null;
+  }
+
+  private static boolean isImageFile(File file) {
+    String name = file.getName().toLowerCase();
+    return name.endsWith(".jpg")
+        || name.endsWith(".jpeg")
+        || name.endsWith(".png")
+        || name.endsWith(".webp")
+        || name.endsWith(".gif");
+  }
+
+  private static String safeName(String value) {
+    return value.replaceAll("[^A-Za-z0-9._-]", "_");
   }
 
   // Faithful copy of the source .desktop, but with the Icon line normalized to the exported PNG

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -42,13 +42,18 @@ public final class FrontendExporter {
 
   /** Export a single shortcut to the configured folder. Returns the written file, or null. */
   public static File exportOne(Context context, Shortcut shortcut) {
+    return exportOne(context, shortcut, (String) null);
+  }
+
+  /** Export a single shortcut, naming it {@code displayName} when non-empty. */
+  public static File exportOne(Context context, Shortcut shortcut, String displayName) {
     File dir = resolveExportDir(context);
     if (dir == null) return null;
-    return exportOne(context, shortcut, dir);
+    return exportOne(context, shortcut, dir, displayName);
   }
 
   /** Export a single shortcut into {@code dir}. Returns the written .desktop file, or null. */
-  public static File exportOne(Context context, Shortcut shortcut, File dir) {
+  public static File exportOne(Context context, Shortcut shortcut, File dir, String displayName) {
     if (dir == null || shortcut == null || shortcut.file == null || !shortcut.file.isFile()) {
       return null;
     }
@@ -60,7 +65,10 @@ public final class FrontendExporter {
         shortcut.saveData();
       }
 
-      String baseName = FileUtils.getBasename(shortcut.file.getPath());
+      String resolvedName =
+          (displayName != null && !displayName.trim().isEmpty()) ? displayName.trim() : null;
+      String baseName =
+          sanitizeFileName(resolvedName != null ? resolvedName : FileUtils.getBasename(shortcut.file.getPath()));
 
       // Copy the cover/icon next to the .desktop so the frontend can show art.
       String iconPath = null;
@@ -71,8 +79,8 @@ public final class FrontendExporter {
         iconPath = iconDst.getAbsolutePath();
       }
 
-      File out = new File(dir, shortcut.file.getName());
-      FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath));
+      File out = new File(dir, baseName + ".desktop");
+      FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath, resolvedName));
       return out;
     } catch (Exception e) {
       Log.e(TAG, "Failed to export shortcut: " + shortcut.name, e);
@@ -93,9 +101,17 @@ public final class FrontendExporter {
     }
     int count = 0;
     for (Shortcut shortcut : shortcuts) {
-      if (exportOne(context, shortcut, dir) != null) count++;
+      String customName = shortcut.getExtra("custom_name");
+      String displayName = (customName != null && !customName.isEmpty()) ? customName : null;
+      if (exportOne(context, shortcut, dir, displayName) != null) count++;
     }
     return count;
+  }
+
+  private static String sanitizeFileName(String name) {
+    String safe = name.replaceAll("[\\\\/:*?\"<>|]", "_").replaceAll("[\\x00-\\x1F]", "");
+    safe = safe.replaceAll("[ .]+$", "");
+    return safe.isEmpty() ? "game" : safe;
   }
 
   private static File resolveIconFile(Shortcut shortcut) {
@@ -116,7 +132,7 @@ public final class FrontendExporter {
 
   // Faithful copy of the source .desktop, but with the Icon line normalized to the exported PNG
   // so the frontend can render it. uuid / container_id already live in [Extra Data].
-  private static String buildDesktopContent(File source, String iconPath) {
+  private static String buildDesktopContent(File source, String iconPath, String displayName) {
     StringBuilder out = new StringBuilder();
     boolean inExtra = false;
     for (String line : FileUtils.readLines(source)) {
@@ -124,12 +140,13 @@ public final class FrontendExporter {
       if (trimmed.startsWith("[")) {
         inExtra = trimmed.equals("[Extra Data]");
         out.append(line).append("\n");
-        if (!inExtra && trimmed.equals("[Desktop Entry]") && iconPath != null) {
-          out.append("Icon=").append(iconPath).append("\n");
+        if (!inExtra && trimmed.equals("[Desktop Entry]")) {
+          if (displayName != null) out.append("Name=").append(displayName).append("\n");
+          if (iconPath != null) out.append("Icon=").append(iconPath).append("\n");
         }
         continue;
       }
-      // Drop the original Icon line in [Desktop Entry]; ours was re-emitted under the header.
+      if (!inExtra && displayName != null && trimmed.startsWith("Name=")) continue;
       if (!inExtra && iconPath != null && trimmed.startsWith("Icon=")) continue;
       out.append(line).append("\n");
     }

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -67,17 +67,27 @@ public final class FrontendExporter {
 
       String resolvedName =
           (displayName != null && !displayName.trim().isEmpty()) ? displayName.trim() : null;
+      if (resolvedName != null && !resolvedName.equals(shortcut.getExtra("frontend_export_name"))) {
+        shortcut.putExtra("frontend_export_name", resolvedName);
+        shortcut.saveData();
+      }
       String baseName =
           sanitizeFileName(resolvedName != null ? resolvedName : FileUtils.getBasename(shortcut.file.getPath()));
 
       // Copy the cover/icon next to the .desktop so the frontend can show art.
       String iconPath = null;
+      File iconDst = new File(dir, baseName + ".png");
       File iconSrc = resolveIconFile(shortcut);
       if (iconSrc != null && iconSrc.isFile()) {
-        File iconDst = new File(dir, baseName + ".png");
         FileUtils.copy(iconSrc, iconDst);
         iconPath = iconDst.getAbsolutePath();
+      } else {
+        android.graphics.Bitmap art = shortcut.getCoverArt();
+        if (art != null && FileUtils.saveBitmapToFile(art, iconDst)) {
+          iconPath = iconDst.getAbsolutePath();
+        }
       }
+      if (iconPath == null) Log.w(TAG, "No icon source resolved for: " + shortcut.name);
 
       File out = new File(dir, baseName + ".desktop");
       FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath, resolvedName));
@@ -101,8 +111,9 @@ public final class FrontendExporter {
     }
     int count = 0;
     for (Shortcut shortcut : shortcuts) {
-      String customName = shortcut.getExtra("custom_name");
-      String displayName = (customName != null && !customName.isEmpty()) ? customName : null;
+      String exportName = shortcut.getExtra("frontend_export_name");
+      if (exportName == null || exportName.isEmpty()) exportName = shortcut.getExtra("custom_name");
+      String displayName = (exportName != null && !exportName.isEmpty()) ? exportName : null;
       if (exportOne(context, shortcut, dir, displayName) != null) count++;
     }
     return count;

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -1,0 +1,138 @@
+package com.winlator.cmod.feature.shortcuts;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.util.Log;
+import androidx.preference.PreferenceManager;
+import com.winlator.cmod.app.config.SettingsConfig;
+import com.winlator.cmod.runtime.container.ContainerManager;
+import com.winlator.cmod.runtime.container.Shortcut;
+import com.winlator.cmod.shared.io.FileUtils;
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * Writes shortcuts as standalone .desktop files (plus their icon) into the configured export
+ * folder so external game frontends (ES-DE, Daijisho, etc.) can scan and launch them. The
+ * exported file keeps the uuid/container_id in [Extra Data] that XServerDisplayActivity resolves
+ * a game from, and points Icon= at a copied PNG so the frontend can render cover art.
+ */
+public final class FrontendExporter {
+  private static final String TAG = "FrontendExporter";
+
+  private FrontendExporter() {}
+
+  /** Resolve (and create) the configured export directory, or null if it can't be written. */
+  public static File resolveExportDir(Context context) {
+    if (context == null) return null;
+    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    String uriString = prefs.getString("shortcuts_export_path_uri", null);
+    File dir;
+    if (uriString != null) {
+      String resolved = FileUtils.getFilePathFromUri(context, Uri.parse(uriString));
+      if (resolved == null || resolved.isEmpty()) return null;
+      dir = new File(resolved);
+    } else {
+      dir = new File(SettingsConfig.DEFAULT_SHORTCUT_EXPORT_PATH);
+    }
+    if (!dir.exists() && !dir.mkdirs()) return null;
+    return dir;
+  }
+
+  /** Export a single shortcut to the configured folder. Returns the written file, or null. */
+  public static File exportOne(Context context, Shortcut shortcut) {
+    File dir = resolveExportDir(context);
+    if (dir == null) return null;
+    return exportOne(context, shortcut, dir);
+  }
+
+  /** Export a single shortcut into {@code dir}. Returns the written .desktop file, or null. */
+  public static File exportOne(Context context, Shortcut shortcut, File dir) {
+    if (dir == null || shortcut == null || shortcut.file == null || !shortcut.file.isFile()) {
+      return null;
+    }
+    try {
+      // Frontends resolve our game by uuid / container_id, so make sure both are persisted first.
+      shortcut.genUUID();
+      if (shortcut.getExtra("container_id").isEmpty()) {
+        shortcut.putExtra("container_id", String.valueOf(shortcut.container.id));
+        shortcut.saveData();
+      }
+
+      String baseName = FileUtils.getBasename(shortcut.file.getPath());
+
+      // Copy the cover/icon next to the .desktop so the frontend can show art.
+      String iconPath = null;
+      File iconSrc = resolveIconFile(shortcut);
+      if (iconSrc != null && iconSrc.isFile()) {
+        File iconDst = new File(dir, baseName + ".png");
+        FileUtils.copy(iconSrc, iconDst);
+        iconPath = iconDst.getAbsolutePath();
+      }
+
+      File out = new File(dir, shortcut.file.getName());
+      FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath));
+      return out;
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to export shortcut: " + shortcut.name, e);
+      return null;
+    }
+  }
+
+  /** Export every shortcut across all containers. Returns the number exported. */
+  public static int exportAll(Context context) {
+    File dir = resolveExportDir(context);
+    if (dir == null) return 0;
+    ArrayList<Shortcut> shortcuts;
+    try {
+      shortcuts = new ContainerManager(context).loadShortcuts();
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to load shortcuts for export", e);
+      return 0;
+    }
+    int count = 0;
+    for (Shortcut shortcut : shortcuts) {
+      if (exportOne(context, shortcut, dir) != null) count++;
+    }
+    return count;
+  }
+
+  private static File resolveIconFile(Shortcut shortcut) {
+    String[] candidates = {
+      shortcut.getExtra("customLibraryIconPath"),
+      shortcut.getCustomCoverArtPath(),
+      shortcut.getExtra("customCoverArtPath"),
+    };
+    for (String candidate : candidates) {
+      if (candidate != null && !candidate.isEmpty()) {
+        File file = new File(candidate);
+        if (file.isFile()) return file;
+      }
+    }
+    if (shortcut.iconFile != null && shortcut.iconFile.isFile()) return shortcut.iconFile;
+    return null;
+  }
+
+  // Faithful copy of the source .desktop, but with the Icon line normalized to the exported PNG
+  // so the frontend can render it. uuid / container_id already live in [Extra Data].
+  private static String buildDesktopContent(File source, String iconPath) {
+    StringBuilder out = new StringBuilder();
+    boolean inExtra = false;
+    for (String line : FileUtils.readLines(source)) {
+      String trimmed = line.trim();
+      if (trimmed.startsWith("[")) {
+        inExtra = trimmed.equals("[Extra Data]");
+        out.append(line).append("\n");
+        if (!inExtra && trimmed.equals("[Desktop Entry]") && iconPath != null) {
+          out.append("Icon=").append(iconPath).append("\n");
+        }
+        continue;
+      }
+      // Drop the original Icon line in [Desktop Entry]; ours was re-emitted under the header.
+      if (!inExtra && iconPath != null && trimmed.startsWith("Icon=")) continue;
+      out.append(line).append("\n");
+    }
+    return out.toString();
+  }
+}

--- a/app/src/main/feature/shortcuts/FrontendExporter.java
+++ b/app/src/main/feature/shortcuts/FrontendExporter.java
@@ -91,6 +91,11 @@ public final class FrontendExporter {
 
       File out = new File(dir, baseName + ".desktop");
       FileUtils.writeString(out, buildDesktopContent(shortcut.file, iconPath, resolvedName));
+
+      String uuid = shortcut.getExtra("uuid");
+      if (uuid != null && !uuid.isEmpty()) {
+        FileUtils.writeString(new File(dir, baseName + ".winnative"), uuid);
+      }
       return out;
     } catch (Exception e) {
       Log.e(TAG, "Failed to export shortcut: " + shortcut.name, e);

--- a/app/src/main/feature/shortcuts/ShortcutsFragment.java
+++ b/app/src/main/feature/shortcuts/ShortcutsFragment.java
@@ -230,64 +230,11 @@ public class ShortcutsFragment extends Fragment {
   }
 
   private void exportShortcut(Shortcut shortcut) {
-    SharedPreferences sharedPreferences =
-        PreferenceManager.getDefaultSharedPreferences(getContext());
-    String uriString = sharedPreferences.getString("shortcuts_export_path_uri", null);
-
-    File shortcutsDir;
-    if (uriString != null) {
-      String resolvedPath = FileUtils.getFilePathFromUri(getContext(), Uri.parse(uriString));
-      if (resolvedPath == null || resolvedPath.isEmpty()) {
-        WinToast.show(getContext(), R.string.common_ui_cannot_write_folder);
-        return;
-      }
-      shortcutsDir = new File(resolvedPath);
+    File exportFile = FrontendExporter.exportOne(getContext(), shortcut);
+    if (exportFile != null) {
+      WinToast.show(
+          getContext(), getString(R.string.shortcuts_list_exported_to, exportFile.getPath()));
     } else {
-      shortcutsDir = new File(SettingsConfig.DEFAULT_SHORTCUT_EXPORT_PATH);
-    }
-
-    if (!shortcutsDir.exists() && !shortcutsDir.mkdirs()) {
-      WinToast.show(getContext(), R.string.common_ui_failed_create_directory);
-      return;
-    }
-
-    File exportFile = new File(shortcutsDir, shortcut.file.getName());
-    boolean fileExists = exportFile.exists();
-    boolean containerIdFound = false;
-
-    try {
-      List<String> lines = new ArrayList<>();
-      try (BufferedReader reader = new BufferedReader(new FileReader(shortcut.file))) {
-        String line;
-        while ((line = reader.readLine()) != null) {
-          if (line.startsWith("container_id:")) {
-            lines.add("container_id:" + shortcut.container.id);
-            containerIdFound = true;
-          } else {
-            lines.add(line);
-          }
-        }
-      }
-
-      if (!containerIdFound) {
-        lines.add("container_id:" + shortcut.container.id);
-      }
-
-      try (FileWriter writer = new FileWriter(exportFile, false)) {
-        for (String line : lines) {
-          writer.write(line + "\n");
-        }
-        writer.flush();
-      }
-
-      Log.d("ShortcutsFragment", "Shortcut exported successfully to " + exportFile.getPath());
-      String message =
-          fileExists
-              ? getString(R.string.shortcuts_properties_updated_at, exportFile.getPath())
-              : getString(R.string.shortcuts_list_exported_to, exportFile.getPath());
-      WinToast.show(getContext(), message);
-    } catch (IOException e) {
-      Log.e("ShortcutsFragment", "Failed to export shortcut", e);
       WinToast.show(getContext(), R.string.shortcuts_list_failed_export);
     }
   }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Kunne ikke klone genvej.</string>
     <string name="shortcuts_list_exported_to">Genvej eksporteret til %1$s</string>
     <string name="shortcuts_list_failed_export">Kunne ikke eksportere genvej</string>
+    <string name="shortcuts_export_all">Eksportér alle</string>
+    <string name="shortcuts_export_to_frontend">Eksportér til frontend</string>
+    <string name="shortcuts_export_all_done">Eksporterede %1$d spil til %2$s</string>
+    <string name="shortcuts_export_all_none">Ingen spil at eksportere</string>
     <string name="shortcuts_list_added">Genvej tilføjet.</string>
     <string name="shortcuts_list_failed_add">Kunne ikke tilføje genvej.</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Verknüpfung konnte nicht geklont werden.</string>
     <string name="shortcuts_list_exported_to">Verknüpfung exportiert nach %1$s</string>
     <string name="shortcuts_list_failed_export">Verknüpfung konnte nicht exportiert werden</string>
+    <string name="shortcuts_export_all">Alle exportieren</string>
+    <string name="shortcuts_export_to_frontend">An Frontend exportieren</string>
+    <string name="shortcuts_export_all_done">%1$d Spiele nach %2$s exportiert</string>
+    <string name="shortcuts_export_all_none">Keine Spiele zum Exportieren</string>
     <string name="shortcuts_list_added">Verknüpfung erfolgreich hinzugefügt.</string>
     <string name="shortcuts_list_failed_add">Verknüpfung konnte nicht hinzugefügt werden.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Error al clonar el acceso directo.</string>
     <string name="shortcuts_list_exported_to">Acceso directo exportado a %1$s</string>
     <string name="shortcuts_list_failed_export">Error al exportar el acceso directo</string>
+    <string name="shortcuts_export_all">Exportar todo</string>
+    <string name="shortcuts_export_to_frontend">Exportar al frontend</string>
+    <string name="shortcuts_export_all_done">Se exportaron %1$d juegos a %2$s</string>
+    <string name="shortcuts_export_all_none">No hay juegos para exportar</string>
     <string name="shortcuts_list_added">Acceso directo añadido correctamente.</string>
     <string name="shortcuts_list_failed_add">Error al añadir el acceso directo.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Échec du clonage du raccourci.</string>
     <string name="shortcuts_list_exported_to">Raccourci exporté vers %1$s</string>
     <string name="shortcuts_list_failed_export">Échec de l\'exportation du raccourci</string>
+    <string name="shortcuts_export_all">Tout exporter</string>
+    <string name="shortcuts_export_to_frontend">Exporter vers le frontend</string>
+    <string name="shortcuts_export_all_done">%1$d jeux exportés vers %2$s</string>
+    <string name="shortcuts_export_all_none">Aucun jeu à exporter</string>
     <string name="shortcuts_list_added">Raccourci ajouté avec succès.</string>
     <string name="shortcuts_list_failed_add">Échec de l\'ajout du raccourci.</string>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -294,6 +294,10 @@
     <string name="shortcuts_list_clone_failed">शॉर्टकट क्लोन करने में विफल.</string>
     <string name="shortcuts_list_exported_to">शॉर्टकट %1$s पर निर्यात किया गया</string>
     <string name="shortcuts_list_failed_export">शॉर्टकट निर्यात करने में विफल</string>
+    <string name="shortcuts_export_all">सभी निर्यात करें</string>
+    <string name="shortcuts_export_to_frontend">फ्रंटएंड में निर्यात करें</string>
+    <string name="shortcuts_export_all_done">%1$d गेम %2$s में निर्यात किए गए</string>
+    <string name="shortcuts_export_all_none">निर्यात करने के लिए कोई गेम नहीं</string>
     <string name="shortcuts_list_added">शॉर्टकट सफलतापूर्वक जोड़ा गया.</string>
     <string name="shortcuts_list_readded_existing">मौजूदा शॉर्टकट पुनः जोड़ा गया</string>
     <string name="shortcuts_list_failed_add">शॉर्टकट जोड़ने में विफल.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Impossibile clonare la scorciatoia.</string>
     <string name="shortcuts_list_exported_to">Scorciatoia esportata in %1$s</string>
     <string name="shortcuts_list_failed_export">Impossibile esportare la scorciatoia</string>
+    <string name="shortcuts_export_all">Esporta tutto</string>
+    <string name="shortcuts_export_to_frontend">Esporta nel frontend</string>
+    <string name="shortcuts_export_all_done">%1$d giochi esportati in %2$s</string>
+    <string name="shortcuts_export_all_none">Nessun gioco da esportare</string>
     <string name="shortcuts_list_added">Scorciatoia aggiunta con successo.</string>
     <string name="shortcuts_list_failed_add">Impossibile aggiungere la scorciatoia.</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">바로가기 복제에 실패했습니다.</string>
     <string name="shortcuts_list_exported_to">바로가기가 %1$s(으)로 내보내졌습니다</string>
     <string name="shortcuts_list_failed_export">바로가기 내보내기에 실패했습니다</string>
+    <string name="shortcuts_export_all">모두 내보내기</string>
+    <string name="shortcuts_export_to_frontend">프런트엔드로 내보내기</string>
+    <string name="shortcuts_export_all_done">게임 %1$d개를 %2$s(으)로 내보냈습니다</string>
+    <string name="shortcuts_export_all_none">내보낼 게임이 없습니다</string>
     <string name="shortcuts_list_added">바로가기가 성공적으로 추가되었습니다.</string>
     <string name="shortcuts_list_failed_add">바로가기 추가에 실패했습니다.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -282,6 +282,10 @@
     <string name="shortcuts_list_clone_failed">Nie udało się sklonować skrótu.</string>
     <string name="shortcuts_list_exported_to">Skrót wyeksportowany do %1$s</string>
     <string name="shortcuts_list_failed_export">Nie udało się wyeksportować skrótu</string>
+    <string name="shortcuts_export_all">Eksportuj wszystko</string>
+    <string name="shortcuts_export_to_frontend">Eksportuj do frontendu</string>
+    <string name="shortcuts_export_all_done">Wyeksportowano %1$d gier do %2$s</string>
+    <string name="shortcuts_export_all_none">Brak gier do wyeksportowania</string>
     <string name="shortcuts_list_added">Skrót dodany pomyślnie.</string>
     <string name="shortcuts_list_failed_add">Nie udało się dodać skrótu.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Falha ao clonar atalho.</string>
     <string name="shortcuts_list_exported_to">Atalho exportado para %1$s</string>
     <string name="shortcuts_list_failed_export">Falha ao exportar atalho</string>
+    <string name="shortcuts_export_all">Exportar tudo</string>
+    <string name="shortcuts_export_to_frontend">Exportar para o frontend</string>
+    <string name="shortcuts_export_all_done">%1$d jogos exportados para %2$s</string>
+    <string name="shortcuts_export_all_none">Nenhum jogo para exportar</string>
     <string name="shortcuts_list_added">Atalho adicionado com sucesso.</string>
     <string name="shortcuts_list_failed_add">Falha ao adicionar atalho.</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">Nu s-a putut clona comanda rapida.</string>
     <string name="shortcuts_list_exported_to">Comanda rapida exportata in %1$s</string>
     <string name="shortcuts_list_failed_export">Nu s-a putut exporta comanda rapida</string>
+    <string name="shortcuts_export_all">Exportă tot</string>
+    <string name="shortcuts_export_to_frontend">Exportă în frontend</string>
+    <string name="shortcuts_export_all_done">%1$d jocuri exportate în %2$s</string>
+    <string name="shortcuts_export_all_none">Niciun joc de exportat</string>
     <string name="shortcuts_list_added">Comanda rapida adaugata cu succes.</string>
     <string name="shortcuts_list_failed_add">Nu s-a putut adauga comanda rapida.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -304,6 +304,10 @@
     <string name="shortcuts_list_clone_failed">Не удалось клонировать ярлык.</string>
     <string name="shortcuts_list_exported_to">Ярлык экспортирован в %1$s.</string>
     <string name="shortcuts_list_failed_export">Не удалось экспортировать ярлык.</string>
+    <string name="shortcuts_export_all">Экспортировать все</string>
+    <string name="shortcuts_export_to_frontend">Экспорт во фронтенд</string>
+    <string name="shortcuts_export_all_done">Экспортировано %1$d игр в %2$s</string>
+    <string name="shortcuts_export_all_none">Нет игр для экспорта</string>
     <string name="shortcuts_list_added">Ярлык успешно добавлен.</string>
     <string name="shortcuts_list_readded_existing">Повторно добавлен существующий ярлык</string>
     <string name="shortcuts_list_failed_add">Не удалось добавить ярлык.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -282,6 +282,10 @@
     <string name="shortcuts_list_clone_failed">Не вдалося клонувати ярлик.</string>
     <string name="shortcuts_list_exported_to">Ярлик експортовано до %1$s</string>
     <string name="shortcuts_list_failed_export">Не вдалося експортувати ярлик</string>
+    <string name="shortcuts_export_all">Експортувати все</string>
+    <string name="shortcuts_export_to_frontend">Експортувати до фронтенду</string>
+    <string name="shortcuts_export_all_done">Експортовано %1$d ігор до %2$s</string>
+    <string name="shortcuts_export_all_none">Немає ігор для експорту</string>
     <string name="shortcuts_list_added">Ярлик успішно додано.</string>
     <string name="shortcuts_list_failed_add">Не вдалося додати ярлик.</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">克隆快捷方式失败。</string>
     <string name="shortcuts_list_exported_to">快捷方式已导出到 %1$s</string>
     <string name="shortcuts_list_failed_export">导出快捷方式失败</string>
+    <string name="shortcuts_export_all">全部导出</string>
+    <string name="shortcuts_export_to_frontend">导出到前端</string>
+    <string name="shortcuts_export_all_done">已将 %1$d 个游戏导出到 %2$s</string>
+    <string name="shortcuts_export_all_none">没有可导出的游戏</string>
     <string name="shortcuts_list_added">快捷方式已成功添加。</string>
     <string name="shortcuts_list_failed_add">添加快捷方式失败。</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -278,6 +278,10 @@
     <string name="shortcuts_list_clone_failed">無法複製捷徑。</string>
     <string name="shortcuts_list_exported_to">捷徑已匯出至 %1$s</string>
     <string name="shortcuts_list_failed_export">無法匯出捷徑</string>
+    <string name="shortcuts_export_all">全部匯出</string>
+    <string name="shortcuts_export_to_frontend">匯出到前端</string>
+    <string name="shortcuts_export_all_done">已將 %1$d 個遊戲匯出至 %2$s</string>
+    <string name="shortcuts_export_all_none">沒有可匯出的遊戲</string>
     <string name="shortcuts_list_added">捷徑已成功新增。</string>
     <string name="shortcuts_list_failed_add">無法新增捷徑。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,6 +308,10 @@
     <string name="shortcuts_list_clone_failed">Failed to clone shortcut.</string>
     <string name="shortcuts_list_exported_to">Shortcut Exported to %1$s</string>
     <string name="shortcuts_list_failed_export">Failed to export shortcut</string>
+    <string name="shortcuts_export_all">Export All</string>
+    <string name="shortcuts_export_to_frontend">Export to Frontend</string>
+    <string name="shortcuts_export_all_done">Exported %1$d games to %2$s</string>
+    <string name="shortcuts_export_all_none">No games to export</string>
     <string name="shortcuts_list_added">Shortcut added successfully.</string>
     <string name="shortcuts_list_readded_existing">Re-added existing shortcut</string>
     <string name="shortcuts_list_failed_add">Failed to add shortcut.</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1047,6 +1047,14 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             }
         }
 
+        if ((shortcutPath == null || shortcutPath.isEmpty()) && launchData != null) {
+            String dataPath = resolveDesktopPathFromUri(launchData);
+            if (dataPath != null && !dataPath.isEmpty()) {
+                shortcutPath = dataPath;
+                Log.d("XServerDisplayActivity", "Resolved shortcut path from VIEW data: " + shortcutPath);
+            }
+        }
+
         Shortcut resolvedShortcut = null;
         if (shortcutUuid != null && !shortcutUuid.isEmpty()) {
             resolvedShortcut = findShortcutByUuid(shortcutUuid, containerId);
@@ -1661,6 +1669,22 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 }
             }, 1000);
         }
+    }
+
+    private String resolveDesktopPathFromUri(android.net.Uri uri) {
+        if (uri == null) return null;
+        try {
+            String scheme = uri.getScheme();
+            if ("file".equalsIgnoreCase(scheme)) {
+                return uri.getPath();
+            }
+            if ("content".equalsIgnoreCase(scheme)) {
+                return com.winlator.cmod.shared.io.FileUtils.getFilePathFromUri(this, uri);
+            }
+        } catch (Exception e) {
+            Log.e("XServerDisplayActivity", "Failed to resolve .desktop path from URI", e);
+        }
+        return null;
     }
 
     private int parseContainerIdFromDesktopFile(File desktopFile) {


### PR DESCRIPTION
New FrontendExporter writes a standalone .desktop plus a copied icon into the configured export folder so external frontends can scan and launch games. Adds a per-game export icon on the game detail screen, an Export All chip in the export-path setting, and an Export to Frontend action in the side menu. Legacy shortcut export now uses the shared routine. Strings localized across all locales.