### PR TITLE
Fix HTTP 403 on GOG chunk downloads

### DIFF
--- a/app/src/main/feature/stores/gog/api/GOGManifestParser.kt
+++ b/app/src/main/feature/stores/gog/api/GOGManifestParser.kt
@@ -291,13 +291,20 @@ class GOGManifestParser
                 val baseCdnUrl = productUrls.first()
 
                 // Where aa/bb are first 4 chars of MD5 hash
-                val chunkUrl =
+                val chunkSuffix =
                     if (chunkMd5.length >= 4) {
                         val first2 = chunkMd5.substring(0, 2)
                         val next2 = chunkMd5.substring(2, 4)
-                        "$baseCdnUrl/$first2/$next2/$chunkMd5"
+                        "/$first2/$next2/$chunkMd5"
                     } else {
-                        "$baseCdnUrl/$chunkMd5"
+                        "/$chunkMd5"
+                    }
+                val queryIndex = baseCdnUrl.indexOf('?')
+                val chunkUrl =
+                    if (queryIndex >= 0) {
+                        baseCdnUrl.substring(0, queryIndex) + chunkSuffix + baseCdnUrl.substring(queryIndex)
+                    } else {
+                        baseCdnUrl + chunkSuffix
                     }
 
                 chunkUrlMap[chunkMd5] = chunkUrl


### PR DESCRIPTION
## Summary
- GOG downloads consistently failed with `HTTP 403 downloading chunk <hash>`, while other stores worked fine.
- Root cause: `buildChunkUrlMapWithProducts` appended the chunk's `/aa/bb/<hash>` path onto the end of the resolved secure link URL. For GOG's primary ("gcore") CDN endpoint, that URL already ends in a signed query string (`?wsSecret=...&wsTime=...&prefix=...`), so the appended path landed inside the `prefix` query value instead of the actual URL path — the real request path sent to the CDN never included the chunk file, so the signature check rejected it every time, regardless of how many times the secure link was refreshed.
- Fix: insert the chunk path before the `?` (into the URL path) instead of appending it to the end of the string. This is safe for both CDN endpoints GOG returns (the primary endpoint with a trailing query string, and the fallback endpoint whose URL has no query string at all).