### PR TITLE
Skip FPS HUD per-frame recording when the HUD is hidden

### DIFF
--- a/app/src/main/feature/leaderboard/SessionRecordingController.kt
+++ b/app/src/main/feature/leaderboard/SessionRecordingController.kt
@@ -115,6 +115,9 @@ class SessionRecordingController(
         frameRating.setFrameObserver(this)
     }
 
+    /** True while a recording session is running (record-to-file on). */
+    fun isActive(): Boolean = active.get()
+
     override fun onFramePresent(nanoTime: Long) {
         collector?.onFramePresent(nanoTime)
         recorder?.recordFramePresent(nanoTime)

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1226,7 +1226,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
         boolean recordToFile = preferences.getBoolean("hud_record_to_file", false);
         perfController = new SessionRecordingController(this);
-        perfController.start(shortcut, container, recordToFile);
+        // Only sample per-frame stats when recording to file is on; nothing else consumes them.
+        if (recordToFile) perfController.start(shortcut, container, recordToFile);
 
         int numControllers = 1;
         if (shortcut != null) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -11202,7 +11202,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     }
 
     private boolean shouldRecordFpsFrame(Window window, WindowManager.FrameSource source) {
-        if ((!effectiveShowFPS && !controllerHudMode) || frameRating == null || window == null) return false;
+        // Perf recording is driven solely by the record-to-file toggle, independent of HUD/controller.
+        boolean recording = perfController != null && perfController.isActive();
+        if ((!effectiveShowFPS && !controllerHudMode && !recording) || frameRating == null || window == null) return false;
         if (source == WindowManager.FrameSource.UNKNOWN) return false;
         if (frameRatingWindowId == window.id) return true;
         if (isRelatedToFrameRatingWindow(window)) return true;


### PR DESCRIPTION
recordGameFrame ran an observer call and method work on every guest present before the visibility check. Return early with no per-present work unless the HUD is showing or a frame recorder is attached.