### PR TITLE
External display: gate auto-output behind a toggle (default off; Vitu…

### DIFF
--- a/app/src/main/feature/settings/other/OtherSettingsFragment.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsFragment.kt
@@ -170,6 +170,10 @@ class OtherSettingsFragment : Fragment() {
                             preferences.edit { putBoolean("enable_background_session", checked) }
                             refresh()
                         },
+                        onExternalDisplayOutputChanged = { checked ->
+                            preferences.edit { putBoolean("external_display_output", checked) }
+                            refresh()
+                        },
                         onRunSetupWizard = {
                             startActivity(SetupWizardActivity.createManualRerunIntent(ctx))
                         },
@@ -235,6 +239,7 @@ class OtherSettingsFragment : Fragment() {
                 shareClipboard = preferences.getBoolean("share_android_clipboard", false),
                 recordPerformanceToFile = preferences.getBoolean("hud_record_to_file", false),
                 enableBackgroundSession = preferences.getBoolean("enable_background_session", false),
+                externalDisplayOutput = preferences.getBoolean("external_display_output", false),
                 imagefsInstallProgress = uiState.imagefsInstallProgress,
             )
     }

--- a/app/src/main/feature/settings/other/OtherSettingsScreen.kt
+++ b/app/src/main/feature/settings/other/OtherSettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LibraryMusic
+import androidx.compose.material.icons.outlined.Monitor
 import androidx.compose.material.icons.outlined.Mouse
 import androidx.compose.material.icons.outlined.OpenInBrowser
 import androidx.compose.material.icons.outlined.Settings
@@ -110,6 +111,7 @@ data class OtherSettingsState(
     val shareClipboard: Boolean = false,
     val recordPerformanceToFile: Boolean = false,
     val enableBackgroundSession: Boolean = false,
+    val externalDisplayOutput: Boolean = false,
     val imagefsInstallProgress: Int? = null,
 )
 
@@ -153,6 +155,7 @@ fun OtherSettingsScreen(
     onShareClipboardChanged: (Boolean) -> Unit,
     onRecordPerformanceToFileChanged: (Boolean) -> Unit,
     onEnableBackgroundSessionChanged: (Boolean) -> Unit,
+    onExternalDisplayOutputChanged: (Boolean) -> Unit,
     onRunSetupWizard: () -> Unit,
     onReinstallImagefs: () -> Unit,
 ) {
@@ -278,6 +281,16 @@ fun OtherSettingsScreen(
                 icon = Icons.Outlined.SportsEsports,
                 checked = state.xinputDisabled,
                 onCheckedChange = onXinputDisabledChanged,
+            )
+        }
+
+        item(key = "external_display_output_card") {
+            SettingsToggleCard(
+                title = stringResource(R.string.session_drawer_output_to_display),
+                subtitle = stringResource(R.string.settings_external_display_output_summary),
+                icon = Icons.Outlined.Monitor,
+                checked = state.externalDisplayOutput,
+                onCheckedChange = onExternalDisplayOutputChanged,
             )
         }
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -751,6 +751,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_general_cursor_lock_summary">Holder direkte museopfangning aktiveret for spil der kræver rå markørinput. Deaktiver med Lydstyrke ned.</string>
     <string name="settings_general_xinput_toggle_title">Deaktiver XInput</string>
     <string name="settings_general_xinput_toggle_summary">Slår XInput-håndtering fra når du ønsker eksklusiv mus- og tastaturkontrol.</string>
+    <string name="settings_external_display_output_summary">Flyt spillet til en tilsluttet ekstern skærm i stedet for at spejle denne skærm. Briller bruger altid deres egen skærm.</string>
     <string name="settings_general_file_provider_summary">Gør WinNative-filer tilgængelige for Android-dokumentvælgere og filhåndtering.</string>
     <string name="settings_general_open_browser_summary">Åbn understøttede weblinks i Android-browseren i stedet for inde i Wine.</string>
     <string name="settings_general_clipboard_summary">Tillad kopiering og indsættelse mellem Android og Wine-sessioner.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1413,6 +1413,7 @@ Installeret sti:
     <string name="session_drawer_output_game_mode_off">Fra</string>
     <string name="session_drawer_output_game_mode_note">Anmoder om tv\'ets spil-/lavlatensstilstand (HDMI ALLM) for at minimere inputforsinkelse. Vises kun, når den tilsluttede skærm understøtter det.</string>
     <string name="session_drawer_output_send_to_display">Send spil til skærm</string>
+    <string name="session_drawer_output_to_display">Output til ekstern skærm</string>
     <string name="session_drawer_output_send_note">En skærm er tilsluttet. Send spillet til den — dine knapper og menuen forbliver på denne telefon. Du kan altid hente det tilbage hertil.</string>
     <string name="session_drawer_output_display">Skærm</string>
     <string name="session_drawer_output_glasses">Briller</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1413,6 +1413,7 @@ Installierter Pfad:
     <string name="session_drawer_output_game_mode_off">Aus</string>
     <string name="session_drawer_output_game_mode_note">Fordert den Spiel-/Niedriglatenzmodus des Fernsehers (HDMI ALLM) an, um die Eingabeverzögerung zu minimieren. Wird nur angezeigt, wenn das verbundene Display dies unterstützt.</string>
     <string name="session_drawer_output_send_to_display">Spiel an Display senden</string>
+    <string name="session_drawer_output_to_display">Auf externem Display ausgeben</string>
     <string name="session_drawer_output_send_note">Ein Display ist verbunden. Sende das Spiel dorthin — deine Steuerung und das Menü bleiben auf diesem Telefon. Du kannst es jederzeit hierher zurückholen.</string>
     <string name="session_drawer_output_display">Anzeige</string>
     <string name="session_drawer_output_glasses">Brille</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -751,6 +751,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_general_cursor_lock_summary">Hält die direkte Mauserfassung für Spiele aktiv, die Rohdaten-Zeigereingabe benötigen. Mit Leiser-Taste deaktivieren.</string>
     <string name="settings_general_xinput_toggle_title">XInput deaktivieren</string>
     <string name="settings_general_xinput_toggle_summary">Schaltet die XInput-Behandlung aus, wenn du exklusive Maus- und Tastatursteuerung möchtest.</string>
+    <string name="settings_external_display_output_summary">Verschiebt das Spiel auf ein angeschlossenes externes Display, anstatt diesen Bildschirm zu spiegeln. Brillen nutzen immer ihr eigenes Display.</string>
     <string name="settings_general_file_provider_summary">WinNative-Dateien für Android-Dokumentenauswahl und Dateimanager bereitstellen.</string>
     <string name="settings_general_open_browser_summary">Unterstützte Weblinks im Android-Browser statt in Wine öffnen.</string>
     <string name="settings_general_clipboard_summary">Kopieren und Einfügen zwischen Android und Wine-Sitzungen erlauben.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1413,6 +1413,7 @@ Ruta instalada:
     <string name="session_drawer_output_game_mode_off">Desactivado</string>
     <string name="session_drawer_output_game_mode_note">Solicita el modo de juego / baja latencia de la TV (HDMI ALLM) para minimizar el retardo de entrada. Se muestra solo cuando la pantalla conectada lo admite.</string>
     <string name="session_drawer_output_send_to_display">Enviar juego a la pantalla</string>
+    <string name="session_drawer_output_to_display">Salida a pantalla externa</string>
     <string name="session_drawer_output_send_note">Hay una pantalla conectada. Envía el juego a ella: tus controles y el menú permanecen en este teléfono. Puedes devolverlo aquí en cualquier momento.</string>
     <string name="session_drawer_output_display">Pantalla</string>
     <string name="session_drawer_output_glasses">Gafas</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -751,6 +751,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantiene la captura directa del ratón activada para juegos que necesitan entrada de puntero sin procesar. Desactívalo con Bajar Volumen.</string>
     <string name="settings_general_xinput_toggle_title">Desactivar XInput</string>
     <string name="settings_general_xinput_toggle_summary">Desactiva el manejo de XInput cuando quieras control exclusivo de ratón y teclado.</string>
+    <string name="settings_external_display_output_summary">Mueve el juego a una pantalla externa conectada en lugar de duplicar esta pantalla. Las gafas siempre usan su propia pantalla.</string>
     <string name="settings_general_file_provider_summary">Exponer los archivos de WinNative a los selectores de documentos y administradores de archivos de Android.</string>
     <string name="settings_general_open_browser_summary">Abrir enlaces web compatibles en el navegador de Android en lugar de dentro de Wine.</string>
     <string name="settings_general_clipboard_summary">Permitir copiar y pegar entre Android y las sesiones de Wine.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -751,6 +751,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_general_cursor_lock_summary">Maintient la capture directe de la souris activée pour les jeux nécessitant une saisie brute du pointeur. Désactivez avec Volume Bas.</string>
     <string name="settings_general_xinput_toggle_title">Désactiver XInput</string>
     <string name="settings_general_xinput_toggle_summary">Désactive la gestion XInput lorsque vous souhaitez un contrôle exclusif au clavier et à la souris.</string>
+    <string name="settings_external_display_output_summary">Déplace le jeu vers un écran externe connecté au lieu de dupliquer cet écran. Les lunettes utilisent toujours leur propre écran.</string>
     <string name="settings_general_file_provider_summary">Exposer les fichiers de WinNative aux sélecteurs de documents et gestionnaires de fichiers Android.</string>
     <string name="settings_general_open_browser_summary">Ouvrir les liens web pris en charge dans le navigateur Android au lieu de les ouvrir dans Wine.</string>
     <string name="settings_general_clipboard_summary">Permettre le copier-coller entre Android et les sessions Wine.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1413,6 +1413,7 @@ Chemin installé :
     <string name="session_drawer_output_game_mode_off">Désactivé</string>
     <string name="session_drawer_output_game_mode_note">Demande le mode jeu / faible latence du téléviseur (HDMI ALLM) pour réduire la latence d\'entrée. Affiché uniquement lorsque l\'écran connecté le prend en charge.</string>
     <string name="session_drawer_output_send_to_display">Envoyer le jeu vers l\'écran</string>
+    <string name="session_drawer_output_to_display">Sortie vers l\'écran externe</string>
     <string name="session_drawer_output_send_note">Un écran est connecté. Envoyez-y le jeu — vos commandes et le menu restent sur ce téléphone. Vous pouvez le ramener ici à tout moment.</string>
     <string name="session_drawer_output_display">Affichage</string>
     <string name="session_drawer_output_glasses">Lunettes</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -860,6 +860,7 @@
     <string name="settings_general_cursor_lock_summary">उन खेलों के लिए सीधे माउस कैप्चर को सक्षम रखता है जिन्हें रॉ पॉइंटर इनपुट की आवश्यकता होती है। इसे वॉल्यूम डाउन के साथ अक्षम करें।</string>
     <string name="settings_general_xinput_toggle_title">XInput अक्षम करें</string>
     <string name="settings_general_xinput_toggle_summary">जब आप विशेष माउस और कीबोर्ड नियंत्रण चाहते हैं तो XInput हैंडलिंग बंद कर देता है।</string>
+    <string name="settings_external_display_output_summary">इस स्क्रीन को मिरर करने के बजाय गेम को कनेक्टेड बाहरी डिस्प्ले पर ले जाएँ। ग्लास हमेशा अपनी डिस्प्ले का उपयोग करते हैं।</string>
     <string name="settings_general_file_provider_summary">WinNative फ़ाइलों को Android दस्तावेज़ चयनकर्ताओं और फ़ाइल प्रबंधकों के सामने उजागर करें।</string>
     <string name="settings_general_open_browser_summary">समर्थित वेब लिंक को Wine के बजाय Android ब्राउज़र में खोलें।</string>
     <string name="settings_general_clipboard_summary">Android और Wine सत्रों के बीच कॉपी और पेस्ट करने की अनुमति दें।</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1350,6 +1350,7 @@
     <string name="session_drawer_output_game_mode_off">बंद</string>
     <string name="session_drawer_output_game_mode_note">इनपुट विलंब कम करने के लिए TV का गेम / कम-विलंबता मोड (HDMI ALLM) अनुरोध करता है। केवल तब दिखता है जब कनेक्ट किया गया डिस्प्ले इसका समर्थन करता है।</string>
     <string name="session_drawer_output_send_to_display">गेम को डिस्प्ले पर भेजें</string>
+    <string name="session_drawer_output_to_display">बाहरी डिस्प्ले पर आउटपुट</string>
     <string name="session_drawer_output_send_note">एक डिस्प्ले कनेक्ट है। गेम को उस पर भेजें — आपके नियंत्रण और मेन्यू इसी फ़ोन पर रहेंगे। आप इसे कभी भी यहाँ वापस ला सकते हैं।</string>
     <string name="session_drawer_output_display">डिस्प्ले</string>
     <string name="session_drawer_output_glasses">ग्लासेस</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1413,6 +1413,7 @@ Percorso installato:
     <string name="session_drawer_output_game_mode_off">Disattiva</string>
     <string name="session_drawer_output_game_mode_note">Richiede la modalità gioco / bassa latenza della TV (HDMI ALLM) per ridurre il ritardo di input. Mostrata solo quando il display collegato la supporta.</string>
     <string name="session_drawer_output_send_to_display">Invia il gioco al display</string>
+    <string name="session_drawer_output_to_display">Uscita su display esterno</string>
     <string name="session_drawer_output_send_note">Un display è collegato. Inviaci il gioco: i comandi e il menu restano su questo telefono. Puoi riportarlo qui in qualsiasi momento.</string>
     <string name="session_drawer_output_display">Schermo</string>
     <string name="session_drawer_output_glasses">Occhiali</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -751,6 +751,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantiene la cattura diretta del mouse abilitata per i giochi che necessitano di input raw del puntatore. Disabilitalo con Volume Giù.</string>
     <string name="settings_general_xinput_toggle_title">Disabilita XInput</string>
     <string name="settings_general_xinput_toggle_summary">Disattiva la gestione XInput quando vuoi il controllo esclusivo di mouse e tastiera.</string>
+    <string name="settings_external_display_output_summary">Sposta il gioco su un display esterno collegato invece di duplicare questo schermo. Gli occhiali usano sempre il proprio display.</string>
     <string name="settings_general_file_provider_summary">Esponi i file di WinNative ai selettori di documenti e file manager di Android.</string>
     <string name="settings_general_open_browser_summary">Apri i link web supportati nel browser Android invece che all\'interno di Wine.</string>
     <string name="settings_general_clipboard_summary">Consenti copia e incolla tra Android e le sessioni Wine.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1414,6 +1414,7 @@
     <string name="session_drawer_output_game_mode_off">끄기</string>
     <string name="session_drawer_output_game_mode_note">입력 지연을 최소화하기 위해 TV의 게임/저지연 모드(HDMI ALLM)를 요청합니다. 연결된 디스플레이가 지원할 때만 표시됩니다.</string>
     <string name="session_drawer_output_send_to_display">게임을 디스플레이로 보내기</string>
+    <string name="session_drawer_output_to_display">외부 디스플레이로 출력</string>
     <string name="session_drawer_output_send_note">디스플레이가 연결되어 있습니다. 게임을 그곳으로 보내세요 — 컨트롤과 메뉴는 이 휴대폰에 그대로 유지됩니다. 언제든지 다시 가져올 수 있습니다.</string>
     <string name="session_drawer_output_display">디스플레이</string>
     <string name="session_drawer_output_glasses">글래스</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -751,6 +751,7 @@
     <string name="settings_general_cursor_lock_summary">원시 포인터 입력이 필요한 게임에서 직접 마우스 캡처를 유지합니다. 볼륨 다운으로 비활성화할 수 있습니다.</string>
     <string name="settings_general_xinput_toggle_title">XInput 비활성화</string>
     <string name="settings_general_xinput_toggle_summary">마우스와 키보드만 사용하려는 경우 XInput 처리를 끕니다.</string>
+    <string name="settings_external_display_output_summary">이 화면을 미러링하는 대신 연결된 외부 디스플레이로 게임을 옮깁니다. 안경은 항상 자체 디스플레이를 사용합니다.</string>
     <string name="settings_general_file_provider_summary">Android 문서 선택기 및 파일 관리자에 WinNative 파일을 노출합니다.</string>
     <string name="settings_general_open_browser_summary">지원되는 웹 링크를 Wine 내부 대신 Android 브라우저에서 엽니다.</string>
     <string name="settings_general_clipboard_summary">Android와 Wine 세션 간에 복사 및 붙여넣기를 허용합니다.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -757,6 +757,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_general_cursor_lock_summary">Utrzymuje bezpośrednie przechwytywanie myszy dla gier wymagających surowego wejścia wskaźnika. Wyłącz przyciskiem Ciszej.</string>
     <string name="settings_general_xinput_toggle_title">Wyłącz XInput</string>
     <string name="settings_general_xinput_toggle_summary">Wyłącza obsługę XInput, gdy chcesz wyłącznej kontroli myszy i klawiatury.</string>
+    <string name="settings_external_display_output_summary">Przenosi grę na podłączony zewnętrzny wyświetlacz zamiast powielać ten ekran. Okulary zawsze korzystają z własnego wyświetlacza.</string>
     <string name="settings_general_file_provider_summary">Udostępnij pliki WinNative selektorom dokumentów i menedżerom plików Androida.</string>
     <string name="settings_general_open_browser_summary">Otwieraj obsługiwane linki w przeglądarce Androida zamiast w Wine.</string>
     <string name="settings_general_clipboard_summary">Umożliw kopiowanie i wklejanie między Androidem a sesjami Wine.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1419,6 +1419,7 @@ Zainstalowana ścieżka:
     <string name="session_drawer_output_game_mode_off">Wył.</string>
     <string name="session_drawer_output_game_mode_note">Żąda trybu gry / niskiego opóźnienia telewizora (HDMI ALLM), aby zminimalizować opóźnienie wejścia. Wyświetlane tylko, gdy podłączony wyświetlacz to obsługuje.</string>
     <string name="session_drawer_output_send_to_display">Wyślij grę na wyświetlacz</string>
+    <string name="session_drawer_output_to_display">Wyjście na ekran zewnętrzny</string>
     <string name="session_drawer_output_send_note">Wyświetlacz jest podłączony. Wyślij na niego grę — sterowanie i menu pozostaną na tym telefonie. Możesz w każdej chwili przywrócić ją tutaj.</string>
     <string name="session_drawer_output_display">Ekran</string>
     <string name="session_drawer_output_glasses">Okulary</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -751,6 +751,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mantem a captura direta do mouse ativada para jogos que precisam de entrada bruta do ponteiro. Desative com Volume Baixo.</string>
     <string name="settings_general_xinput_toggle_title">Desativar XInput</string>
     <string name="settings_general_xinput_toggle_summary">Desliga o tratamento XInput quando voce quer controle exclusivo de mouse e teclado.</string>
+    <string name="settings_external_display_output_summary">Move o jogo para um monitor externo conectado em vez de espelhar esta tela. Os óculos sempre usam a própria tela.</string>
     <string name="settings_general_file_provider_summary">Expor arquivos do WinNative para seletores de documentos e gerenciadores de arquivos do Android.</string>
     <string name="settings_general_open_browser_summary">Abrir links da web compativeis no navegador Android em vez de dentro do Wine.</string>
     <string name="settings_general_clipboard_summary">Permitir copiar e colar entre o Android e sessoes do Wine.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1413,6 +1413,7 @@ Caminho instalado:
     <string name="session_drawer_output_game_mode_off">Desligado</string>
     <string name="session_drawer_output_game_mode_note">Solicita o modo jogo / baixa latência da TV (HDMI ALLM) para minimizar o atraso de entrada. Exibido apenas quando a tela conectada é compatível.</string>
     <string name="session_drawer_output_send_to_display">Enviar jogo para a tela</string>
+    <string name="session_drawer_output_to_display">Saída para tela externa</string>
     <string name="session_drawer_output_send_note">Uma tela está conectada. Envie o jogo para ela — seus controles e o menu permanecem neste telefone. Você pode trazê-lo de volta aqui a qualquer momento.</string>
     <string name="session_drawer_output_display">Tela</string>
     <string name="session_drawer_output_glasses">Óculos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -751,6 +751,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_general_cursor_lock_summary">Mentine captura directa a mouse-ului activata pentru jocuri care necesita intrare bruta de cursor. Dezactiveaza cu Volum Jos.</string>
     <string name="settings_general_xinput_toggle_title">Dezactiveaza XInput</string>
     <string name="settings_general_xinput_toggle_summary">Opreste gestionarea XInput cand doresti control exclusiv cu mouse-ul si tastatura.</string>
+    <string name="settings_external_display_output_summary">Mută jocul pe un afișaj extern conectat în loc să oglindească acest ecran. Ochelarii folosesc întotdeauna propriul afișaj.</string>
     <string name="settings_general_file_provider_summary">Expune fisierele WinNative catre selectoarele de documente si managerii de fisiere Android.</string>
     <string name="settings_general_open_browser_summary">Deschide link-urile web compatibile in browserul Android in loc de Wine.</string>
     <string name="settings_general_clipboard_summary">Permite copierea si lipirea intre Android si sesiunile Wine.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1413,6 +1413,7 @@ Cale instalata:
     <string name="session_drawer_output_game_mode_off">Oprit</string>
     <string name="session_drawer_output_game_mode_note">Solicită modul joc / latență redusă al televizorului (HDMI ALLM) pentru a minimiza întârzierea la intrare. Afișat doar când ecranul conectat îl acceptă.</string>
     <string name="session_drawer_output_send_to_display">Trimite jocul la ecran</string>
+    <string name="session_drawer_output_to_display">Ieșire pe afișaj extern</string>
     <string name="session_drawer_output_send_note">Un ecran este conectat. Trimite-i jocul — comenzile și meniul rămân pe acest telefon. Îl poți aduce înapoi aici oricând.</string>
     <string name="session_drawer_output_display">Ecran</string>
     <string name="session_drawer_output_glasses">Ochelari</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -819,6 +819,7 @@
     <string name="settings_general_cursor_lock_summary">Сохраняет прямой захват мыши включенным для игр, которым требуется необработанный ввод указателя. Отключите его с помощью Volume Down.</string>
     <string name="settings_general_xinput_toggle_title">Отключить XInput</string>
     <string name="settings_general_xinput_toggle_summary">Отключает обработку XInput, если вам требуется единоличное управление мышью и клавиатурой.</string>
+    <string name="settings_external_display_output_summary">Переносит игру на подключённый внешний дисплей вместо зеркалирования этого экрана. Очки всегда используют собственный дисплей.</string>
     <string name="settings_general_file_provider_summary">Предоставляйте файлы WinNative средствам выбора документов и файловым менеджерам Android.</string>
     <string name="settings_general_open_browser_summary">Открывайте поддерживаемые веб-ссылки в браузере Android, а не внутри Wine.</string>
     <string name="settings_general_clipboard_summary">Разрешить копирование и вставку между сеансами Android и Wine.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1319,6 +1319,7 @@
     <string name="session_drawer_output_game_mode_off">Выкл.</string>
     <string name="session_drawer_output_game_mode_note">Запрашивает игровой режим / низкую задержку телевизора (HDMI ALLM) для уменьшения задержки ввода. Показывается только если подключённый дисплей это поддерживает.</string>
     <string name="session_drawer_output_send_to_display">Отправить игру на дисплей</string>
+    <string name="session_drawer_output_to_display">Вывод на внешний дисплей</string>
     <string name="session_drawer_output_send_note">Дисплей подключён. Отправьте игру на него — управление и меню останутся на этом телефоне. Вы можете вернуть её сюда в любой момент.</string>
     <string name="session_drawer_output_display">Экран</string>
     <string name="session_drawer_output_glasses">Очки</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1419,6 +1419,7 @@
     <string name="session_drawer_output_game_mode_off">Вимк.</string>
     <string name="session_drawer_output_game_mode_note">Запитує ігровий режим / низьку затримку телевізора (HDMI ALLM), щоб зменшити затримку вводу. Показується лише коли підключений дисплей це підтримує.</string>
     <string name="session_drawer_output_send_to_display">Надіслати гру на дисплей</string>
+    <string name="session_drawer_output_to_display">Виведення на зовнішній дисплей</string>
     <string name="session_drawer_output_send_note">Дисплей підключено. Надішліть гру на нього — керування та меню залишаться на цьому телефоні. Ви можете будь-коли повернути її сюди.</string>
     <string name="session_drawer_output_display">Екран</string>
     <string name="session_drawer_output_glasses">Окуляри</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -757,6 +757,7 @@
     <string name="settings_general_cursor_lock_summary">Підтримує пряме захоплення миші для ігор, що потребують необробленого введення вказівника. Вимкніть кнопкою гучності вниз.</string>
     <string name="settings_general_xinput_toggle_title">Вимкнути XInput</string>
     <string name="settings_general_xinput_toggle_summary">Вимикає обробку XInput, коли потрібне ексклюзивне керування мишею та клавіатурою.</string>
+    <string name="settings_external_display_output_summary">Переносить гру на під\'єднаний зовнішній дисплей замість дублювання цього екрана. Окуляри завжди використовують власний дисплей.</string>
     <string name="settings_general_file_provider_summary">Надати доступ до файлів WinNative для засобів вибору документів та файлових менеджерів Android.</string>
     <string name="settings_general_open_browser_summary">Відкривати підтримувані веб-посилання у браузері Android замість Wine.</string>
     <string name="settings_general_clipboard_summary">Дозволити копіювання та вставку між Android та сесіями Wine.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -751,6 +751,7 @@
     <string name="settings_general_cursor_lock_summary">为需要原始指针输入的游戏保持直接鼠标捕获。按音量减键禁用。</string>
     <string name="settings_general_xinput_toggle_title">禁用 XInput</string>
     <string name="settings_general_xinput_toggle_summary">在需要独占鼠标和键盘控制时关闭 XInput 处理。</string>
+    <string name="settings_external_display_output_summary">将游戏移到已连接的外部显示器，而不是镜像此屏幕。眼镜始终使用自己的显示屏。</string>
     <string name="settings_general_file_provider_summary">向 Android 文档选择器和文件管理器公开 WinNative 文件。</string>
     <string name="settings_general_open_browser_summary">在 Android 浏览器中打开支持的网页链接，而非在 Wine 内部打开。</string>
     <string name="settings_general_clipboard_summary">允许在 Android 和 Wine 会话之间复制和粘贴。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1413,6 +1413,7 @@
     <string name="session_drawer_output_game_mode_off">关</string>
     <string name="session_drawer_output_game_mode_note">请求电视的游戏/低延迟模式（HDMI ALLM）以尽量减少输入延迟。仅在已连接的显示器支持时显示。</string>
     <string name="session_drawer_output_send_to_display">将游戏发送到显示器</string>
+    <string name="session_drawer_output_to_display">输出到外部显示器</string>
     <string name="session_drawer_output_send_note">已连接显示器。将游戏发送到该显示器——你的控制和菜单仍保留在本手机上。你可以随时将其取回这里。</string>
     <string name="session_drawer_output_display">显示</string>
     <string name="session_drawer_output_glasses">眼镜</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -751,6 +751,7 @@
     <string name="settings_general_cursor_lock_summary">為需要原始指標輸入的遊戲保持直接滑鼠擷取。使用音量降低鍵停用。</string>
     <string name="settings_general_xinput_toggle_title">停用 XInput</string>
     <string name="settings_general_xinput_toggle_summary">當您想要獨佔滑鼠和鍵盤控制時，關閉 XInput 處理。</string>
+    <string name="settings_external_display_output_summary">將遊戲移至已連接的外部顯示器，而非鏡像此螢幕。眼鏡一律使用自己的顯示器。</string>
     <string name="settings_general_file_provider_summary">將 WinNative 檔案公開給 Android 文件選取器和檔案管理員。</string>
     <string name="settings_general_open_browser_summary">在 Android 瀏覽器中開啟支援的網頁連結，而非在 Wine 內開啟。</string>
     <string name="settings_general_clipboard_summary">允許在 Android 和 Wine 工作階段之間複製和貼上。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1413,6 +1413,7 @@
     <string name="session_drawer_output_game_mode_off">關</string>
     <string name="session_drawer_output_game_mode_note">請求電視的遊戲/低延遲模式（HDMI ALLM）以盡量減少輸入延遲。僅在已連接的顯示器支援時顯示。</string>
     <string name="session_drawer_output_send_to_display">將遊戲傳送到顯示器</string>
+    <string name="session_drawer_output_to_display">輸出到外部顯示器</string>
     <string name="session_drawer_output_send_note">已連接顯示器。將遊戲傳送到該顯示器——你的控制與選單仍保留在本手機上。你可以隨時將其取回這裡。</string>
     <string name="session_drawer_output_display">顯示</string>
     <string name="session_drawer_output_glasses">眼鏡</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -822,6 +822,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_output_game_mode_off">Off</string>
     <string name="session_drawer_output_game_mode_note">Requests the TV\'s low‑latency / game mode (HDMI ALLM) to minimize input lag. Shown only when the connected display supports it.</string>
     <string name="session_drawer_output_send_to_display">Send game to display</string>
+    <string name="session_drawer_output_to_display">Output to External Display</string>
     <string name="session_drawer_output_send_note">A display is connected. Send the game to it — your controls and menu stay on this phone. You can return it here any time.</string>
     <string name="session_drawer_output_display">Display</string>
     <string name="session_drawer_output_glasses">Glasses</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1035,6 +1035,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_general_cursor_lock_summary">Keeps direct mouse capture enabled for games that need raw pointer input. Disable it with Volume Down.</string>
     <string name="settings_general_xinput_toggle_title">Disable XInput</string>
     <string name="settings_general_xinput_toggle_summary">Turns off XInput handling when you want exclusive mouse and keyboard control.</string>
+    <string name="settings_external_display_output_summary">Move the game to a connected external display instead of mirroring this screen. Glasses always use their own display.</string>
     <string name="settings_general_file_provider_summary">Expose WinNative files to Android document pickers and file managers.</string>
     <string name="settings_general_open_browser_summary">Open supported web links in the Android browser instead of inside Wine.</string>
     <string name="settings_general_clipboard_summary">Allow copy and paste between Android and Wine sessions.</string>

--- a/app/src/main/runtime/display/ExternalDisplayController.java
+++ b/app/src/main/runtime/display/ExternalDisplayController.java
@@ -691,6 +691,13 @@ public final class ExternalDisplayController {
         return viture.isConnected();
     }
 
+    // Viture sink check usable before a swap: USB control up, or the available display's EDID says VITURE.
+    public boolean isVitureSinkAvailable() {
+        if (viture.isConnected()) return true;
+        String name = describeDisplay(findExternalDisplay());
+        return !name.isEmpty() && name.toUpperCase(java.util.Locale.ROOT).contains("VITURE");
+    }
+
     public String getVitureName() {
         return viture.modelName();
     }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4018,8 +4018,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     externalDisplayController.isGameModeEnabled(),
                     externalDisplayController.isPanelScaling(),
                     externalDisplayController.getPanelNativeSummary(),
-                    externalDisplayController.hasExternalDisplay(),
-                    externalDisplayController.isVitureSinkAvailable());
+                    externalDisplayController.hasExternalDisplay());
             if (externalDisplayController.isVitureConnected()) {
                 state = XServerDrawerMenuKt.withVitureState(
                         state,
@@ -4298,22 +4297,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                                     R.string.display_output_swapped_toast,
                                     android.widget.Toast.LENGTH_SHORT).show();
                         }
-                    }
-
-                    @Override
-                    public void onOutputModeChanged(boolean enabled) {
-                        if (externalDisplayController == null) return;
-                        // Viture glasses always output regardless of the toggle.
-                        if (externalDisplayController.isVitureSinkAvailable()) return;
-                        if (preferences != null) {
-                            preferences.edit().putBoolean("external_display_output", enabled).apply();
-                        }
-                        if (enabled) {
-                            externalDisplayController.enterSwap();
-                        } else {
-                            externalDisplayController.exitSwap();
-                        }
-                        renderDrawerMenu();
                     }
 
                     @Override

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4300,6 +4300,20 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     }
 
                     @Override
+                    public void onOutputModeChanged(boolean enabled) {
+                        if (externalDisplayController == null) return;
+                        if (preferences != null) {
+                            preferences.edit().putBoolean("external_display_output", enabled).apply();
+                        }
+                        if (enabled) {
+                            externalDisplayController.enterSwap();
+                        } else {
+                            externalDisplayController.exitSwap();
+                        }
+                        renderDrawerMenu();
+                    }
+
+                    @Override
                     public void onOutputCastClick() {
                         launchWirelessDisplayPicker();
                     }
@@ -6962,6 +6976,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                         runOnUiThread(() -> {
                             if (isFinishing() || isDestroyed() || externalDisplayController == null
                                     || externalDisplayController.isSwapActive()) return;
+                            boolean outputEnabled = preferences != null
+                                    && preferences.getBoolean("external_display_output", false);
+                            if (!externalDisplayController.isVitureSinkAvailable() && !outputEnabled) return;
                             externalDisplayController.enterSwap();
                             renderDrawerMenu();
                             android.widget.Toast.makeText(XServerDisplayActivity.this,

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4018,7 +4018,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     externalDisplayController.isGameModeEnabled(),
                     externalDisplayController.isPanelScaling(),
                     externalDisplayController.getPanelNativeSummary(),
-                    externalDisplayController.hasExternalDisplay());
+                    externalDisplayController.hasExternalDisplay(),
+                    externalDisplayController.isVitureSinkAvailable());
             if (externalDisplayController.isVitureConnected()) {
                 state = XServerDrawerMenuKt.withVitureState(
                         state,
@@ -4302,6 +4303,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onOutputModeChanged(boolean enabled) {
                         if (externalDisplayController == null) return;
+                        // Viture glasses always output regardless of the toggle.
+                        if (externalDisplayController.isVitureSinkAvailable()) return;
                         if (preferences != null) {
                             preferences.edit().putBoolean("external_display_output", enabled).apply();
                         }
@@ -6974,16 +6977,19 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     public void onExternalDisplayConnected(android.view.Display display) {
                         // Automatic swap: the game shows only on the external display, controls stay on the phone.
                         runOnUiThread(() -> {
-                            if (isFinishing() || isDestroyed() || externalDisplayController == null
-                                    || externalDisplayController.isSwapActive()) return;
+                            if (isFinishing() || isDestroyed() || externalDisplayController == null) return;
                             boolean outputEnabled = preferences != null
                                     && preferences.getBoolean("external_display_output", false);
-                            if (!externalDisplayController.isVitureSinkAvailable() && !outputEnabled) return;
-                            externalDisplayController.enterSwap();
+                            boolean swap = !externalDisplayController.isSwapActive()
+                                    && (externalDisplayController.isVitureSinkAvailable() || outputEnabled);
+                            if (swap) {
+                                externalDisplayController.enterSwap();
+                                android.widget.Toast.makeText(XServerDisplayActivity.this,
+                                        R.string.display_output_swapped_toast,
+                                        android.widget.Toast.LENGTH_SHORT).show();
+                            }
+                            // Re-render even when not swapping so an open Output pane shows the toggle.
                             renderDrawerMenu();
-                            android.widget.Toast.makeText(XServerDisplayActivity.this,
-                                    R.string.display_output_swapped_toast,
-                                    android.widget.Toast.LENGTH_SHORT).show();
                         });
                     }
 

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -617,6 +617,8 @@ interface XServerDrawerActionListener {
 
     fun onOutputSwapToDisplay()
 
+    fun onOutputModeChanged(enabled: Boolean)
+
     fun onOutputCastClick()
 
     fun onSGSREnabledChanged(enabled: Boolean)
@@ -3063,11 +3065,13 @@ private fun OutputActiveControls(
         OutputGlassesCard(state = state, listener = listener, paneScale = paneScale)
     }
 
-    OutputPaneButton(
-        label = stringResource(R.string.session_drawer_output_return_to_phone),
-        paneScale = paneScale,
-        onClick = listener::onOutputReturnToPhone,
-    )
+    if (!state.outputVitureConnected) {
+        DrawerBooleanRow(
+            title = stringResource(R.string.session_drawer_output_to_display),
+            checked = state.outputSwapActive,
+            onCheckedChange = { listener.onOutputModeChanged(it) },
+        )
+    }
 }
 
 @Composable
@@ -3216,11 +3220,13 @@ private fun OutputSendToDisplay(
     paneScale: Float,
 ) {
     OutputDeviceHeader(state = state, paneScale = paneScale)
-    OutputPaneButton(
-        label = stringResource(R.string.session_drawer_output_send_to_display),
-        paneScale = paneScale,
-        onClick = listener::onOutputSwapToDisplay,
-    )
+    if (!state.outputVitureConnected) {
+        DrawerBooleanRow(
+            title = stringResource(R.string.session_drawer_output_to_display),
+            checked = state.outputSwapActive,
+            onCheckedChange = { listener.onOutputModeChanged(it) },
+        )
+    }
     Text(
         text = stringResource(R.string.session_drawer_output_send_note),
         color = DrawerTextSecondary,

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -400,6 +400,8 @@ data class XServerDrawerState(
     val outputDisplayAvailable: Boolean = false,
     // Viture XR glasses controls (USB), present only when Viture glasses are connected.
     val outputVitureConnected: Boolean = false,
+    // Viture sink present via USB control or EDID name; the output toggle is hidden for it.
+    val outputVitureSink: Boolean = false,
     val outputVitureName: String = "",
     val outputVitureSupportsBrightness: Boolean = false,
     val outputVitureBrightness: Int = 0,
@@ -1031,6 +1033,7 @@ fun withOutputState(
     panelScaling: Boolean,
     panelNative: String,
     displayAvailable: Boolean,
+    vitureSink: Boolean,
 ): XServerDrawerState {
     val outputItem =
         XServerDrawerItem(
@@ -1053,6 +1056,7 @@ fun withOutputState(
         outputPanelScaling = panelScaling,
         outputPanelNative = panelNative,
         outputDisplayAvailable = displayAvailable,
+        outputVitureSink = vitureSink,
     )
 }
 
@@ -3065,7 +3069,7 @@ private fun OutputActiveControls(
         OutputGlassesCard(state = state, listener = listener, paneScale = paneScale)
     }
 
-    if (!state.outputVitureConnected) {
+    if (!state.outputVitureSink) {
         DrawerBooleanRow(
             title = stringResource(R.string.session_drawer_output_to_display),
             checked = state.outputSwapActive,
@@ -3220,7 +3224,7 @@ private fun OutputSendToDisplay(
     paneScale: Float,
 ) {
     OutputDeviceHeader(state = state, paneScale = paneScale)
-    if (!state.outputVitureConnected) {
+    if (!state.outputVitureSink) {
         DrawerBooleanRow(
             title = stringResource(R.string.session_drawer_output_to_display),
             checked = state.outputSwapActive,

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -400,8 +400,6 @@ data class XServerDrawerState(
     val outputDisplayAvailable: Boolean = false,
     // Viture XR glasses controls (USB), present only when Viture glasses are connected.
     val outputVitureConnected: Boolean = false,
-    // Viture sink present via USB control or EDID name; the output toggle is hidden for it.
-    val outputVitureSink: Boolean = false,
     val outputVitureName: String = "",
     val outputVitureSupportsBrightness: Boolean = false,
     val outputVitureBrightness: Int = 0,
@@ -618,8 +616,6 @@ interface XServerDrawerActionListener {
     fun onOutputReturnToPhone()
 
     fun onOutputSwapToDisplay()
-
-    fun onOutputModeChanged(enabled: Boolean)
 
     fun onOutputCastClick()
 
@@ -1033,7 +1029,6 @@ fun withOutputState(
     panelScaling: Boolean,
     panelNative: String,
     displayAvailable: Boolean,
-    vitureSink: Boolean,
 ): XServerDrawerState {
     val outputItem =
         XServerDrawerItem(
@@ -1056,7 +1051,6 @@ fun withOutputState(
         outputPanelScaling = panelScaling,
         outputPanelNative = panelNative,
         outputDisplayAvailable = displayAvailable,
-        outputVitureSink = vitureSink,
     )
 }
 
@@ -3069,13 +3063,11 @@ private fun OutputActiveControls(
         OutputGlassesCard(state = state, listener = listener, paneScale = paneScale)
     }
 
-    if (!state.outputVitureSink) {
-        DrawerBooleanRow(
-            title = stringResource(R.string.session_drawer_output_to_display),
-            checked = state.outputSwapActive,
-            onCheckedChange = { listener.onOutputModeChanged(it) },
-        )
-    }
+    OutputPaneButton(
+        label = stringResource(R.string.session_drawer_output_return_to_phone),
+        paneScale = paneScale,
+        onClick = listener::onOutputReturnToPhone,
+    )
 }
 
 @Composable
@@ -3224,13 +3216,11 @@ private fun OutputSendToDisplay(
     paneScale: Float,
 ) {
     OutputDeviceHeader(state = state, paneScale = paneScale)
-    if (!state.outputVitureSink) {
-        DrawerBooleanRow(
-            title = stringResource(R.string.session_drawer_output_to_display),
-            checked = state.outputSwapActive,
-            onCheckedChange = { listener.onOutputModeChanged(it) },
-        )
-    }
+    OutputPaneButton(
+        label = stringResource(R.string.session_drawer_output_send_to_display),
+        paneScale = paneScale,
+        onClick = listener::onOutputSwapToDisplay,
+    )
     Text(
         text = stringResource(R.string.session_drawer_output_send_note),
         color = DrawerTextSecondary,


### PR DESCRIPTION
…re exempt)

Some devices (Ayn, Odin) expose a phantom presentation display, so the auto-swap moved the game onto a non-existent external screen and the panel went black as if a monitor were attached.

Add an 'Output to External Display' toggle in the session Output pane, backed by the external_display_output preference (default off). When off, the game mirrors normally and is never auto-moved to a detected display; when on, it moves to the output device as before. The auto-swap on display connect now only fires when the toggle is on. Viture glasses are exempt: when their sink is present (USB control or EDID name) the game always outputs to them regardless of the toggle, and the toggle is hidden.

Adds session_drawer_output_to_display in all locales.