### PR TITLE
Fix: container boot crash on API <33

### DIFF
--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -655,7 +655,7 @@ public abstract class ProcessHelper {
   private static String readProcCmdline(File proc, String pid) {
     try (FileInputStream fr = new FileInputStream(proc + "/" + pid + "/cmdline")) {
       ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-      byte[] data = new byte[4096];
+      byte[] data = new byte[8192];
       int nRead;
       while ((nRead = fr.read(data)) != -1) buffer.write(data, 0, nRead);
       byte[] bytes = buffer.toByteArray();

--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -654,7 +654,11 @@ public abstract class ProcessHelper {
 
   private static String readProcCmdline(File proc, String pid) {
     try (FileInputStream fr = new FileInputStream(proc + "/" + pid + "/cmdline")) {
-      byte[] bytes = fr.readAllBytes();
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      byte[] data = new byte[4096];
+      int nRead;
+      while ((nRead = fr.read(data)) != -1) buffer.write(data, 0, nRead);
+      byte[] bytes = buffer.toByteArray();
       return new String(bytes, StandardCharsets.UTF_8).replace('\0', ' ');
     } catch (IOException e) {
       return "";


### PR DESCRIPTION
readAllBytes() on FileInputStream is API 33+; on older devices it threw NoSuchMethodError while reading /proc/<pid>/cmdline, crashing container boot. Use a ByteArrayOutputStream read loop instead.