### PR TITLE
HUD: add C.TMP - CPU-temperature element and rename battery temp to B.TMP

### DIFF
--- a/app/src/main/res/layout/frame_rating.xml
+++ b/app/src/main/res/layout/frame_rating.xml
@@ -66,6 +66,29 @@
     <TextView
         android:textSize="10sp"
         android:textStyle="bold"
+        android:textColor="#9e9e9e"
+        android:id="@+id/TVCpuTemp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:text="C.TMP"
+        android:shadowColor="#ff000000"
+        android:shadowDx="1"
+        android:shadowDy="1"
+        android:shadowRadius="1"
+        android:fontFamily="monospace"/>
+    <TextView
+        android:textSize="10sp"
+        android:textStyle="bold"
+        android:textColor="#616161"
+        android:id="@+id/Sep6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:text=" | "/>
+    <TextView
+        android:textSize="10sp"
+        android:textStyle="bold"
         android:textColor="#90caf9"
         android:id="@+id/TVRam"
         android:layout_width="wrap_content"
@@ -112,7 +135,7 @@
         android:id="@+id/TVTemp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="TMP"
+        android:text="B.TMP"
         android:shadowColor="#ff000000"
         android:shadowDx="1"
         android:shadowDy="1"

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -588,6 +588,7 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Bat.</string>
     <string name="session_drawer_hud_element_graph">Graf</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Vil du afslutte denne proces?</string>
@@ -1512,7 +1513,7 @@ Installeret sti:
     <string name="session_drawer_hud_background">Baggrund</string>
     <string name="session_drawer_hud_background_alpha">Baggrundsalfa</string>
     <string name="session_drawer_hud_background_alpha_input_title">Indstil baggrundsalfa</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Tilpas størrelse</string>
     <string name="session_task_bring_to_front">Flyt til forgrunden</string>
     <string name="session_task_custom_value">Brugerdefineret værdi</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -588,6 +588,7 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Akku</string>
     <string name="session_drawer_hud_element_graph">Graph</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Möchtest du diesen Prozess beenden?</string>
@@ -1512,7 +1513,7 @@ Installierter Pfad:
     <string name="session_drawer_hud_background">Hintergrund</string>
     <string name="session_drawer_hud_background_alpha">Hintergrund-Alpha</string>
     <string name="session_drawer_hud_background_alpha_input_title">Hintergrund-Alpha festlegen</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Größe anpassen</string>
     <string name="session_task_bring_to_front">In den Vordergrund</string>
     <string name="session_task_custom_value">Benutzerdefinierter Wert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -588,6 +588,7 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Bat.</string>
     <string name="session_drawer_hud_element_graph">Gráf.</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">¿Deseas finalizar este proceso?</string>
@@ -1512,7 +1513,7 @@ Ruta instalada:
     <string name="session_drawer_hud_background">Fondo</string>
     <string name="session_drawer_hud_background_alpha">Alfa del fondo</string>
     <string name="session_drawer_hud_background_alpha_input_title">Establecer alfa del fondo</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Ajustar tamaño</string>
     <string name="session_task_bring_to_front">Traer al frente</string>
     <string name="session_task_custom_value">Valor personalizado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -588,6 +588,7 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Batt.</string>
     <string name="session_drawer_hud_element_graph">Graphe</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Voulez-vous terminer ce processus ?</string>
@@ -1512,7 +1513,7 @@ Chemin installé :
     <string name="session_drawer_hud_background">Arrière-plan</string>
     <string name="session_drawer_hud_background_alpha">Alpha de l\'arrière-plan</string>
     <string name="session_drawer_hud_background_alpha_input_title">Définir l\'alpha de l\'arrière-plan</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Ajuster la taille</string>
     <string name="session_task_bring_to_front">Mettre au premier plan</string>
     <string name="session_task_custom_value">Valeur personnalisée</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -658,6 +658,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">BAT</string>
     <string name="session_drawer_hud_element_graph">ग्राफ़</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
     <string name="hud_position_menu_title">HUD को यहाँ ले जाएँ</string>
     <string name="hud_position_top_left">ऊपर बाएँ</string>
     <string name="hud_position_top_center">ऊपर केंद्र</string>
@@ -1448,7 +1449,7 @@
     <string name="session_drawer_hud_background">पृष्ठभूमि</string>
     <string name="session_drawer_hud_background_alpha">पृष्ठभूमि अल्फा</string>
     <string name="session_drawer_hud_background_alpha_input_title">पृष्ठभूमि अल्फा सेट करें</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">आकार समायोजित करें</string>
     <string name="session_task_bring_to_front">सामने लाएँ</string>
     <string name="session_task_custom_value">कस्टम मान</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -588,6 +588,7 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Batt.</string>
     <string name="session_drawer_hud_element_graph">Graf.</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Vuoi terminare questo processo?</string>
@@ -1512,7 +1513,7 @@ Percorso installato:
     <string name="session_drawer_hud_background">Sfondo</string>
     <string name="session_drawer_hud_background_alpha">Alfa sfondo</string>
     <string name="session_drawer_hud_background_alpha_input_title">Imposta alfa sfondo</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Adatta dimensione</string>
     <string name="session_task_bring_to_front">Porta in primo piano</string>
     <string name="session_task_custom_value">Valore personalizzato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -588,6 +588,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">배터리</string>
     <string name="session_drawer_hud_element_graph">그래프</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">이 프로세스를 종료하시겠습니까?</string>
@@ -1513,7 +1514,7 @@
     <string name="session_drawer_hud_background">배경</string>
     <string name="session_drawer_hud_background_alpha">배경 알파</string>
     <string name="session_drawer_hud_background_alpha_input_title">배경 알파 설정</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">크기 조정</string>
     <string name="session_task_bring_to_front">앞으로 가져오기</string>
     <string name="session_task_custom_value">사용자 지정 값</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -592,6 +592,7 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Bat.</string>
     <string name="session_drawer_hud_element_graph">Wykr.</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Czy chcesz zakończyć ten proces?</string>
@@ -1518,7 +1519,7 @@ Zainstalowana ścieżka:
     <string name="session_drawer_hud_background">Tło</string>
     <string name="session_drawer_hud_background_alpha">Alfa tła</string>
     <string name="session_drawer_hud_background_alpha_input_title">Ustaw alfę tła</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Dopasuj rozmiar</string>
     <string name="session_task_bring_to_front">Przenieś na wierzch</string>
     <string name="session_task_custom_value">Wartość niestandardowa</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -588,6 +588,7 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Bat.</string>
     <string name="session_drawer_hud_element_graph">Graf.</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Deseja encerrar este processo?</string>
@@ -1512,7 +1513,7 @@ Caminho instalado:
     <string name="session_drawer_hud_background">Fundo</string>
     <string name="session_drawer_hud_background_alpha">Alfa do fundo</string>
     <string name="session_drawer_hud_background_alpha_input_title">Definir alfa do fundo</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Ajustar tamanho</string>
     <string name="session_task_bring_to_front">Trazer para frente</string>
     <string name="session_task_custom_value">Valor personalizado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -588,6 +588,7 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Bat.</string>
     <string name="session_drawer_hud_element_graph">Grafic</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Doresti sa opresti acest proces?</string>
@@ -1511,7 +1512,7 @@ Cale instalata:
     <string name="session_drawer_hud_background">Fundal</string>
     <string name="session_drawer_hud_background_alpha">Alfa fundal</string>
     <string name="session_drawer_hud_background_alpha_input_title">Setează alfa fundalului</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Ajustează dimensiunea</string>
     <string name="session_task_bring_to_front">Adu în față</string>
     <string name="session_task_custom_value">Valoare personalizată</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -610,6 +610,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Батарея</string>
     <string name="session_drawer_hud_element_graph">График</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
     <string name="hud_position_menu_title">Переместить HUD</string>
     <string name="hud_position_top_left">Вверху слева</string>
     <string name="hud_position_top_center">Вверху по центру</string>
@@ -1418,7 +1419,7 @@
     <string name="session_drawer_hud_background">Фон</string>
     <string name="session_drawer_hud_background_alpha">Альфа фона</string>
     <string name="session_drawer_hud_background_alpha_input_title">Задать альфу фона</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Изменить размер</string>
     <string name="session_task_bring_to_front">На передний план</string>
     <string name="session_task_custom_value">Своё значение</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -592,6 +592,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">Бат.</string>
     <string name="session_drawer_hud_element_graph">Графік</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">Ви хочете завершити цей процес?</string>
@@ -1518,7 +1519,7 @@
     <string name="session_drawer_hud_background">Фон</string>
     <string name="session_drawer_hud_background_alpha">Альфа фону</string>
     <string name="session_drawer_hud_background_alpha_input_title">Задати альфу фону</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">Змінити розмір</string>
     <string name="session_task_bring_to_front">На передній план</string>
     <string name="session_task_custom_value">Власне значення</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -588,6 +588,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">电量</string>
     <string name="session_drawer_hud_element_graph">图表</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">您要结束此进程吗？</string>
@@ -1512,7 +1513,7 @@
     <string name="session_drawer_hud_background">背景</string>
     <string name="session_drawer_hud_background_alpha">背景透明度</string>
     <string name="session_drawer_hud_background_alpha_input_title">设置背景透明度</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">调整大小</string>
     <string name="session_task_bring_to_front">置于顶层</string>
     <string name="session_task_custom_value">自定义值</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -588,6 +588,7 @@
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">電量</string>
     <string name="session_drawer_hud_element_graph">圖表</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
 
     <!-- Session > Task Manager -->
     <string name="session_task_confirm_end_process">您要結束此程序嗎？</string>
@@ -1511,7 +1512,7 @@
     <string name="session_drawer_hud_background">背景</string>
     <string name="session_drawer_hud_background_alpha">背景透明度</string>
     <string name="session_drawer_hud_background_alpha_input_title">設定背景透明度</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_refactor_size">調整大小</string>
     <string name="session_task_bring_to_front">置於最上層</string>
     <string name="session_task_custom_value">自訂值</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -737,8 +737,9 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_hud_element_cpu">CPU</string>
     <string name="session_drawer_hud_element_ram">RAM</string>
     <string name="session_drawer_hud_element_battery">BAT</string>
-    <string name="session_drawer_hud_element_temp">TMP</string>
+    <string name="session_drawer_hud_element_temp">B.TMP</string>
     <string name="session_drawer_hud_element_graph">Graph</string>
+    <string name="session_drawer_hud_element_cpu_temp">C.TMP</string>
     <string name="hud_position_menu_title">Move HUD to</string>
     <string name="hud_position_top_left">Top Left</string>
     <string name="hud_position_top_center">Top Center</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -402,7 +402,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private boolean hudBackgroundAlphaDecoupled = false;
     private float hudBackgroundTransparency = 1.0f;
     private float hudScale = 1.0f;
-    private boolean[] hudElements = new boolean[]{true, true, true, true, true, true, true, true};
+    private boolean[] hudElements = new boolean[]{true, true, true, true, true, true, true, true, false};
     private boolean dualSeriesBattery = false;
     private boolean frametimeNumericMode = false;
     private boolean hudCardExpanded = false;
@@ -5299,6 +5299,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                 hudElements[5] = obj.optBoolean("showBattery", legacyBattTemp);
                 hudElements[6] = obj.optBoolean("showTemp", legacyBattTemp);
                 hudElements[7] = obj.optBoolean("showGraph", true);
+                hudElements[8] = obj.optBoolean("showCpuTemp", false);
             } catch (JSONException e) {
                 Log.e("XServerDisplayActivity", "Failed to load HUD settings", e);
             }
@@ -5322,6 +5323,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             obj.put("showBattery", hudElements[5]);
             obj.put("showTemp", hudElements[6]);
             obj.put("showGraph", hudElements[7]);
+            obj.put("showCpuTemp", hudElements[8]);
             container.putExtra("hudSettings", obj.toString());
             container.saveData();
         } catch (JSONException e) {

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -589,7 +589,7 @@ data class XServerDrawerState(
     val hudBackgroundAlphaEnabled: Boolean = false,
     val hudBackgroundTransparency: Float = 1.0f,
     val hudScale: Float = 1.0f,
-    val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true),
+    val hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true, false),
     val dualSeriesBatteryEnabled: Boolean = false,
     val frametimeNumericEnabled: Boolean = false,
     val hudCardExpanded: Boolean = false,
@@ -1121,7 +1121,7 @@ fun buildXServerDrawerState(
     hudBackgroundAlphaEnabled: Boolean = false,
     hudBackgroundTransparency: Float = 1.0f,
     hudScale: Float = 1.0f,
-    hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true),
+    hudElements: BooleanArray = booleanArrayOf(true, true, true, true, true, true, true, true, false),
     dualSeriesBatteryEnabled: Boolean = false,
     frametimeNumericEnabled: Boolean = false,
     hudCardExpanded: Boolean = false,
@@ -2374,8 +2374,9 @@ private fun HUDPaneContent(
             stringResource(R.string.session_drawer_hud_element_battery),
             stringResource(R.string.session_drawer_hud_element_temp),
             stringResource(R.string.session_drawer_hud_element_graph),
+            stringResource(R.string.session_drawer_hud_element_cpu_temp),
         )
-    val elementOrder = listOf(1, 2, 3, 4, 5, 6, 0, 7)
+    val elementOrder = listOf(1, 2, 3, 8, 4, 5, 6, 0, 7)
     val active =
         state.items.firstOrNull { it.itemId == R.id.main_menu_fps_monitor }?.active ?: false
 

--- a/app/src/main/runtime/display/ui/FrameRating.java
+++ b/app/src/main/runtime/display/ui/FrameRating.java
@@ -85,6 +85,7 @@ public class FrameRating extends LinearLayout implements Runnable {
   private final int C_GPU;
   private final int C_RAM;
   private final int C_TEMP;
+  private final int C_CPU_TEMP;
   private final int C_VALUE;
   private int battFailCount;
   private BatteryManager batteryManager;
@@ -96,9 +97,11 @@ public class FrameRating extends LinearLayout implements Runnable {
   private int cpuFailCount;
   private volatile int cpuPercent;
   private volatile int cpuTemp;
+  private volatile int cpuSensorTemp;
   private volatile float currentMs;
   private boolean enableBatt;
   private boolean enableTemp;
+  private boolean enableCpuTemp;
   private boolean enableCpu;
   private boolean enableRam;
   private boolean enableFps;
@@ -135,10 +138,11 @@ public class FrameRating extends LinearLayout implements Runnable {
   private int frameTimesCount;
   private String rendererName;
   private String gpuName;
-  private final View sep0, sep1, sep2, sep3, sep4, sep5;
+  private final View sep0, sep1, sep2, sep3, sep4, sep5, sep6;
   private final TextView tvRenderer;
   private final TextView tvGpuLoad;
   private final TextView tvCpu;
+  private final TextView tvCpuTemp;
   private final TextView tvRam;
   private final TextView tvBat;
   private final TextView tvTemp;
@@ -200,6 +204,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.enableGraph = true;
     this.enableGpu = true;
     this.enableCpu = true;
+    this.enableCpuTemp = false;
     this.enableRam = true;
     this.enableBatt = true;
     this.enableTemp = true;
@@ -208,6 +213,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.gpuLoad = -1;
     this.batteryWatts = -1.0f;
     this.cpuTemp = -1;
+    this.cpuSensorTemp = -1;
     this.ramText = "N/A";
     this.rendererName = "Vulkan";
     this.gpuName = null;
@@ -225,6 +231,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.C_RAM = Color.parseColor("#26C6DA");
     this.C_BAT = Color.parseColor("#E03A94");
     this.C_TEMP = Color.parseColor("#E53935");
+    this.C_CPU_TEMP = Color.parseColor("#9E9E9E");
     this.C_GPU = Color.parseColor("#E040FB");
     this.C_FPS_OK = Color.parseColor("#76FF03");
     this.C_WARM = Color.parseColor("#FFC107"); // TMP value when battery is warm (40-44C)
@@ -244,6 +251,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.tvRenderer = view.findViewById(R.id.TVRenderer);
     this.tvGpuLoad = view.findViewById(R.id.TVGpuLoad);
     this.tvCpu = view.findViewById(R.id.TVCpu);
+    this.tvCpuTemp = view.findViewById(R.id.TVCpuTemp);
     this.tvRam = view.findViewById(R.id.TVRam);
     this.tvBat = view.findViewById(R.id.TVBat);
     this.tvTemp = view.findViewById(R.id.TVTemp);
@@ -256,6 +264,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     this.sep3 = view.findViewById(R.id.Sep3);
     this.sep4 = view.findViewById(R.id.Sep4);
     this.sep5 = view.findViewById(R.id.Sep5);
+    this.sep6 = view.findViewById(R.id.Sep6);
     this.graphView = new FrametimeGraphView(context);
     if (this.graphContainer != null) {
       this.graphContainer.addView(this.graphView);
@@ -1105,13 +1114,17 @@ public class FrameRating extends LinearLayout implements Runnable {
         this.enableGraph = visible;
         applyFrametimeDisplayVisibility();
         break;
+      case 8:
+        this.enableCpuTemp = visible;
+        if (this.tvCpuTemp != null) this.tvCpuTemp.setVisibility(v);
+        break;
     }
     updateSeparators(getOrientation() == LinearLayout.HORIZONTAL);
   }
 
   private void updateSeparators(boolean horizontal) {
     if (!horizontal) {
-      View[] seps = {sep0, sep1, sep2, sep3, sep4, sep5};
+      View[] seps = {sep0, sep1, sep2, sep3, sep4, sep5, sep6};
       for (View s : seps) if (s != null) s.setVisibility(View.GONE);
       return;
     }
@@ -1119,6 +1132,7 @@ public class FrameRating extends LinearLayout implements Runnable {
     boolean vRen = tvRenderer != null && tvRenderer.getVisibility() == View.VISIBLE;
     boolean vGpu = tvGpuLoad != null && tvGpuLoad.getVisibility() == View.VISIBLE;
     boolean vCpu = tvCpu != null && tvCpu.getVisibility() == View.VISIBLE;
+    boolean vCTmp = tvCpuTemp != null && tvCpuTemp.getVisibility() == View.VISIBLE;
     boolean vRam = tvRam != null && tvRam.getVisibility() == View.VISIBLE;
     boolean vBat = tvBat != null && tvBat.getVisibility() == View.VISIBLE;
     boolean vTmp = tvTemp != null && tvTemp.getVisibility() == View.VISIBLE;
@@ -1126,11 +1140,15 @@ public class FrameRating extends LinearLayout implements Runnable {
 
     if (sep0 != null)
       sep0.setVisibility(
-          vRen && (vGpu || vCpu || vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
+          vRen && (vGpu || vCpu || vCTmp || vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
     if (sep1 != null)
-      sep1.setVisibility(vGpu && (vCpu || vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
+      sep1.setVisibility(
+          vGpu && (vCpu || vCTmp || vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
     if (sep2 != null)
-      sep2.setVisibility(vCpu && (vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
+      sep2.setVisibility(
+          vCpu && (vCTmp || vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
+    if (sep6 != null)
+      sep6.setVisibility(vCTmp && (vRam || vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
     if (sep3 != null) sep3.setVisibility(vRam && (vBat || vTmp || vFps) ? View.VISIBLE : View.GONE);
     if (sep4 != null) sep4.setVisibility(vBat && (vTmp || vFps) ? View.VISIBLE : View.GONE);
     if (sep5 != null) sep5.setVisibility(vTmp && vFps ? View.VISIBLE : View.GONE);
@@ -1358,6 +1376,13 @@ public class FrameRating extends LinearLayout implements Runnable {
         this.cpuFailCount++;
       }
     }
+    if (this.enableCpuTemp) {
+      try {
+        this.cpuSensorTemp = CPUStatus.getCpuTempC();
+      } catch (Exception e) {
+        this.cpuSensorTemp = -1;
+      }
+    }
     if (this.enableRam) {
       try {
         ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
@@ -1438,6 +1463,21 @@ public class FrameRating extends LinearLayout implements Runnable {
       this.tvCpu.setVisibility(View.GONE);
     }
 
+    if (this.enableCpuTemp && this.tvCpuTemp != null) {
+      SpannableStringBuilder b = new SpannableStringBuilder();
+      append(b, "C.TMP ", this.C_CPU_TEMP);
+      if (this.cpuSensorTemp >= 0) {
+        append(b, this.cpuSensorTemp + "°", this.C_VALUE);
+        appendSmall(b, "C", this.C_VALUE, 0.7f);
+      } else {
+        append(b, "N/A", this.C_VALUE);
+      }
+      this.tvCpuTemp.setText(b);
+      this.tvCpuTemp.setVisibility(View.VISIBLE);
+    } else if (this.tvCpuTemp != null) {
+      this.tvCpuTemp.setVisibility(View.GONE);
+    }
+
     if (this.enableRam && this.tvRam != null) {
       SpannableStringBuilder b = new SpannableStringBuilder();
       append(b, "RAM ", this.C_RAM);
@@ -1472,7 +1512,7 @@ public class FrameRating extends LinearLayout implements Runnable {
 
     if (this.enableTemp && this.tvTemp != null) {
       SpannableStringBuilder b = new SpannableStringBuilder();
-      append(b, "TMP ", this.C_TEMP);
+      append(b, "B.TMP ", this.C_TEMP);
       if (this.cpuTemp >= 0) {
         int tempColor =
             this.cpuTemp >= 45 ? this.C_HOT : this.cpuTemp >= 40 ? this.C_WARM : this.C_VALUE;

--- a/app/src/main/runtime/system/CPUStatus.java
+++ b/app/src/main/runtime/system/CPUStatus.java
@@ -1,6 +1,10 @@
 package com.winlator.cmod.runtime.system;
 
 import com.winlator.cmod.shared.io.FileUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Locale;
 
 public abstract class CPUStatus {
   public static short[] getCurrentClockSpeeds() {
@@ -18,5 +22,67 @@ public abstract class CPUStatus {
     int maxFreq =
         FileUtils.readInt("/sys/devices/system/cpu/cpu" + cpuIndex + "/cpufreq/cpuinfo_max_freq");
     return (short) (maxFreq / 1000);
+  }
+
+  private static volatile String[] cpuTempPaths;
+
+  /**
+   * CPU temperature in whole °C read from the best-matching sysfs thermal zone, or -1 if none is
+   * readable. Zone paths are discovered once (ranked by the zone `type` name) and cached; each call
+   * then just reads the chosen temp file, converting millidegrees to °C.
+   */
+  public static int getCpuTempC() {
+    String[] paths = cpuTempPaths;
+    if (paths == null) {
+      paths = discoverCpuTempPaths();
+      if (paths.length > 0) cpuTempPaths = paths;
+    }
+    for (String path : paths) {
+      int raw = FileUtils.readInt(path);
+      int celsius = raw > 1000 ? (raw + 500) / 1000 : raw;
+      if (celsius >= 1 && celsius <= 150) return celsius;
+    }
+    return -1;
+  }
+
+  private static String[] discoverCpuTempPaths() {
+    ArrayList<int[]> ranks = new ArrayList<>();
+    ArrayList<String> paths = new ArrayList<>();
+    File[] roots = {new File("/sys/class/thermal"), new File("/sys/devices/virtual/thermal")};
+    for (File root : roots) {
+      File[] zones =
+          root.listFiles((dir, name) -> name.startsWith("thermal_zone") && new File(dir, name).isDirectory());
+      if (zones == null) continue;
+      for (File zone : zones) {
+        String type = FileUtils.readString(new File(zone, "type"));
+        if (type == null) continue;
+        int rank = rankCpuZone(type.trim().toLowerCase(Locale.US));
+        if (rank < 0) continue;
+        String path = new File(zone, "temp").getAbsolutePath();
+        if (paths.contains(path)) continue;
+        ranks.add(new int[] {rank, paths.size()});
+        paths.add(path);
+      }
+    }
+    // Order by rank (best CPU match first), then path for a stable tie-break.
+    Collections.sort(
+        ranks,
+        (a, b) -> a[0] != b[0] ? a[0] - b[0] : paths.get(a[1]).compareTo(paths.get(b[1])));
+    String[] ordered = new String[ranks.size()];
+    for (int i = 0; i < ranks.size(); i++) ordered[i] = paths.get(ranks.get(i)[1]);
+    return ordered;
+  }
+
+  private static int rankCpuZone(String type) {
+    if (type.contains("cpu-silicon")) return 0;
+    if (type.contains("cpu-0")) return 1;
+    if (type.contains("cpu") && !type.contains("gpu")) return 2;
+    if (type.contains("soc")) return 3;
+    if (type.contains("s5p-tmu")) return 4;
+    if (type.contains("cputop")) return 5;
+    if (type.contains("tsens")) return 6;
+    if (type.contains("cluster")) return 7;
+    if (type.contains("big") || type.contains("little")) return 8;
+    return -1;
   }
 }


### PR DESCRIPTION
Add a C.TMP element that reads CPU temperature from sysfs thermal zones (ranked zone-type match, cached paths). Off by default, persisted per container like the other elements, shown between CPU and RAM with a gray label and white readout. Rename the existing battery-temperature label from TMP to B.TMP across all locales.