### PR TITLE
Fix: emit link-local fallback when device is offline

### DIFF
--- a/app/src/main/runtime/display/environment/components/NetworkHelper.java
+++ b/app/src/main/runtime/display/environment/components/NetworkHelper.java
@@ -92,6 +92,19 @@ public class NetworkHelper {
         }
     }
 
+    /**
+     * Adapter reported to Wine when Android has no active network. Represents an
+     * up link-local interface so iphlpapi never hands the guest a down, all-zero
+     * adapter (which some games dereference blindly during boot enumeration).
+     */
+    public static IFAddress offlineFallback() {
+        IFAddress ifAddress = new IFAddress();
+        ifAddress.flags = OsConstants.IFF_UP | OsConstants.IFF_RUNNING;
+        ifAddress.address = "169.254.1.2";
+        ifAddress.netmask = "255.255.0.0";
+        return ifAddress;
+    }
+
     public boolean isConnected() {
         NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
         if (networkInfo == null) return false;

--- a/app/src/main/runtime/display/environment/components/NetworkInfoUpdateComponent.java
+++ b/app/src/main/runtime/display/environment/components/NetworkInfoUpdateComponent.java
@@ -64,7 +64,7 @@ public class NetworkInfoUpdateComponent extends EnvironmentComponent {
                 content.append(ifAddress.toString());
             }
         } else {
-            content.append(new NetworkHelper.IFAddress().toString());
+            content.append(NetworkHelper.offlineFallback().toString());
         }
         FileUtils.writeString(file, content.toString());
     }


### PR DESCRIPTION
Offline, the guest received a down, all-zero adapter (address/netmask 0) which boot-time adapter enumeration could dereference and crash on. Emit an up link-local interface instead so iphlpapi always exposes a valid NIC.