### PR TITLE
Add optional Steam chat service toggle to chat settings

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -1940,6 +1940,7 @@ class UnifiedActivity :
             if (!drawerState.isOpen) drawerNavBridge.controllerActive = false
         }
         val isLoggedIn by SteamService.isLoggedInFlow.collectAsState()
+        val chatServiceEnabled by SteamService.chatServiceEnabledFlow.collectAsState()
         val isEpicLoggedIn by EpicAuthManager.isLoggedInFlow.collectAsState()
         val isGogLoggedIn by GOGAuthManager.isLoggedInFlow.collectAsState()
         val steamApps by db.steamAppDao().getAllOwnedApps().collectAsState(initial = emptyList())
@@ -1967,24 +1968,24 @@ class UnifiedActivity :
             installedFriendGameIds =
                 withContext(Dispatchers.IO) { ids.filter { SteamService.isAppInstalled(it) }.toSet() }
         }
-        LaunchedEffect(isLoggedIn) {
-            if (isLoggedIn) {
+        LaunchedEffect(isLoggedIn, chatServiceEnabled) {
+            if (isLoggedIn && chatServiceEnabled) {
                 while (true) {
                     runCatching { SteamService.instance?.refreshFriends() }
                     kotlinx.coroutines.delay(30_000L)
                 }
             }
         }
-        LaunchedEffect(isLoggedIn, friendsDrawerOpen) {
-            if (isLoggedIn && friendsDrawerOpen) {
+        LaunchedEffect(isLoggedIn, friendsDrawerOpen, chatServiceEnabled) {
+            if (isLoggedIn && friendsDrawerOpen && chatServiceEnabled) {
                 while (true) {
                     runCatching { SteamService.instance?.syncFriendsPresence() }
                     kotlinx.coroutines.delay(5_000L)
                 }
             }
         }
-        LaunchedEffect(isLoggedIn) {
-            if (isLoggedIn) {
+        LaunchedEffect(isLoggedIn, chatServiceEnabled) {
+            if (isLoggedIn && chatServiceEnabled) {
                 runCatching { com.winlator.cmod.feature.stores.steam.chat.ChatOverlayService.start(context) }
             }
         }
@@ -2251,6 +2252,7 @@ class UnifiedActivity :
                         self = persona ?: com.winlator.cmod.feature.stores.steam.data.SteamFriend(),
                         friends = friends,
                         installedGameIds = installedFriendGameIds,
+                        chatEnabled = chatServiceEnabled,
                         onSetState = { st -> scope.launch { SteamService.setPersonaState(st) } },
                         onOpenChat = { f -> chatFriend = f; scope.launch { rightDrawerState.close() } },
                         onJoinGame = { f ->

--- a/app/src/main/feature/stores/steam/friends/FriendsDrawerContent.kt
+++ b/app/src/main/feature/stores/steam/friends/FriendsDrawerContent.kt
@@ -65,6 +65,7 @@ import com.winlator.cmod.feature.stores.steam.chat.ChatOverlayService
 import com.winlator.cmod.feature.stores.steam.data.SteamFriend
 import com.winlator.cmod.feature.stores.steam.data.SteamFriendEntry
 import com.winlator.cmod.feature.stores.steam.enums.EPersonaState
+import com.winlator.cmod.feature.stores.steam.service.SteamService
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 import com.winlator.cmod.shared.ui.nav.DialogPaneNav
 import com.winlator.cmod.shared.ui.nav.LocalPaneNav
@@ -107,6 +108,7 @@ fun FriendsDrawerContent(
     self: SteamFriend,
     friends: List<SteamFriendEntry>,
     installedGameIds: Set<Int>,
+    chatEnabled: Boolean,
     onSetState: (EPersonaState) -> Unit,
     onOpenChat: (SteamFriendEntry) -> Unit,
     onJoinGame: (SteamFriendEntry) -> Unit,
@@ -139,43 +141,54 @@ fun FriendsDrawerContent(
                     .statusBarsPadding()
                     .padding(horizontal = 14.dp, vertical = 16.dp),
             ) {
-                SelfCard(self = self, onSetState = onSetState)
+                SelfCard(self = self, chatEnabled = chatEnabled, onSetState = onSetState)
                 Spacer(Modifier.height(14.dp))
-                Text(
-                    text = stringResource(R.string.steam_friends_count, friends.count { it.isOnline }),
-                    style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-                    color = TextSecondary,
-                    modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-                )
+                if (chatEnabled) {
+                    Text(
+                        text = stringResource(R.string.steam_friends_count, friends.count { it.isOnline }),
+                        style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
+                        color = TextSecondary,
+                        modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
+                    )
+                }
                 Column(
                     Modifier.fillMaxWidth().weight(1f).verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
-                    if (inGame.isNotEmpty()) {
-                        SectionHeader(stringResource(R.string.steam_friends_section_in_game, inGame.size))
-                        inGame.forEach {
-                            InGameFriendCard(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
-                        }
-                    }
-                    if (online.isNotEmpty()) {
-                        SectionHeader(stringResource(R.string.steam_friends_section_online, online.size))
-                        online.forEach {
-                            FriendRow(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
-                        }
-                    }
-                    if (offline.isNotEmpty()) {
-                        SectionHeader(stringResource(R.string.steam_friends_section_offline, offline.size))
-                        offline.forEach {
-                            FriendRow(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
-                        }
-                    }
-                    if (friends.isEmpty()) {
+                    if (!chatEnabled) {
                         Text(
-                            stringResource(R.string.steam_friends_none_loaded),
+                            stringResource(R.string.steam_friends_chat_off),
                             color = TextSecondary,
                             style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
                             modifier = Modifier.padding(12.dp),
                         )
+                    } else {
+                        if (inGame.isNotEmpty()) {
+                            SectionHeader(stringResource(R.string.steam_friends_section_in_game, inGame.size))
+                            inGame.forEach {
+                                InGameFriendCard(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
+                            }
+                        }
+                        if (online.isNotEmpty()) {
+                            SectionHeader(stringResource(R.string.steam_friends_section_online, online.size))
+                            online.forEach {
+                                FriendRow(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
+                            }
+                        }
+                        if (offline.isNotEmpty()) {
+                            SectionHeader(stringResource(R.string.steam_friends_section_offline, offline.size))
+                            offline.forEach {
+                                FriendRow(it, it.gameAppId in installedGameIds, onOpenChat, onJoinGame, onPlayGame)
+                            }
+                        }
+                        if (friends.isEmpty()) {
+                            Text(
+                                stringResource(R.string.steam_friends_none_loaded),
+                                color = TextSecondary,
+                                style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(12.dp),
+                            )
+                        }
                     }
                 }
             }
@@ -195,9 +208,11 @@ private fun SectionHeader(text: String) {
 }
 
 @Composable
-private fun SelfCard(self: SteamFriend, onSetState: (EPersonaState) -> Unit) {
+private fun SelfCard(self: SteamFriend, chatEnabled: Boolean, onSetState: (EPersonaState) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     var showChatSettings by remember { mutableStateOf(false) }
+    // Chat off => you're offline; show that on the card and hide the status picker.
+    val displayState = if (chatEnabled) self.state else EPersonaState.Offline
     Surface(
         shape = RoundedCornerShape(16.dp),
         color = SurfaceDark,
@@ -206,7 +221,7 @@ private fun SelfCard(self: SteamFriend, onSetState: (EPersonaState) -> Unit) {
     ) {
         Column(Modifier.padding(14.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Avatar(self.avatarHashUrl(), 44.dp, statusColor(self.state))
+                Avatar(self.avatarHashUrl(), 44.dp, statusColor(displayState))
                 Spacer(Modifier.width(12.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
@@ -218,10 +233,10 @@ private fun SelfCard(self: SteamFriend, onSetState: (EPersonaState) -> Unit) {
                         overflow = TextOverflow.Ellipsis,
                     )
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Box(Modifier.size(8.dp).clip(CircleShape).background(statusColor(self.state)))
+                        Box(Modifier.size(8.dp).clip(CircleShape).background(statusColor(displayState)))
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            statusLabel(self.state),
+                            statusLabel(displayState),
                             color = TextSecondary,
                             style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
                         )
@@ -238,18 +253,20 @@ private fun SelfCard(self: SteamFriend, onSetState: (EPersonaState) -> Unit) {
                         .padding(6.dp)
                         .size(20.dp),
                 )
-                Spacer(Modifier.width(2.dp))
-                Text(
-                    if (expanded) "▲" else "▼",
-                    color = TextSecondary,
-                    modifier = Modifier
-                        .clip(CircleShape)
-                        .paneNavItem(onActivate = { expanded = !expanded }, tapToSelect = true)
-                        .clickable { expanded = !expanded }
-                        .padding(6.dp),
-                )
+                if (chatEnabled) {
+                    Spacer(Modifier.width(2.dp))
+                    Text(
+                        if (expanded) "▲" else "▼",
+                        color = TextSecondary,
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .paneNavItem(onActivate = { expanded = !expanded }, tapToSelect = true)
+                            .clickable { expanded = !expanded }
+                            .padding(6.dp),
+                    )
+                }
             }
-            AnimatedVisibility(visible = expanded) {
+            AnimatedVisibility(visible = expanded && chatEnabled) {
                 Column {
                     Spacer(Modifier.height(8.dp))
                     HorizontalDivider(color = TextSecondary.copy(alpha = 0.15f))
@@ -268,6 +285,7 @@ private fun SelfCard(self: SteamFriend, onSetState: (EPersonaState) -> Unit) {
 @Composable
 private fun ChatSettingsDialog(onDismiss: () -> Unit) {
     val context = LocalContext.current
+    var master by remember { mutableStateOf(PrefManager.chatServiceEnabled) }
     var notifications by remember { mutableStateOf(PrefManager.chatNotificationsEnabled) }
     var heads by remember { mutableStateOf(PrefManager.chatHeadsEnabled) }
     var autoHide by remember { mutableStateOf(PrefManager.chatHeadsAutoHide) }
@@ -338,20 +356,28 @@ private fun ChatSettingsDialog(onDismiss: () -> Unit) {
                 ) {
                     Column(Modifier.weight(1f)) {
                         ChatSettingToggle(
-                            stringResource(R.string.steam_chat_setting_notifications),
-                            stringResource(R.string.steam_chat_setting_notifications_desc),
-                            notifications,
+                            stringResource(R.string.steam_chat_setting_service),
+                            stringResource(R.string.steam_chat_setting_service_desc),
+                            master,
                             navRow = 1,
                             navCol = 0,
                             isEntry = true,
+                        ) { v -> master = v; SteamService.setChatServiceEnabled(context, v) }
+                        ChatSettingToggle(
+                            stringResource(R.string.steam_chat_setting_notifications),
+                            stringResource(R.string.steam_chat_setting_notifications_desc),
+                            notifications,
+                            navRow = 2,
+                            navCol = 0,
+                            enabled = master,
                         ) { v -> notifications = v; PrefManager.chatNotificationsEnabled = v }
                         ChatSettingToggle(
                             stringResource(R.string.steam_chat_setting_heads),
                             stringResource(R.string.steam_chat_setting_heads_desc),
                             heads,
-                            navRow = 2,
+                            navRow = 3,
                             navCol = 0,
-                            enabled = stayRunning,
+                            enabled = master && stayRunning,
                         ) { v ->
                             if (v) {
                                 if (android.provider.Settings.canDrawOverlays(context)) {
@@ -374,28 +400,31 @@ private fun ChatSettingsDialog(onDismiss: () -> Unit) {
                                 ChatOverlayService.stop(context)
                             }
                         }
+                    }
+                    Column(Modifier.weight(1f)) {
                         ChatSettingToggle(
                             stringResource(R.string.steam_chat_setting_autohide),
                             stringResource(R.string.steam_chat_setting_autohide_desc),
                             autoHide,
-                            navRow = 3,
-                            navCol = 0,
+                            navRow = 1,
+                            navCol = 1,
+                            enabled = master,
                         ) { v -> autoHide = v; PrefManager.chatHeadsAutoHide = v }
-                    }
-                    Column(Modifier.weight(1f)) {
                         ChatSettingToggle(
                             stringResource(R.string.steam_chat_setting_ingame),
                             stringResource(R.string.steam_chat_setting_ingame_desc),
                             inGame,
-                            navRow = 1,
+                            navRow = 2,
                             navCol = 1,
+                            enabled = master,
                         ) { v -> inGame = v; PrefManager.chatInGameEnabled = v }
                         ChatSettingToggle(
                             stringResource(R.string.steam_chat_setting_stay_running),
                             stringResource(R.string.steam_chat_setting_stay_running_desc),
                             stayRunning,
-                            navRow = 2,
+                            navRow = 3,
                             navCol = 1,
+                            enabled = master,
                         ) { v -> stayRunning = v; PrefManager.chatStayRunningOnExit = v }
                     }
                 }
@@ -438,7 +467,10 @@ private fun ChatSettingToggle(
         Spacer(Modifier.width(12.dp))
         Switch(
             checked = checked,
-            onCheckedChange = if (enabled) onChange else null,
+            // Keep the callback non-null so the switch keeps its 48dp minimum interactive size;
+            // `enabled = false` still blocks interaction. A null callback drops that min size and
+            // makes disabled switches shrink out of alignment.
+            onCheckedChange = onChange,
             enabled = enabled,
             colors = SwitchDefaults.colors(checkedTrackColor = Accent, checkedThumbColor = Color.White),
         )

--- a/app/src/main/feature/stores/steam/service/SteamService.kt
+++ b/app/src/main/feature/stores/steam/service/SteamService.kt
@@ -869,6 +869,24 @@ class SteamService : Service() {
         private val _isLoggedInFlow = MutableStateFlow(false)
         val isLoggedInFlow = _isLoggedInFlow.asStateFlow()
 
+        // Master chat switch (default on). When off, the Steam session stays logged on for
+        // downloads/library, but the chat layer is killed: offline presence, no message
+        // poller, no friends refresh, no chat overlay/notifications.
+        private val _chatServiceEnabledFlow = MutableStateFlow(true)
+        val chatServiceEnabledFlow = _chatServiceEnabledFlow.asStateFlow()
+
+        /** Flip the master chat switch: persists, updates the reactive flag, and applies at once (presence, poller, overlay). */
+        fun setChatServiceEnabled(context: Context, enabled: Boolean) {
+            PrefManager.chatServiceEnabled = enabled
+            _chatServiceEnabledFlow.value = enabled
+            instance?.applyChatServiceState(enabled)
+            if (!enabled) {
+                com.winlator.cmod.feature.stores.steam.chat.ChatOverlayService.stop(context)
+            } else if (PrefManager.chatHeadsEnabled) {
+                com.winlator.cmod.feature.stores.steam.chat.ChatOverlayService.start(context)
+            }
+        }
+
         /** Pure getter over [isLoggedInFlow] — never write the flow from a read (caused UI flicker on transient CM disconnect); only authoritative sources mutate it (initLoginStatus, onLoggedOn/Off, logOut, clearValues). */
         val isLoggedIn: Boolean
             get() = !isLoggingOut && _isLoggedInFlow.value
@@ -7606,6 +7624,8 @@ class SteamService : Service() {
         super.onCreate()
         instance = this
 
+        _chatServiceEnabledFlow.value = PrefManager.chatServiceEnabled
+
         notificationHelper = NotificationHelper(applicationContext)
         val notification = notificationHelper.createForegroundNotification("Steam Service is running")
         startForeground(1, notification)
@@ -7769,6 +7789,32 @@ class SteamService : Service() {
                     delay(backoffMs)
                 }
             }
+    }
+
+    /** Applies the master chat switch to a live session: enable → restart the message poller, go online (stored persona), refresh friends; disable → stop the poller and go offline. No-op until logged on (onWnLoggedOn handles cold start). */
+    private fun applyChatServiceState(enabled: Boolean) {
+        if (!isLoggedIn) return
+        if (enabled) {
+            messagePollerJob?.cancel()
+            messagePollerJob = continuousIncomingMessagePoller()
+            scope.launch {
+                val effectiveState =
+                    (EPersonaState.from(PrefManager.personaState) ?: EPersonaState.Online).code()
+                withWnSession { s -> s.setPersonaState(effectiveState) }
+                com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient
+                    .setPersonaState(effectiveState)
+            }
+            scope.launch { runCatching { refreshFriends() } }
+        } else {
+            messagePollerJob?.cancel()
+            messagePollerJob = null
+            scope.launch {
+                val offline = EPersonaState.Offline.code()
+                withWnSession { s -> s.setPersonaState(offline) }
+                com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient
+                    .setPersonaState(offline)
+            }
+        }
     }
 
     private fun ensureHealthySessionImpl() {
@@ -8224,15 +8270,19 @@ class SteamService : Service() {
         picsGetProductInfoJob?.cancel()
         picsGetProductInfoJob = continuousPICSGetProductInfo()
         messagePollerJob?.cancel()
-        messagePollerJob = continuousIncomingMessagePoller()
+        messagePollerJob = if (PrefManager.chatServiceEnabled) continuousIncomingMessagePoller() else null
 
         // Repair legacy depots whose stored download>size was frozen by the change-number skip.
         healCorruptManifestDownloadSizes()
 
-        // Tell steam we're online, this allows friends to update.
+        // Tell steam our presence — online (stored persona) when chat is on, offline when the master switch is off — this lets friends update.
         scope.launch {
             val effectiveState =
-                (EPersonaState.from(PrefManager.personaState) ?: EPersonaState.Online).code()
+                if (!PrefManager.chatServiceEnabled) {
+                    EPersonaState.Offline.code()
+                } else {
+                    (EPersonaState.from(PrefManager.personaState) ?: EPersonaState.Online).code()
+                }
             withWnSession { s -> s.setPersonaState(effectiveState) }
             com.winlator.cmod.feature.stores.steam.wnsteam.WnLibSteamClient
                 .setPersonaState(effectiveState)

--- a/app/src/main/feature/stores/steam/utils/PrefManager.kt
+++ b/app/src/main/feature/stores/steam/utils/PrefManager.kt
@@ -324,6 +324,12 @@ object PrefManager {
             setString("gog_download_folder", value)
         }
 
+    var chatServiceEnabled: Boolean
+        get() = getBoolean("chat_service_enabled", true)
+        set(value) {
+            setBoolean("chat_service_enabled", value)
+        }
+
     var chatNotificationsEnabled: Boolean
         get() = getBoolean("chat_notifications_enabled", true)
         set(value) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1501,6 +1501,7 @@ Installed path:
     <string name="steam_friends_section_online">Online (%1$d)</string>
     <string name="steam_friends_section_offline">Offline (%1$d)</string>
     <string name="steam_friends_none_loaded">No friends loaded yet.</string>
+    <string name="steam_friends_chat_off">Chat is off. Turn Chat Service back on to see your friends.</string>
     <string name="steam_friends_self_you">You</string>
     <string name="steam_friends_in_game">In game</string>
     <string name="steam_friends_join">Join</string>
@@ -1526,6 +1527,8 @@ Installed path:
     <string name="steam_join_the_game">the game</string>
     <string name="steam_friends_settings">Settings</string>
     <string name="steam_chat_settings_title">Chat Settings</string>
+    <string name="steam_chat_setting_service">Chat Service</string>
+    <string name="steam_chat_setting_service_desc">Sign in to friends and chat; turn off to go offline</string>
     <string name="steam_chat_setting_notifications">Chat Notifications</string>
     <string name="steam_chat_setting_notifications_desc">Show a notification when you receive a message</string>
     <string name="steam_chat_setting_heads">Chat Heads</string>


### PR DESCRIPTION
Master on/off switch (default on), first option in chat settings. When off: go offline, stop the message poller, friends refresh and chat overlay, and hide the friends list; Steam stays signed in for downloads. Keep disabled toggles at their minimum interactive size so they stay uniform.