### PR TITLE
fix: Z drive boot and shortcut creation

### DIFF
--- a/app/src/main/runtime/wine/MSLink.java
+++ b/app/src/main/runtime/wine/MSLink.java
@@ -243,12 +243,21 @@ public abstract class MSLink {
       File containerRootDir = container != null ? container.getRootDir() : new File(imageFs.getRootDir(), "home/" + ImageFs.USER);
       winePrefix = new File(containerRootDir, ".wine").getAbsolutePath();
 
-      // PEACFUL UPGRADE: If getNativePath failed (common during first creation), 
+      // PEACFUL UPGRADE: If getNativePath failed (common during first creation),
       // calculate the Absolute Android Path math immediately so we have the parent folder.
       if (exeFile == null || !exeFile.exists()) {
         String relPath = windowsPath.substring(2).replace("\\", "/");
         while (relPath.startsWith("/")) relPath = relPath.substring(1);
         exeFile = new File(containerRootDir, ".wine/drive_c/" + relPath);
+      }
+    } else if (windowsPath.matches("^[zZ]:.*")) {
+      File containerRootDir = container != null ? container.getRootDir() : new File(imageFs.getRootDir(), "home/" + ImageFs.USER);
+      winePrefix = new File(containerRootDir, ".wine").getAbsolutePath();
+
+      if (exeFile == null || !exeFile.exists()) {
+        String relPath = windowsPath.substring(2).replace("\\", "/");
+        while (relPath.startsWith("/")) relPath = relPath.substring(1);
+        exeFile = new File(imageFs.getRootDir(), relPath);
       }
     }
 

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -46,6 +46,15 @@ public abstract class WineUtils {
         if (relativePath.isEmpty()) return "C:\\";
         return "C:\\" + relativePath;
       }
+
+      String driveZRoot =
+          normalizeHostPath(new File(container.getRootDir(), "../..").getAbsolutePath());
+      if (pathStartsWith(normalizedHostPath, driveZRoot)) {
+        String relativePath = normalizedHostPath.substring(driveZRoot.length()).replace("/", "\\");
+        while (relativePath.startsWith("\\")) relativePath = relativePath.substring(1);
+        if (relativePath.isEmpty()) return "Z:\\";
+        return "Z:\\" + relativePath;
+      }
     }
 
     String bestDriveLetter = null;
@@ -1388,6 +1397,10 @@ public abstract class WineUtils {
       // Direct drive_c fallback
       if (drive.equals("c")) {
         return new File(homePrefix, ".wine/drive_c/" + relPath);
+      }
+      // Direct drive_z fallback (Z: maps to the imageFs root)
+      if (drive.equals("z")) {
+        return new File(imageFs.getRootDir(), relPath);
       }
     }
     return new File(imageFs.getRootDir(), path);


### PR DESCRIPTION
Resolve Z: paths to the imageFs root (the dosdevices z: symlink target) the same way C: resolves to drive_c: add a z: fallback in getNativePath, write the absolute android path into the .desktop at creation in createDesktopFile, and reverse-map host paths under the imageFs root back to Z:\ in hostPathToMappedWinePath. Fixes "path not found" when booting shortcuts for games on the Z drive.