### PR TITLE
Fix off-center shadow artifact on library top-bar icon buttons

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -2322,7 +2322,6 @@ class UnifiedActivity :
                         modifier =
                             Modifier
                                 .size(44.dp)
-                                .shadow(6.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.5f))
                                 .clip(CircleShape)
                                 .background(Color.Transparent)
                                 .border(1.dp, Accent.copy(alpha = 0.5f), CircleShape)
@@ -2362,7 +2361,6 @@ class UnifiedActivity :
                         modifier =
                             Modifier
                                 .size(44.dp)
-                                .shadow(6.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.5f))
                                 .clip(CircleShape)
                                 .background(
                                     if (isSearchExpanded) {
@@ -2432,7 +2430,6 @@ class UnifiedActivity :
                         modifier =
                             Modifier
                                 .size(44.dp)
-                                .shadow(6.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.5f))
                                 .clip(CircleShape)
                                 .background(Color.Transparent)
                                 .border(1.dp, Accent.copy(alpha = 0.5f), CircleShape)
@@ -2452,7 +2449,6 @@ class UnifiedActivity :
                         modifier =
                             Modifier
                                 .size(44.dp)
-                                .shadow(6.dp, CircleShape, spotColor = Color.Black.copy(alpha = 0.5f))
                                 .clip(CircleShape)
                                 .background(Color.Transparent)
                                 .border(1.dp, Accent.copy(alpha = 0.5f), CircleShape)


### PR DESCRIPTION
Remove elevation shadow that bled through the transparent circle fill of the settings, search, file-picker and filter buttons, showing as an off-center polygon over background art.