### PR TITLE
Fix Steam library not refreshing after game exit

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -910,6 +910,7 @@ class UnifiedActivity :
         chasingBordersPaused.value = false
         if (hasCompletedInitialResume) {
             libraryPlaytimeRefreshSignal++
+            SteamService.ensureHealthySession()
         } else {
             hasCompletedInitialResume = true
         }

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -6950,6 +6950,11 @@ class SteamService : Service() {
             instance?.handleAppBackgrounded()
         }
 
+        @JvmStatic
+        fun ensureHealthySession() {
+            instance?.ensureHealthySessionImpl()
+        }
+
         fun stop() {
             instance?.let { steamInstance ->
                 if (!isStopping) {
@@ -7704,7 +7709,21 @@ class SteamService : Service() {
             }
     }
 
-    /** App returned to the foreground: wake the Steam session if suspended for background — reconnect and let the logon observer restart the PICS loops via onWnLoggedOn. */
+    private fun ensureHealthySessionImpl() {
+        if (!isRunning || isStopping || isLoggingOut) return
+        if (PrefManager.refreshToken.isBlank()) return
+        if (PluviaApp.isGameSessionActive()) return
+        if (suspendedForBionic) {
+            Timber.w("ensureHealthySession: clearing stale Bionic hand-off (no game running)")
+            bionicHandoffReleaseImpl()
+            return
+        }
+        if (wnSession?.state() == 3) return
+        Timber.i("ensureHealthySession: session not logged on — re-driving connectAndLogon")
+        retryAttempt = 0
+        connectAndLogon()
+    }
+
     private fun handleAppForegrounded() {
         appInForeground = true
         // Cancel any pending suspend timer — the app is back, so the session must stay up regardless of how long it was minimized.
@@ -8610,10 +8629,8 @@ class SteamService : Service() {
     private fun continuousPICSChangesChecker(): Job =
         scope.launch {
             while (isActive && isLoggedIn) {
-                // Initial delay before each check
-                delay(60.seconds)
-
                 PICSChangesCheck()
+                delay(60.seconds)
             }
         }
 


### PR DESCRIPTION
Add ensureHealthySession self-heal on app resume: clears a stale Bionic hand-off, resets the reconnect budget, and re-drives connectAndLogon when the CM session is not logged on and no game is running. Also make the PICS changes checker poll immediately instead of waiting 60s on first run.