### PR TITLE
Fix: file picker tap highlights file instead of auto-confirming

### DIFF
--- a/app/src/main/shared/android/DirectoryPickerDialog.kt
+++ b/app/src/main/shared/android/DirectoryPickerDialog.kt
@@ -831,11 +831,7 @@ object DirectoryPickerDialog {
                                         isEntry = entry === entries.first(),
                                         onClick = {
                                             if (entry.isSelectableFile) {
-                                                if (mode == SelectionMode.FILE) {
-                                                    onSelect(entry.target.absolutePath)
-                                                } else {
-                                                    selectedFile = entry.target
-                                                }
+                                                selectedFile = entry.target
                                             } else {
                                                 currentDir = entry.target
                                             }


### PR DESCRIPTION
Tapping a file now only selects/highlights it so its full name shows in the header box; Start or OK confirms. Restores read-before-confirm for the .wcp component install and other file pickers.