### PR TITLE
Fix: adjust glass control opacity slider

### DIFF
--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -893,7 +893,10 @@ return boundingBox;
     int accent = resolveAccentColor();
     boolean hasAccent = accent != -1;
 
-    float gameHubDim = Math.min(1.0f, 0.5f + overlayOpacity * 0.7f);
+    // Anchored at 40% default; steeper below, gentle to full above.
+    float gameHubDim = overlayOpacity <= 0.4f
+        ? 0.28f + (overlayOpacity - 0.1f) * (0.5f / 0.3f)
+        : 0.78f + (overlayOpacity - 0.4f) * (0.22f / 0.6f);
     int fillAlpha = (int) (90 * gameHubDim * effectiveOpacity);
     int strokeAlpha = (int) (150 * gameHubDim * effectiveOpacity);
     int pressedFillAlpha = (int) (60 * gameHubDim * effectiveOpacity);


### PR DESCRIPTION
Remap the GameHub brightness curve, anchored at the 40% default: dims further below it and stays responsive above instead of saturating past ~70%. Non-glass style unaffected.