### PR TITLE
Audio: fix crackling via larger output buffers

### DIFF
--- a/app/src/main/runtime/audio/alsaserver/ALSAClient.java
+++ b/app/src/main/runtime/audio/alsaserver/ALSAClient.java
@@ -41,14 +41,14 @@ public class ALSAClient {
   private final Options options;
 
   public static class Options {
-    public static final int DEFAULT_LATENCY_MILLIS = 16;
+    public static final int DEFAULT_LATENCY_MILLIS = 40;
     public static final float DEFAULT_VOLUME = 1.0f;
     public static final float MAX_VOLUME = 16.0f;
     public static final float DEFAULT_BASS_BOOST = 0.0f;
     public static final float MAX_BASS_BOOST = 2.0f;
 
     public int latencyMillis = DEFAULT_LATENCY_MILLIS;
-    public int performanceMode = AudioTrack.PERFORMANCE_MODE_LOW_LATENCY;
+    public int performanceMode = AudioTrack.PERFORMANCE_MODE_NONE;
     public float volume = DEFAULT_VOLUME;
     public float bassBoost = DEFAULT_BASS_BOOST;
 
@@ -77,12 +77,12 @@ public class ALSAClient {
       String performanceMode =
           firstNonEmpty(
               envVars.get("ANDROID_ALSA_PERFORMANCE_MODE"), envVars.get("WINNATIVE_ALSA_PERFORMANCE_MODE"));
-      if (performanceMode.equalsIgnoreCase("none") || performanceMode.equals("0")) {
-        options.performanceMode = AudioTrack.PERFORMANCE_MODE_NONE;
+      if (performanceMode.equalsIgnoreCase("low_latency") || performanceMode.equals("1")) {
+        options.performanceMode = AudioTrack.PERFORMANCE_MODE_LOW_LATENCY;
       } else if (performanceMode.equalsIgnoreCase("power_saving") || performanceMode.equals("2")) {
         options.performanceMode = AudioTrack.PERFORMANCE_MODE_POWER_SAVING;
       } else {
-        options.performanceMode = AudioTrack.PERFORMANCE_MODE_LOW_LATENCY;
+        options.performanceMode = AudioTrack.PERFORMANCE_MODE_NONE;
       }
 
       return options;

--- a/app/src/main/runtime/display/environment/components/PulseAudioComponent.java
+++ b/app/src/main/runtime/display/environment/components/PulseAudioComponent.java
@@ -34,7 +34,7 @@ public class PulseAudioComponent extends EnvironmentComponent {
   }
 
   public static class Options {
-    public static final int DEFAULT_LATENCY_MILLIS = 40;
+    public static final int DEFAULT_LATENCY_MILLIS = 144;
     public static final int DEFAULT_FRAGMENT_MILLIS = 10;
     public static final int DEFAULT_SAMPLE_RATE = 48000;
     public static final int DEFAULT_ALTERNATE_SAMPLE_RATE = 44100;


### PR DESCRIPTION
ALSA output now defaults to PERFORMANCE_MODE_NONE at 40ms latency instead of LOW_LATENCY at 16ms. LOW_LATENCY capped the AudioTrack buffer capacity, so underrun recovery could not grow it, causing crackle/dropouts on bursty streams. An unset performance-mode env var now resolves to NONE; low_latency stays an explicit opt-in. PulseAudio default latency raised from 40ms to 144ms.