### PR TITLE
Preserve d3d10/d3d10_1/d3d8/d3dimm builtins from DXVK pre-extract wipe

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -6701,6 +6701,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         File syswow64 = new File(rootDir, ImageFs.WINEPREFIX + "/drive_c/windows/syswow64");
         int deleted = 0;
         for (String name : DXWRAPPER_DLLS) {
+            if (name.equals("d3d10.dll") || name.equals("d3d10_1.dll")
+                    || name.equals("d3d8.dll") || name.equals("d3dimm.dll")) continue;
             File a = new File(system32, name);
             File b = new File(syswow64, name);
             if (a.exists() && a.delete()) deleted++;


### PR DESCRIPTION
These Wine built-in DLLs are seeded at container creation and are not re-supplied by the DXVK launch path, so wiping them before re-extract left D3D10/D3D8 apps with no loader. Skip them in the wipe; the wined3d/None paths still restore them.