### PR TITLE
Fix Steam cloud save container targeting and exit-sync conflict handling

### DIFF
--- a/app/src/main/feature/steamcloudsync/SteamAutoCloud.kt
+++ b/app/src/main/feature/steamcloudsync/SteamAutoCloud.kt
@@ -1430,10 +1430,25 @@ object SteamAutoCloud {
                                             // Only a real content divergence is a conflict; a bare change-number drift reconciles the baseline silently.
                                             val contentDiffers =
                                                 cloudContentDiffersFromLocal(appFileListChange, prefixToPath, appInfo)
+                                            // cloudContentDiffersFromLocal only walks cloud files, so local-only files (new this session) are invisible to it; upload them instead of baselining them away.
+                                            val cloudLocalPaths =
+                                                groupPersistedCloudFilesByLocalPath(appFileListChange, prefixToPath, cloudRouting).keys
+                                            val hasLocalOnlyFiles =
+                                                allLocalUserFiles.any { file ->
+                                                    runCatching {
+                                                        file.getAbsPath(prefixToPath).toAbsolutePath().normalize()
+                                                    }.getOrNull() !in cloudLocalPaths
+                                                }
                                             if (contentDiffers) {
                                                 syncResult = SyncResult.Conflict
                                                 remoteTimestamp = appFileListChange.files.map { it.timestamp }.maxOrNull() ?: 0L
                                                 localTimestamp = allLocalUserFiles.map { it.timestamp }.maxOrNull() ?: 0L
+                                            } else if (hasLocalOnlyFiles) {
+                                                Timber.i(
+                                                    "Change number differs ($effectiveLocalAppChangeNumber -> $cloudAppChangeNumber) " +
+                                                        "with identical shared content but new local-only file(s); uploading",
+                                                )
+                                                uploadUserFiles(parentScope).await()
                                             } else {
                                                 Timber.i(
                                                     "Change number differs ($effectiveLocalAppChangeNumber -> $cloudAppChangeNumber) " +

--- a/app/src/main/feature/steamcloudsync/SteamCloudHistoryProvider.kt
+++ b/app/src/main/feature/steamcloudsync/SteamCloudHistoryProvider.kt
@@ -11,18 +11,16 @@ import com.winlator.cmod.runtime.container.Container
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.security.MessageDigest
 
 /**
  * Provides Steam Cloud entries for the save-history UI.
  *
- * Steam Cloud stores the current version of each filename, not a server-side version history.
- * To approximate recent save events, files modified within [GROUP_WINDOW_MS] are grouped
- * together. This mirrors games that update several save files during one save action.
+ * Steam Cloud stores only the current version of each filename — no server-side version
+ * history — so, like Steam's own remote-storage website, this lists one entry per file
+ * currently in the cloud, each individually downloadable.
  *
- * Restoring any group syncs the full current cloud state through
- * [SteamCloudSyncHelper.forceDownloadById]. Groups only describe what changed together; they
- * are not independently restorable snapshots.
+ * Restoring syncs the full current cloud state through
+ * [SteamCloudSyncHelper.forceDownloadById].
  *
  * Labels are stored locally in SharedPrefs. Delete is unsupported because Steam manages cloud
  * retention.
@@ -33,11 +31,10 @@ import java.security.MessageDigest
 object SteamCloudHistoryProvider {
     private const val TAG = "SteamCloudHistory"
 
-    /** Time window for grouping files into one save event. */
-    private const val GROUP_WINDOW_MS = 120_000L
+    /** Maximum number of files shown in the history UI. */
+    private const val MAX_FILES = 200
 
-    /** Maximum number of groups shown in the history UI. */
-    private const val MAX_GROUPS = 30
+    private const val FILE_ID_SEPARATOR = ":file:"
 
     /** SharedPrefs file for user-set group labels. */
     private const val LABEL_PREFS = "steam_cloud_history_labels"
@@ -85,6 +82,23 @@ object SteamCloudHistoryProvider {
         return if (ms > 4_102_444_800_000L) 0L else ms
     }
 
+    /** The prefixed path used to download [file] from Steam Cloud (pathPrefix/filename). */
+    private fun downloadPathFor(
+        file: SteamAutoCloud.CloudFileInfo,
+        response: SteamAutoCloud.CloudFileChangeList,
+    ): String {
+        val prefix = response.pathPrefixes.getOrNull(file.pathPrefixIndex).orEmpty()
+        return if (prefix.isEmpty()) file.filename else "${prefix.trimEnd('/', '\\')}/${file.filename}"
+    }
+
+    /** Human-readable file path: root placeholders stripped, separators normalized. */
+    private fun displayNameFor(downloadPath: String): String =
+        downloadPath
+            .replace(Regex("%\\w+%"), "")
+            .replace('\\', '/')
+            .trimStart('/')
+            .ifEmpty { downloadPath }
+
     private fun buildEntries(
         context: Context,
         appId: Int,
@@ -97,57 +111,39 @@ object SteamCloudHistoryProvider {
 
         if (persistedFiles.isEmpty()) return emptyList()
 
-        class FileCluster {
-            val files = mutableListOf<SteamAutoCloud.CloudFileInfo>()
-            val timestamps = mutableListOf<Long>()
-            fun representativeTs(): Long = timestamps.maxOrNull() ?: 0L
-            fun earliestTs(): Long = timestamps.minOrNull() ?: 0L
-        }
-
-        val clusters = mutableListOf<FileCluster>()
-        for (file in persistedFiles) {
-            val ts: Long = toMillis(file.timestamp).takeIf { it > 0L } ?: continue
-            val current: FileCluster? = clusters.lastOrNull()
-            val joinsCurrent: Boolean =
-                current != null && (current.representativeTs() - ts) <= GROUP_WINDOW_MS
-            val target: FileCluster =
-                if (joinsCurrent) {
-                    current!!
-                } else {
-                    FileCluster().also { clusters += it }
-                }
-            target.files += file
-            target.timestamps += ts
-        }
-
         val labelPrefs = context.getSharedPreferences(LABEL_PREFS, Context.MODE_PRIVATE)
 
-        return clusters
-            .take(MAX_GROUPS)
-            .map { cluster ->
-                val sortedFilenames = cluster.files.map { it.filename }.sorted()
-                val groupId = buildGroupId(sortedFilenames, cluster.earliestTs())
-                val totalSize = cluster.files.sumOf { it.rawFileSize }
-                val timestampMs = cluster.representativeTs()
-                val label = labelPrefs.getString("$appId:$groupId", null)
-                val firstFile = cluster.files.first().filename
-                val fileName =
-                    if (cluster.files.size == 1) {
-                        firstFile
-                    } else {
-                        "$firstFile (+${cluster.files.size - 1} more)"
-                    }
+        return persistedFiles
+            .take(MAX_FILES)
+            .map { file ->
+                val downloadPath = downloadPathFor(file, response)
+                val fileId = "$appId$FILE_ID_SEPARATOR$downloadPath"
                 BackupHistoryEntry(
-                    fileId = "$appId:$groupId",
-                    fileName = fileName,
-                    timestampMs = timestampMs,
+                    fileId = fileId,
+                    fileName = displayNameFor(downloadPath),
+                    timestampMs = toMillis(file.timestamp),
                     origin = BackupOrigin.CLOUD,
-                    sizeBytes = totalSize,
-                    label = label,
+                    sizeBytes = file.rawFileSize,
+                    label = labelPrefs.getString(fileId, null),
                     storage = BackupStorage.STEAM_CLOUD,
                 )
             }
     }
+
+    /** Fetch the current cloud bytes for a [BackupHistoryEntry.fileId] produced by [buildEntries]. Null on failure. */
+    suspend fun downloadFileBytes(
+        appId: Int,
+        fileId: String,
+    ): ByteArray? =
+        withContext(Dispatchers.IO) {
+            val downloadPath = fileId.substringAfter(FILE_ID_SEPARATOR, "").ifEmpty { return@withContext null }
+            try {
+                SteamService.downloadCloudFileBytes(appId, downloadPath)
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "downloadFileBytes failed for appId=%d path=%s", appId, downloadPath)
+                null
+            }
+        }
 
     /**
      * Restores by syncing the full current Steam Cloud file set to local.
@@ -181,19 +177,5 @@ object SteamCloudHistoryProvider {
         val edit = prefs.edit()
         if (label.isNullOrEmpty()) edit.remove(groupFileId) else edit.putString(groupFileId, label)
         edit.apply()
-    }
-
-    /**
-     * Builds a stable ID from the cluster's sorted filenames and earliest timestamp.
-     */
-    private fun buildGroupId(sortedFilenames: List<String>, earliestTs: Long): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        md.update(earliestTs.toString().toByteArray(Charsets.UTF_8))
-        md.update(0)
-        sortedFilenames.forEach {
-            md.update(it.toByteArray(Charsets.UTF_8))
-            md.update(0)
-        }
-        return md.digest().copyOfRange(0, 8).joinToString("") { "%02x".format(it) }
     }
 }

--- a/app/src/main/feature/steamcloudsync/SteamExitCloudSync.kt
+++ b/app/src/main/feature/steamcloudsync/SteamExitCloudSync.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.winlator.cmod.R
 import com.winlator.cmod.feature.stores.steam.service.SteamService
 import com.winlator.cmod.feature.sync.google.GameSaveBackupManager
+import com.winlator.cmod.runtime.container.Container
 import com.winlator.cmod.runtime.container.Shortcut
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,6 +30,7 @@ object SteamExitCloudSync {
     fun syncOnExit(
         activity: Activity,
         shortcut: Shortcut?,
+        sessionContainer: Container?,
         statusSink: StatusSink,
         callback: ResultCallback,
     ) {
@@ -36,6 +38,10 @@ object SteamExitCloudSync {
             callback.onComplete(Result(success = true, message = "", retryable = false))
             return
         }
+
+        // Sync the wineprefix the session actually ran in; shortcut.container goes stale after a container reassignment.
+        val syncContainer =
+            sessionContainer ?: SteamCloudSyncHelper.resolveShortcutContainer(activity, shortcut)
 
         val appId = shortcut.getExtra("app_id").toIntOrNull()
         if (appId == null) {
@@ -74,7 +80,7 @@ object SteamExitCloudSync {
                                         activity.applicationContext,
                                         appId,
                                         GameSaveBackupManager.BackupOrigin.AUTO,
-                                        shortcut.container,
+                                        syncContainer,
                                     )
                                 }.onFailure {
                                     Timber.tag("SteamExitCloudSync").w(
@@ -94,7 +100,7 @@ object SteamExitCloudSync {
                         )
                     }
                 },
-                shortcut.container,
+                syncContainer,
             )
         } catch (e: Exception) {
             Timber.tag("SteamExitCloudSync").w(e, "Failed to initiate Steam cloud sync")

--- a/app/src/main/feature/steamcloudsync/SteamLaunchCloudSync.kt
+++ b/app/src/main/feature/steamcloudsync/SteamLaunchCloudSync.kt
@@ -172,6 +172,7 @@ object SteamLaunchCloudSync {
                         gameName = gameName,
                         origin = origin,
                         authMode = GoogleAuthMode.RESUME,
+                        containerHint = SteamCloudSyncHelper.resolveShortcutContainer(activity, shortcut),
                     )
                 }
             Timber.tag("SteamLaunchCloudSync").i("Discarded Steam save backup: %s", result.message)

--- a/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
+++ b/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
@@ -286,7 +286,7 @@ object SteamSaveSnapshotManager {
         }
     }
 
-    /** Return the up-to-30 newest snapshots for [appId], newest-first. */
+    /** Return the up-to-[MAX_HISTORY_ENTRIES] newest snapshots for [appId], newest-first. */
     suspend fun listHistory(context: Context, appId: Int): List<BackupHistoryEntry> =
         withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
+++ b/app/src/main/feature/steamcloudsync/SteamSaveSnapshotManager.kt
@@ -201,6 +201,10 @@ object SteamSaveSnapshotManager {
         origin: BackupOrigin,
         containerHint: Container? = null,
     ): Boolean {
+        if (!activateContainerForCloudOp(context, appId, containerHint)) {
+            Timber.tag(TAG).e("captureSnapshotLocked: container activation failed for appId=%d; skipping snapshot", appId)
+            return false
+        }
         cleanupPartialEntries(context, appId)
         val sources = enumerateSaveSources(context, appId, containerHint = containerHint)
         if (sources.isEmpty()) {
@@ -402,7 +406,7 @@ object SteamSaveSnapshotManager {
                             live.mkdirs()
                             asideDirs += Triple(live, bak, hadLive)
                         }
-                        extractZipToSources(zipFile, sources)
+                        extractZipToSources(zipFile, targetSources)
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "restoreFromEntry: extraction failed; rolling back")
                         rollbackAside()
@@ -412,7 +416,7 @@ object SteamSaveSnapshotManager {
                     asideDirs.forEach { (_, bak, _) -> bak?.let { runCatching { it.deleteRecursively() } } }
 
                     // Push the restored state to Steam Cloud so the next launch is consistent.
-                    val uploadOk = uploadLocalToSteam(context, appId)
+                    val uploadOk = uploadLocalToSteam(context, appId, containerHint)
                     if (uploadOk) {
                         BackupResult(true, "Save restored and pushed to Steam Cloud.")
                     } else {
@@ -540,10 +544,10 @@ object SteamSaveSnapshotManager {
 
                     captureSnapshotLocked(context, appId, BackupOrigin.MANUAL, containerHint)
                     // Retry the upload once after a delay so a concurrent background sync doesn't strand the imported state out of cloud.
-                    var uploadOk = uploadLocalToSteam(context, appId)
+                    var uploadOk = uploadLocalToSteam(context, appId, containerHint)
                     if (!uploadOk) {
                         kotlinx.coroutines.delay(1_500)
-                        uploadOk = uploadLocalToSteam(context, appId)
+                        uploadOk = uploadLocalToSteam(context, appId, containerHint)
                     }
 
                     val parts = mutableListOf("Imported $written file(s)")
@@ -655,9 +659,13 @@ object SteamSaveSnapshotManager {
             ?: 0L
 
     /** Push the local save up to Steam Cloud; forces overwrite (overrideLocalChangeNumber = -1) so the rollback isn't rejected as stale. */
-    private suspend fun uploadLocalToSteam(context: Context, appId: Int): Boolean {
+    private suspend fun uploadLocalToSteam(
+        context: Context,
+        appId: Int,
+        containerHint: Container? = null,
+    ): Boolean {
         return try {
-            val resolver = steamPrefixResolver(context, appId)
+            val resolver = steamPrefixResolver(context, appId, containerHint)
             val info =
                 SteamService
                     .forceSyncUserFiles(

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -6082,12 +6082,12 @@ class SteamService : Service() {
         ): CloudSyncOutcome =
             withContext(Dispatchers.IO) {
                 async {
+                    // In-Wine Steam owns cloud saves during a hand-off; syncing here too would race it as a second writer.
+                    if (isBionicHandoffActive()) {
+                        Timber.i("closeApp: Bionic hand-off active for app %d — deferring exit cloud sync to in-Wine Steam", appId)
+                        return@async CloudSyncOutcome(true, "Steam Launcher handles cloud saves directly.")
+                    }
                     if (isOffline || !isConnected) {
-                        // Steam Launcher mode hands the CM session to the in-Wine Steam, which owns cloud saves during play; don't report its intentional offline as a failure.
-                        if (isBionicHandoffActive()) {
-                            Timber.i("closeApp: Bionic hand-off active for app %d — deferring exit cloud sync to in-Wine Steam", appId)
-                            return@async CloudSyncOutcome(true, "Steam Launcher handles cloud saves directly.")
-                        }
                         return@async CloudSyncOutcome(false, "Steam is offline.")
                     }
 
@@ -6117,13 +6117,14 @@ class SteamService : Service() {
 
                                 if (steamInstance != null && appInfo != null) {
                                     progressWrapper("Checking Local Saves", 0f)
+                                    // SaveLocation.None: unchanged content never uploads, and both-sides-changed surfaces as a Conflict instead of overwriting the newer cloud copy.
                                     val postSyncInfo =
                                         SteamAutoCloud
                                             .syncUserFiles(
                                                 appInfo = appInfo,
                                                 clientId = clientId,
                                                 steamInstance = steamInstance,
-                                                preferredSave = SaveLocation.Local,
+                                                preferredSave = SaveLocation.None,
                                                 parentScope = this@async,
                                                 prefixToPath = prefixToPath,
                                                 onProgress = progressWrapper,

--- a/app/src/main/feature/sync/CloudSyncHelper.kt
+++ b/app/src/main/feature/sync/CloudSyncHelper.kt
@@ -162,7 +162,12 @@ object CloudSyncHelper {
 
         return runBlocking {
             when (gameSource) {
-                "STEAM" -> SteamCloudSyncHelper.hasActualLocalSaves(context, appId.toIntOrNull() ?: return@runBlocking false, shortcut.container)
+                "STEAM" ->
+                    SteamCloudSyncHelper.hasActualLocalSaves(
+                        context,
+                        appId.toIntOrNull() ?: return@runBlocking false,
+                        SteamCloudSyncHelper.resolveShortcutContainer(context, shortcut),
+                    )
                 "EPIC" -> {
                     val epicAppId = appId.toIntOrNull() ?: return@runBlocking false
                     EpicCloudSavesManager.getResolvedSaveDirectory(context, epicAppId, epicTargetContainerId(shortcut))?.hasAnyFile() == true

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -51,7 +51,7 @@ object GameSaveBackupManager {
     private const val AUTH_SESSION_RETRY_DELAY_MS = 750L
 
     /** Maximum number of history entries retained (and shown) per game. */
-    const val MAX_HISTORY_ENTRIES = 30
+    const val MAX_HISTORY_ENTRIES = 100
 
     /** Entries older than this are pruned whenever history is listed or written. */
     const val HISTORY_MAX_AGE_DAYS = 30

--- a/app/src/main/feature/sync/google/GameSaveBackupManager.kt
+++ b/app/src/main/feature/sync/google/GameSaveBackupManager.kt
@@ -235,6 +235,7 @@ object GameSaveBackupManager {
         origin: BackupOrigin,
         authMode: GoogleAuthMode = GoogleAuthMode.INTERACTIVE,
         customSaveDir: File? = null,
+        containerHint: Container? = null,
     ): BackupResult =
         withContext(Dispatchers.IO) {
             try {
@@ -245,12 +246,12 @@ object GameSaveBackupManager {
                     ?: return@withContext BackupResult(false, "Invalid Steam appId for snapshot.")
 
                 // 1) Local rolling snapshot — the offline rollback safety net (always attempted).
-                val localOk = SteamSaveSnapshotManager.recordSnapshot(activity.applicationContext, appId, origin)
+                val localOk = SteamSaveSnapshotManager.recordSnapshot(activity.applicationContext, appId, origin, containerHint)
 
                 // 2) Mirror to Google Play Games when signed in; a silent no-op otherwise (only the local snapshot is kept).
                 val googleResult =
                     runCatching {
-                        backupSaveToGoogle(activity, gameSource, gameId, gameName, origin, authMode)
+                        backupSaveToGoogle(activity, gameSource, gameId, gameName, origin, authMode, containerHint = containerHint)
                     }.getOrElse { e ->
                         Timber.tag(TAG).w(e, "Google mirror of kept save failed for $gameId")
                         BackupResult(false, e.message ?: "Google backup failed.")

--- a/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
+++ b/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
@@ -1124,9 +1124,16 @@ private fun SaveHistorySection(
                 }
 
                 else -> {
+                    // Steam Cloud stores only the current version of each file, so only the newest group actually matches what a restore downloads; older groups stay read-only.
+                    val newestCloudGroupId =
+                        entries
+                            .filter { it.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD }
+                            .maxByOrNull { it.timestampMs }
+                            ?.fileId
                     entries.forEachIndexed { index, entry ->
                         SaveHistoryRow(
                             entry = entry,
+                            cloudRestorable = entry.fileId == newestCloudGroupId,
                             onRestore = { onRestore(entry) },
                             onRename = { onRename(entry) },
                         )
@@ -1146,6 +1153,7 @@ private fun SaveHistorySection(
 @Composable
 private fun SaveHistoryRow(
     entry: GameSaveBackupManager.BackupHistoryEntry,
+    cloudRestorable: Boolean = false,
     onRestore: () -> Unit,
     onRename: () -> Unit,
 ) {
@@ -1168,11 +1176,15 @@ private fun SaveHistoryRow(
             GameSaveBackupManager.BackupStorage.EPIC_CLOUD -> stringResource(R.string.cloud_saves_history_storage_epic)
             GameSaveBackupManager.BackupStorage.GOG_CLOUD -> stringResource(R.string.cloud_saves_history_storage_gog)
         }
-    // STEAM_CLOUD "groups" view the CURRENT cloud file list (no server-side version history), so they're read-only history like GOG_CLOUD — per-entry rollback lives in STEAM_LOCAL snapshots.
+    // STEAM_CLOUD "groups" view the CURRENT cloud file list (no server-side version history); only the newest group is restorable (downloads the current cloud state) — per-entry rollback lives in STEAM_LOCAL snapshots.
     val canRestore =
-        entry.storage != GameSaveBackupManager.BackupStorage.GOG_CLOUD &&
-            entry.storage != GameSaveBackupManager.BackupStorage.STEAM_CLOUD
-    val isReadOnlyCloudGroup = entry.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD
+        when (entry.storage) {
+            GameSaveBackupManager.BackupStorage.GOG_CLOUD -> false
+            GameSaveBackupManager.BackupStorage.STEAM_CLOUD -> cloudRestorable
+            else -> true
+        }
+    val isReadOnlyCloudGroup =
+        entry.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD && !cloudRestorable
     Row(
         modifier =
             Modifier

--- a/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
+++ b/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
@@ -166,6 +166,38 @@ internal fun CloudSavesContent(
         }
     var gogZipBusy by remember { mutableStateOf(false) }
     var googleBackupBusy by remember { mutableStateOf(false) }
+    var pendingCloudFileDownload by remember {
+        mutableStateOf<GameSaveBackupManager.BackupHistoryEntry?>(null)
+    }
+    val cloudFileDownloadLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
+            val entry = pendingCloudFileDownload
+            pendingCloudFileDownload = null
+            if (uri == null || entry == null) return@rememberLauncherForActivityResult
+            val appId = gameId.toIntOrNull() ?: return@rememberLauncherForActivityResult
+            scope.launch {
+                val ok =
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            val bytes = SteamCloudHistoryProvider.downloadFileBytes(appId, entry.fileId)
+                            if (bytes == null) {
+                                false
+                            } else {
+                                context.contentResolver.openOutputStream(uri)?.use { output ->
+                                    output.write(bytes)
+                                    true
+                                } ?: false
+                            }
+                        }.getOrDefault(false)
+                    }
+                notify(
+                    context.getString(
+                        if (ok) R.string.cloud_saves_history_download_success else R.string.cloud_saves_history_download_failed,
+                    ),
+                    Toast.LENGTH_SHORT,
+                )
+            }
+        }
     val gogZipLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
             if (uri == null) return@rememberLauncherForActivityResult
@@ -732,6 +764,15 @@ internal fun CloudSavesContent(
             },
             onRestore = { entry -> entryPendingRestore = entry },
             onRename = { entry -> entryPendingRename = entry },
+            onDownload = { entry ->
+                pendingCloudFileDownload = entry
+                runCatching {
+                    cloudFileDownloadLauncher.launch(entry.fileName.substringAfterLast('/'))
+                }.onFailure {
+                    pendingCloudFileDownload = null
+                    notify(context.getString(R.string.cloud_saves_history_download_failed), Toast.LENGTH_SHORT)
+                }
+            },
         )
 
         if (showBottomBack) {
@@ -1062,6 +1103,7 @@ private fun SaveHistorySection(
     onRefresh: () -> Unit,
     onRestore: (GameSaveBackupManager.BackupHistoryEntry) -> Unit,
     onRename: (GameSaveBackupManager.BackupHistoryEntry) -> Unit,
+    onDownload: (GameSaveBackupManager.BackupHistoryEntry) -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
@@ -1124,18 +1166,12 @@ private fun SaveHistorySection(
                 }
 
                 else -> {
-                    // Steam Cloud stores only the current version of each file, so only the newest group actually matches what a restore downloads; older groups stay read-only.
-                    val newestCloudGroupId =
-                        entries
-                            .filter { it.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD }
-                            .maxByOrNull { it.timestampMs }
-                            ?.fileId
                     entries.forEachIndexed { index, entry ->
                         SaveHistoryRow(
                             entry = entry,
-                            cloudRestorable = entry.fileId == newestCloudGroupId,
                             onRestore = { onRestore(entry) },
                             onRename = { onRename(entry) },
+                            onDownload = { onDownload(entry) },
                         )
                         if (index < entries.lastIndex) {
                             HorizontalDivider(
@@ -1153,9 +1189,9 @@ private fun SaveHistorySection(
 @Composable
 private fun SaveHistoryRow(
     entry: GameSaveBackupManager.BackupHistoryEntry,
-    cloudRestorable: Boolean = false,
     onRestore: () -> Unit,
     onRename: () -> Unit,
+    onDownload: () -> Unit,
 ) {
     val whenLabel =
         remember(entry.timestampMs) {
@@ -1176,15 +1212,11 @@ private fun SaveHistoryRow(
             GameSaveBackupManager.BackupStorage.EPIC_CLOUD -> stringResource(R.string.cloud_saves_history_storage_epic)
             GameSaveBackupManager.BackupStorage.GOG_CLOUD -> stringResource(R.string.cloud_saves_history_storage_gog)
         }
-    // STEAM_CLOUD "groups" view the CURRENT cloud file list (no server-side version history); only the newest group is restorable (downloads the current cloud state) — per-entry rollback lives in STEAM_LOCAL snapshots.
+    // STEAM_CLOUD entries mirror Steam's remote-storage website: one row per current cloud file, downloadable — no fake version history. Per-entry rollback lives in STEAM_LOCAL snapshots.
     val canRestore =
-        when (entry.storage) {
-            GameSaveBackupManager.BackupStorage.GOG_CLOUD -> false
-            GameSaveBackupManager.BackupStorage.STEAM_CLOUD -> cloudRestorable
-            else -> true
-        }
-    val isReadOnlyCloudGroup =
-        entry.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD && !cloudRestorable
+        entry.storage != GameSaveBackupManager.BackupStorage.GOG_CLOUD &&
+            entry.storage != GameSaveBackupManager.BackupStorage.STEAM_CLOUD
+    val canDownload = entry.storage == GameSaveBackupManager.BackupStorage.STEAM_CLOUD
     Row(
         modifier =
             Modifier
@@ -1273,13 +1305,12 @@ private fun SaveHistoryRow(
                     onClick = onRestore,
                 )
                 Spacer(Modifier.width(6.dp))
-            } else if (isReadOnlyCloudGroup) {
-                Text(
-                    text = stringResource(R.string.cloud_saves_history_cloud_readonly),
-                    color = TextSecondary,
-                    fontSize = 8.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    letterSpacing = 0.5.sp,
+            } else if (canDownload) {
+                HistoryActionChip(
+                    icon = Icons.Outlined.Download,
+                    label = stringResource(R.string.cloud_saves_history_download),
+                    tint = CloudAccent,
+                    onClick = onDownload,
                 )
                 Spacer(Modifier.width(6.dp))
             }

--- a/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
+++ b/app/src/main/feature/sync/ui/CloudSavesUIContent.kt
@@ -24,8 +24,11 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -1166,18 +1169,27 @@ private fun SaveHistorySection(
                 }
 
                 else -> {
-                    entries.forEachIndexed { index, entry ->
-                        SaveHistoryRow(
-                            entry = entry,
-                            onRestore = { onRestore(entry) },
-                            onRename = { onRename(entry) },
-                            onDownload = { onDownload(entry) },
-                        )
-                        if (index < entries.lastIndex) {
-                            HorizontalDivider(
-                                color = CloudBorder.copy(alpha = 0.7f),
-                                modifier = Modifier.padding(horizontal = 10.dp),
+                    // Scrolls within a bounded panel so long histories aren't cut off on hosts without their own scrolling.
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 360.dp)
+                                .verticalScroll(rememberScrollState()),
+                    ) {
+                        entries.forEachIndexed { index, entry ->
+                            SaveHistoryRow(
+                                entry = entry,
+                                onRestore = { onRestore(entry) },
+                                onRename = { onRename(entry) },
+                                onDownload = { onDownload(entry) },
                             )
+                            if (index < entries.lastIndex) {
+                                HorizontalDivider(
+                                    color = CloudBorder.copy(alpha = 0.7f),
+                                    modifier = Modifier.padding(horizontal = 10.dp),
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1366,6 +1366,9 @@ Installed path:
     <string name="cloud_saves_history_storage_epic">Epic</string>
     <string name="cloud_saves_history_storage_gog">GOG</string>
     <string name="cloud_saves_history_restore">Restore</string>
+    <string name="cloud_saves_history_download">Download</string>
+    <string name="cloud_saves_history_download_success">File downloaded.</string>
+    <string name="cloud_saves_history_download_failed">Download failed.</string>
     <string name="cloud_saves_history_cloud_readonly">Read-only</string>
     <string name="cloud_saves_history_restore_confirm_title">Restore this backup?</string>
     <string name="cloud_saves_history_restore_confirm_body">This will replace your current local save with the backup from %1$s.</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -3263,6 +3263,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                         SteamExitCloudSync.syncOnExit(
                                 this,
                                 shortcut,
+                                container,
                                 text -> preloaderDialog.showOnUiThread(text),
                                 result ->
                                         callback.onComplete(


### PR DESCRIPTION
- Exit sync and its rollback snapshot now use the container the session actually ran in (or the resolved container_id override) instead of the stale shortcut.container
- Exit sync uses SaveLocation.None so unchanged saves never upload and a both-sides-changed state surfaces as a Steam conflict instead of overwriting the newer cloud copy
- Bionic hand-off skips the Android exit sync unconditionally so the in-Wine Steam client is the only cloud writer during hand-off
- Change-number reconcile uploads new local-only save files instead of silently baselining them out of the cloud
- Snapshot restore/import push to Steam Cloud with the same container they restored into; snapshot capture aborts on container activation failure; restore extraction is limited to the snapshot's own roots
- Conflict-dialog discarded-save backups and local-save detection use the resolved shortcut container