### PR TITLE
Fix Steam download failures and dead Retry/Resume

### DIFF
--- a/app/src/main/app/service/download/DownloadCoordinator.kt
+++ b/app/src/main/app/service/download/DownloadCoordinator.kt
@@ -37,6 +37,9 @@ object DownloadCoordinator {
 
         /** Cancel a running download and delete partial files. */
         fun cancelRunning(record: DownloadRecord)
+
+        /** True while the store has a live transfer for this record. */
+        fun isTransferActive(record: DownloadRecord): Boolean = true
     }
 
     private val mutex = Mutex()
@@ -237,7 +240,30 @@ object DownloadCoordinator {
                 }
                 tick()
             }
+            DownloadRecord.STATUS_DOWNLOADING -> {
+                // Requeue records wedged in DOWNLOADING with no live transfer so Retry works.
+                val live = dispatchers[store]?.isTransferActive(record) ?: false
+                if (!live) {
+                    Timber.w("resume: requeuing wedged DOWNLOADING record ${record.store}/${record.storeGameId}")
+                    mutex.withLock {
+                        daoRef.updateStatus(record.id, DownloadRecord.STATUS_QUEUED)
+                        refreshState(daoRef)
+                    }
+                    tick()
+                }
+            }
             else -> Unit
+        }
+    }
+
+    /** Put a just-dispatched record back in the queue without ticking; a later tick() retries it. */
+    suspend fun requeue(store: String, storeGameId: String) {
+        val daoRef = dao ?: return
+        val record = daoRef.findByStoreGame(store, storeGameId) ?: return
+        if (record.status != DownloadRecord.STATUS_DOWNLOADING) return
+        mutex.withLock {
+            daoRef.updateStatus(record.id, DownloadRecord.STATUS_QUEUED)
+            refreshState(daoRef)
         }
     }
 

--- a/app/src/main/cpp/wn-steam-client/rust/src/depot_downloader.rs
+++ b/app/src/main/cpp/wn-steam-client/rust/src/depot_downloader.rs
@@ -247,6 +247,9 @@ pub fn map_write_progress(
 
 pub type DepotProgressCallback<'a> = &'a (dyn Fn(&DepotDownloadProgress) + Sync);
 
+/// Returns a fresh manifest request code for (depot_id, manifest_id); Steam rotates codes ~every 5 min.
+pub type ManifestCodeRefresher<'a> = &'a (dyn Fn(u32, u64) -> Option<u64> + Sync);
+
 pub fn download_resolved_depots(
     install_dir: &str,
     depots: &[ResolvedDepotSpec],
@@ -262,6 +265,7 @@ pub fn download_resolved_depots(
         ca_bundle_path,
         fresh,
         max_workers,
+        None,
         None,
         None,
     )
@@ -285,6 +289,7 @@ pub fn download_resolved_depots_with_cancel(
         max_workers,
         cancel,
         None,
+        None,
     )
 }
 
@@ -297,6 +302,7 @@ pub fn download_resolved_depots_with_cancel_progress(
     max_workers: u32,
     cancel: Option<&AtomicBool>,
     on_progress: Option<DepotProgressCallback<'_>>,
+    code_refresher: Option<ManifestCodeRefresher<'_>>,
 ) -> DepotDownloadResult {
     if let Err(error) = validate_resolved_download_inputs(install_dir, depots, servers) {
         return error;
@@ -365,15 +371,36 @@ pub fn download_resolved_depots_with_cancel_progress(
                 if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
                     return DepotDownloadResult::fail("cancelled");
                 }
-                let manifest = fetch_manifest_with_retry(
+                // Prefer a code obtained now; the pre-resolved one may have expired.
+                let refreshed_code = code_refresher
+                    .and_then(|refresh| refresh(depot.depot_id, depot.manifest_id));
+                let request_code = refreshed_code.unwrap_or(depot.manifest_request_code);
+                let mut manifest = fetch_manifest_with_retry(
                     &cdn,
                     &usable_servers,
                     depot.depot_id,
                     depot.manifest_id,
-                    depot.manifest_request_code,
+                    request_code,
                     "",
                     CdnClient::default_timeout(),
                 );
+                if !manifest.ok() {
+                    // One more pass with a code obtained after the failed attempts.
+                    if let Some(fresh) = code_refresher
+                        .and_then(|refresh| refresh(depot.depot_id, depot.manifest_id))
+                        .filter(|fresh| *fresh != request_code)
+                    {
+                        manifest = fetch_manifest_with_retry(
+                            &cdn,
+                            &usable_servers,
+                            depot.depot_id,
+                            depot.manifest_id,
+                            fresh,
+                            "",
+                            CdnClient::default_timeout(),
+                        );
+                    }
+                }
                 if !manifest.ok() {
                     return DepotDownloadResult::fail(format!(
                         "download: manifest fetch failed for depot {}: {}",

--- a/app/src/main/cpp/wn-steam-client/rust/src/jni.rs
+++ b/app/src/main/cpp/wn-steam-client/rust/src/jni.rs
@@ -3436,6 +3436,22 @@ pub extern "system" fn Java_com_winlator_cmod_feature_stores_steam_wnsteam_WnSte
             dispatch_download_progress(&progress_listener, progress);
         };
         let progress_cb: crate::depot_downloader::DepotProgressCallback = &progress;
+        // Re-resolve manifest request codes right before each depot's manifest fetch.
+        let code_refresher = |depot_id: u32, manifest_id: u64| -> Option<u64> {
+            match resolve_manifest_code_with_retry(
+                &runtime,
+                app_id,
+                depot_id,
+                manifest_id,
+                &branch,
+                timeout,
+                download_cancel.as_ref(),
+            ) {
+                CodeResolution::Code(code) => Some(code),
+                _ => None,
+            }
+        };
+        let code_refresher_cb: crate::depot_downloader::ManifestCodeRefresher = &code_refresher;
         let result =
             crate::depot_downloader::download_resolved_depots_with_cancel_progress(
                 &install_dir,
@@ -3446,6 +3462,7 @@ pub extern "system" fn Java_com_winlator_cmod_feature_stores_steam_wnsteam_WnSte
                 max_workers,
                 Some(download_cancel.as_ref()),
                 Some(progress_cb),
+                Some(code_refresher_cb),
             );
         dispatch_download_complete(listener, result);
     });

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -4063,7 +4063,13 @@ class SteamService : Service() {
                                 throw e
                             } catch (e: Exception) {
                                 Timber.e(e, "Download failed for app $appId")
-                                clearFailedResumeState(appId)
+                                // Transient failures keep resume state so Retry continues from the same offset.
+                                val isTransientFailure = e is WnDownloadTransientException
+                                if (isTransientFailure) {
+                                    runCatching { di.persistProgressSnapshot(force = true) }
+                                } else {
+                                    clearFailedResumeState(appId)
+                                }
 
                                 val errorMsg =
                                     when (e) {
@@ -4078,9 +4084,11 @@ class SteamService : Service() {
                                 if (downloadTaskType == DownloadRecord.TASK_UPDATE) {
                                     MarkerUtils.removeMarker(appDirPath, Marker.DOWNLOAD_COMPLETE_MARKER)
                                 }
-                                runBlocking {
-                                    instance?.downloadingAppInfoDao?.deleteApp(appId)
-                                    Unit
+                                if (!isTransientFailure) {
+                                    runBlocking {
+                                        instance?.downloadingAppInfoDao?.deleteApp(appId)
+                                        Unit
+                                    }
                                 }
                                 runBlocking {
                                     DownloadCoordinator.notifyFinished(
@@ -7467,7 +7475,26 @@ class SteamService : Service() {
     private val coordinatorDispatcher =
         object : DownloadCoordinator.Dispatcher {
             override fun startQueued(record: DownloadRecord) {
-                val appId = record.storeGameId.toIntOrNull() ?: return
+                val appId = record.storeGameId.toIntOrNull()
+                if (appId == null) {
+                    runBlocking {
+                        DownloadCoordinator.notifyFinished(
+                            DownloadRecord.STORE_STEAM,
+                            record.storeGameId,
+                            DownloadRecord.STATUS_FAILED,
+                            "Invalid Steam app id '${record.storeGameId}'",
+                        )
+                    }
+                    return
+                }
+                // No AppInfo yet (pre-login dispatch): requeue; the post-logon tick retries it.
+                if (getAppInfoOf(appId) == null) {
+                    Timber.w("startQueued: no AppInfo yet for appId=$appId — requeueing until Steam data is ready")
+                    runBlocking {
+                        DownloadCoordinator.requeue(DownloadRecord.STORE_STEAM, record.storeGameId)
+                    }
+                    return
+                }
                 // Drop any stale queued/paused DownloadInfo BEFORE downloadApp(), else it finds the inactive entry and calls removeDownloadJob() (firing the legacy checkQueue() + an extra notify) before building a fresh one.
                 downloadJobs.remove(appId)
                 // selectedDlcs carries authoritative DLC app IDs for installs; for updates it carries the changed depot IDs from checkForAppUpdate() so queued updates keep the narrowed scope.
@@ -7475,13 +7502,31 @@ class SteamService : Service() {
                     record.selectedDlcs
                         .split(',')
                         .mapNotNull { it.trim().toIntOrNull() }
-                if (record.taskType == DownloadRecord.TASK_UPDATE) {
-                    downloadAppForUpdate(appId, persistedIds)
-                } else if (record.taskType == DownloadRecord.TASK_VERIFY) {
-                    downloadAppForVerify(appId)
-                } else {
-                    downloadApp(appId, persistedIds)
+                val started =
+                    if (record.taskType == DownloadRecord.TASK_UPDATE) {
+                        downloadAppForUpdate(appId, persistedIds)
+                    } else if (record.taskType == DownloadRecord.TASK_VERIFY) {
+                        downloadAppForVerify(appId)
+                    } else {
+                        downloadApp(appId, persistedIds)
+                    }
+                if (started == null) {
+                    // Mark FAILED so the slot frees and Retry stays functional.
+                    Timber.e("startQueued: downloadApp returned null for appId=$appId (task=${record.taskType}) — marking record FAILED")
+                    runBlocking {
+                        DownloadCoordinator.notifyFinished(
+                            DownloadRecord.STORE_STEAM,
+                            record.storeGameId,
+                            DownloadRecord.STATUS_FAILED,
+                            "Could not start download — retry after Steam finishes loading",
+                        )
+                    }
                 }
+            }
+
+            override fun isTransferActive(record: DownloadRecord): Boolean {
+                val appId = record.storeGameId.toIntOrNull() ?: return false
+                return downloadJobs[appId]?.isActive() == true
             }
 
             override fun pauseRunning(record: DownloadRecord) {
@@ -8132,6 +8177,9 @@ class SteamService : Service() {
         com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient
             .setCloudEnabledForAccount(true)
 
+
+        // Start downloads that were requeued while AppInfo wasn't loaded yet.
+        DownloadCoordinator.blockingTick()
 
         // retrieve persona data of logged in user
         scope.launch { requestUserPersona() }


### PR DESCRIPTION
- Handle downloadApp() null returns in startQueued: requeue when AppInfo isn't loaded yet, otherwise mark the record FAILED instead of leaving it wedged in DOWNLOADING (which blocked the slot and made Retry a no-op)
- Let resume() requeue DOWNLOADING records with no live transfer via new Dispatcher.isTransferActive, unwedging already-stuck downloads
- Tick the download queue after Steam logon so requeued records start
- Refresh manifest request codes right before each depot's manifest fetch (Steam rotates them ~every 5 min, so codes pre-resolved at download start expired for later depots of multi-depot games, causing 401 manifest fetch failures)
- Keep resume state on transient download failures so Retry continues from the same offset instead of restarting