### PR TITLE
Fix import save zips. 

### DIFF
--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -1753,42 +1753,38 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 WinNativeComposeDialogs.showLoading(context, context.getString(R.string.common_ui_loading))
             }
             try {
-                zipFile.inputStream().use { isStream ->
-                    java.util.zip.ZipInputStream(java.io.BufferedInputStream(isStream)).use { zis ->
-                        val usersDir = File(container.getRootDir(), ".wine/drive_c/users")
-                        val xuserDir = File(usersDir, "xuser")
+                java.util.zip.ZipFile(zipFile).use { zf ->
+                    val usersDir = File(container.getRootDir(), ".wine/drive_c/users")
+                    val xuserDir = File(usersDir, "xuser")
 
-                        var ze: java.util.zip.ZipEntry?
-                        while (zis.nextEntry.also { ze = it } != null) {
-                            val entry = ze!!
-                            val name = entry.name
+                    val entries = zf.entries()
+                    while (entries.hasMoreElements()) {
+                        val entry = entries.nextElement()
+                        val name = entry.name
 
-                            if (isPathExcluded(name)) {
-                                zis.closeEntry()
-                                continue
-                            }
+                        if (isPathExcluded(name)) continue
 
-                            var destFile: File? = null
+                        var destFile: File? = null
 
-                            if (name.startsWith("users/")) {
-                                destFile = File(usersDir.parentFile, name)
-                            } else if (name.startsWith("ProgramData/")) {
-                                destFile = File(usersDir.parentFile, name)
-                            } else if (name.startsWith("xuser/")) {
-                                destFile = File(usersDir, name)
-                            } else if (name.startsWith("Documents/") || name.startsWith("Saved Games/") || name.startsWith("AppData/")) {
-                                destFile = File(xuserDir, name)
-                            }
+                        if (name.startsWith("users/")) {
+                            destFile = File(usersDir.parentFile, name)
+                        } else if (name.startsWith("ProgramData/")) {
+                            destFile = File(usersDir.parentFile, name)
+                        } else if (name.startsWith("xuser/")) {
+                            destFile = File(usersDir, name)
+                        } else if (name.startsWith("Documents/") || name.startsWith("Saved Games/") || name.startsWith("AppData/")) {
+                            destFile = File(xuserDir, name)
+                        }
 
-                            if (destFile != null) {
-                                if (entry.isDirectory) {
-                                    destFile.mkdirs()
-                                } else {
-                                    destFile.parentFile?.mkdirs()
-                                    destFile.outputStream().use { zis.copyTo(it) }
+                        if (destFile != null) {
+                            if (entry.isDirectory) {
+                                destFile.mkdirs()
+                            } else {
+                                destFile.parentFile?.mkdirs()
+                                zf.getInputStream(entry).use { input ->
+                                    destFile.outputStream().use { input.copyTo(it) }
                                 }
                             }
-                            zis.closeEntry()
                         }
                     }
                 }

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -65,7 +65,7 @@ const val XSERVER_DRAWER_OPEN_TRIGGER_DP = 32
 // Open only on a clearly rightward swipe: dx must exceed this * |dy| (~27deg of horizontal).
 const val XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO = 2f
 
-private val DrawerWidth = 305.dp
+private val DrawerWidth = 300.dp
 private val DrawerStartPadding = 6.dp
 private val DrawerVerticalPadding = 6.dp
 private const val DrawerSettleAnimationMs = 200


### PR DESCRIPTION
Changes from ZipInputStream to ZipFile on import saves so zips safely read before importing. Fixing this error.
Failed to import saves: Unexpected end of ZLIB input stream