### PR TITLE
Fix: FPS cap by aligning frame pacing to the vsync grid

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -679,7 +679,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         Runnable applyRefresh = () -> {
             if (isFinishing() || isDestroyed()) return;
 
-            RefreshRateUtils.applyPreferredRefreshRate(this, getRefreshRateOverride(), runtimeFpsLimit);
+            float hz = RefreshRateUtils.applyPreferredRefreshRate(this, getRefreshRateOverride(), runtimeFpsLimit);
+            if (xServer != null) {
+                xServer.getFramePaceClock().setDisplayRefreshHz(hz);
+                xServer.getFramePaceClock().setCapActive(runtimeFpsLimit > 0);
+            }
         };
 
         if (Looper.myLooper() == Looper.getMainLooper()) {
@@ -726,6 +730,11 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     private void handleDisplayCapabilitiesChanged() {
         if (isFinishing() || isDestroyed()) return;
+
+        // Keep the pacer's refresh rate current across seamless mode switches that don't cross the limit.
+        if (xServer != null) {
+            xServer.getFramePaceClock().setDisplayRefreshHz(RefreshRateUtils.getActiveRefreshRate(this));
+        }
 
         int maxRate = RefreshRateUtils.getMaxSupportedRefreshRate(this);
         boolean maxChanged = maxRate != lastKnownMaxRefreshRate;

--- a/app/src/main/runtime/display/xserver/FramePaceClock.java
+++ b/app/src/main/runtime/display/xserver/FramePaceClock.java
@@ -7,19 +7,17 @@ import android.view.Choreographer;
 /**
  * Tracks the display's vsync phase and refresh rate so the FPS-cap pacer
  * ({@link XClient#enforceAbsoluteFramerate()}) can align frame release to the live vsync grid
- * instead of a free-running wall clock. This removes the beat between the software cap timer and
- * the FIFO present clock that caused microstutter at low caps (e.g. 30 fps on 90/120 Hz panels).
+ * instead of a free-running wall clock, removing the beat that caused microstutter at low caps.
  *
- * <p>Shared fields are written on the UI thread (Choreographer callback + activity) and read on
- * the X-dispatch thread; they are {@code volatile} and never read-modify-written across each
- * other, so the pacer's hot path needs no lock. The Choreographer callback only reposts while a
- * cap is active, so there is no per-vsync UI wakeup when the cap is off.
+ * <p>Fields are written on the UI thread and read on the X-dispatch thread; they are
+ * {@code volatile} and never read-modify-written together, so the pacer needs no lock. The
+ * Choreographer callback only reposts while a cap is active, so the cap-off path has no UI wakeup.
  */
 public class FramePaceClock {
     private volatile long lastVsyncNanos = 0;
     private volatile float displayRefreshHz = 0f;
     private volatile boolean capActive = false;
-    // Touched only on the UI thread (startTracking body + onVsync), so it needs no synchronization.
+    // UI-thread only.
     private boolean tracking = false;
 
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
@@ -30,7 +28,7 @@ public class FramePaceClock {
         return lastVsyncNanos;
     }
 
-    /** Effective display refresh rate in Hz (0 if unknown). */
+    /** Display refresh rate in Hz (0 if unknown). */
     public float getDisplayRefreshHz() {
         return displayRefreshHz;
     }
@@ -39,7 +37,7 @@ public class FramePaceClock {
         displayRefreshHz = hz > 0f ? hz : 0f;
     }
 
-    /** Arms vsync tracking while a cap is set; disarms it (stopping UI wakeups) when the cap clears. */
+    /** Arms vsync tracking while a cap is set; disarms it when the cap clears. */
     public void setCapActive(boolean on) {
         capActive = on;
         if (on) startTracking();

--- a/app/src/main/runtime/display/xserver/FramePaceClock.java
+++ b/app/src/main/runtime/display/xserver/FramePaceClock.java
@@ -1,0 +1,64 @@
+package com.winlator.cmod.runtime.display.xserver;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Choreographer;
+
+/**
+ * Tracks the display's vsync phase and refresh rate so the FPS-cap pacer
+ * ({@link XClient#enforceAbsoluteFramerate()}) can align frame release to the live vsync grid
+ * instead of a free-running wall clock. This removes the beat between the software cap timer and
+ * the FIFO present clock that caused microstutter at low caps (e.g. 30 fps on 90/120 Hz panels).
+ *
+ * <p>Shared fields are written on the UI thread (Choreographer callback + activity) and read on
+ * the X-dispatch thread; they are {@code volatile} and never read-modify-written across each
+ * other, so the pacer's hot path needs no lock. The Choreographer callback only reposts while a
+ * cap is active, so there is no per-vsync UI wakeup when the cap is off.
+ */
+public class FramePaceClock {
+    private volatile long lastVsyncNanos = 0;
+    private volatile float displayRefreshHz = 0f;
+    private volatile boolean capActive = false;
+    // Touched only on the UI thread (startTracking body + onVsync), so it needs no synchronization.
+    private boolean tracking = false;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final Choreographer.FrameCallback frameCallback = this::onVsync;
+
+    /** Latest vsync timestamp in the {@link System#nanoTime()} timebase (0 until the first frame). */
+    public long getLastVsyncNanos() {
+        return lastVsyncNanos;
+    }
+
+    /** Effective display refresh rate in Hz (0 if unknown). */
+    public float getDisplayRefreshHz() {
+        return displayRefreshHz;
+    }
+
+    public void setDisplayRefreshHz(float hz) {
+        displayRefreshHz = hz > 0f ? hz : 0f;
+    }
+
+    /** Arms vsync tracking while a cap is set; disarms it (stopping UI wakeups) when the cap clears. */
+    public void setCapActive(boolean on) {
+        capActive = on;
+        if (on) startTracking();
+    }
+
+    private void startTracking() {
+        mainHandler.post(() -> {
+            if (tracking) return;
+            tracking = true;
+            Choreographer.getInstance().postFrameCallback(frameCallback);
+        });
+    }
+
+    private void onVsync(long frameTimeNanos) {
+        lastVsyncNanos = frameTimeNanos;
+        if (capActive) {
+            Choreographer.getInstance().postFrameCallback(frameCallback);
+        } else {
+            tracking = false;
+        }
+    }
+}

--- a/app/src/main/runtime/display/xserver/XClient.java
+++ b/app/src/main/runtime/display/xserver/XClient.java
@@ -4,6 +4,7 @@ import androidx.collection.ArrayMap;
 import com.winlator.cmod.runtime.display.connector.XInputStream;
 import com.winlator.cmod.runtime.display.connector.XOutputStream;
 import com.winlator.cmod.runtime.display.xserver.events.Event;
+import com.winlator.cmod.shared.android.RefreshRateUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.locks.LockSupport;
@@ -166,6 +167,42 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
       return;
     }
 
+    FramePaceClock clock = xServer.getFramePaceClock();
+    float hz = clock.getDisplayRefreshHz();
+    long anchor = clock.getLastVsyncNanos();
+
+    // No vsync sample yet, or panel rate isn't an integer multiple of the target: free-run.
+    if (hz <= 0f || anchor == 0 || !RefreshRateUtils.isFrameCadenceCompatible(hz, targetFps)) {
+      enforceFreeRunning(targetFps);
+      return;
+    }
+
+    long period = (long) (1_000_000_000.0 / hz);
+    int n = Math.round(hz / targetFps);
+    long stride = (long) n * period;
+    long now = System.nanoTime();
+
+    // First frame or >100ms late: snap onto the live vsync grid.
+    if (nextFrameTimeNanos == 0 || now > nextFrameTimeNanos + 100_000_000L) {
+      long k = Math.floorDiv(now - anchor, period) + 1;
+      nextFrameTimeNanos = anchor + k * period;
+    }
+
+    long remaining = nextFrameTimeNanos - now;
+    while (remaining > 0) {
+      LockSupport.parkNanos(remaining);
+      if (Thread.interrupted()) break;
+      remaining = nextFrameTimeNanos - System.nanoTime();
+    }
+
+    // Advance N vsync periods, then re-snap to the freshest phase (mean interval unchanged).
+    long target = nextFrameTimeNanos + stride;
+    long anchorNow = clock.getLastVsyncNanos();
+    long steps = Math.round((double) (target - anchorNow) / period);
+    nextFrameTimeNanos = anchorNow + steps * period;
+  }
+
+  private void enforceFreeRunning(int targetFps) {
     long targetFrameTime = 1_000_000_000L / targetFps;
     long now = System.nanoTime();
 

--- a/app/src/main/runtime/display/xserver/XServer.java
+++ b/app/src/main/runtime/display/xserver/XServer.java
@@ -50,6 +50,7 @@ public class XServer {
   public final CursorLocker cursorLocker;
   private SHMSegmentManager shmSegmentManager;
   private VulkanRenderer renderer;
+  private final FramePaceClock framePaceClock = new FramePaceClock();
   private WinHandler winHandler;
   private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
   private boolean relativeMouseMovement = false;
@@ -114,6 +115,10 @@ public class XServer {
 
   public VulkanRenderer getRenderer() {
     return renderer;
+  }
+
+  public FramePaceClock getFramePaceClock() {
+    return framePaceClock;
   }
 
   public GrabManager getGrabManager() {

--- a/app/src/main/shared/android/RefreshRateUtils.java
+++ b/app/src/main/shared/android/RefreshRateUtils.java
@@ -221,7 +221,7 @@ public final class RefreshRateUtils {
     return fpsLimit;
   }
 
-  private static boolean isFrameCadenceCompatible(float refreshRate, int fpsLimit) {
+  public static boolean isFrameCadenceCompatible(float refreshRate, int fpsLimit) {
     if (refreshRate <= 0f || fpsLimit <= 0 || refreshRate < fpsLimit) {
       return false;
     }
@@ -285,16 +285,17 @@ public final class RefreshRateUtils {
     observer.removeOnWindowFocusChangeListener(listener);
   }
 
-  public static void applyPreferredRefreshRate(Activity activity) {
-    applyPreferredRefreshRate(activity, getSavedGlobalRefreshRateOverride(activity));
+  public static float applyPreferredRefreshRate(Activity activity) {
+    return applyPreferredRefreshRate(activity, getSavedGlobalRefreshRateOverride(activity));
   }
 
-  public static void applyPreferredRefreshRate(Activity activity, int requestedHz) {
-    applyPreferredRefreshRate(activity, requestedHz, 0);
+  public static float applyPreferredRefreshRate(Activity activity, int requestedHz) {
+    return applyPreferredRefreshRate(activity, requestedHz, 0);
   }
 
-  public static void applyPreferredRefreshRate(Activity activity, int requestedHz, int fpsLimit) {
-    if (activity.isFinishing() || activity.isDestroyed()) return;
+  /** Applies the preferred display mode and returns the effective refresh rate in Hz (0 on early-out). */
+  public static float applyPreferredRefreshRate(Activity activity, int requestedHz, int fpsLimit) {
+    if (activity.isFinishing() || activity.isDestroyed()) return 0f;
 
     int effectiveRequestedHz = resolveFramePacedRefreshRate(activity, requestedHz, fpsLimit);
     WindowManager.LayoutParams params = activity.getWindow().getAttributes();
@@ -316,5 +317,14 @@ public final class RefreshRateUtils {
             + modeId
             + " refreshRate="
             + refreshRate);
+    return refreshRate;
+  }
+
+  /** Current active refresh rate of the activity's display in Hz (0 if unavailable). */
+  public static float getActiveRefreshRate(Activity activity) {
+    Display display = getDisplay(activity);
+    if (display == null) return 0f;
+    Display.Mode mode = display.getMode();
+    return mode != null ? mode.getRefreshRate() : 0f;
   }
 }


### PR DESCRIPTION
Snap the absolute-framerate pacer onto the display's live vsync grid instead of a free-running wall clock, so a cap becomes an exact integer vsync divider (N = round(refreshHz/targetFps)). This removes the beat between the software cap timer and the FIFO present clock that produced microstutter at low caps on high-refresh panels. Falls back to the previous free-running pacer when the panel rate is not an integer multiple of the target; parkNanos is retained (no busy-spin). Mean frame interval is unchanged, so guest timing is unaffected.