### PR TITLE
Yet another app log fix

### DIFF
--- a/app/src/main/app/PluviaApp.kt
+++ b/app/src/main/app/PluviaApp.kt
@@ -237,8 +237,6 @@ class PluviaApp : Application() {
                 }.onFailure { Log.e("PluviaApp", "DownloadCoordinator startup failed", it) }
 
                 com.winlator.cmod.runtime.system.LogManager
-                    .rotateLogsOnAppStart(this@PluviaApp)
-                com.winlator.cmod.runtime.system.LogManager
                     .startAppLogging(this@PluviaApp)
 
                 if (steamLogsEnabled) {

--- a/app/src/main/feature/settings/debug/DebugFragment.kt
+++ b/app/src/main/feature/settings/debug/DebugFragment.kt
@@ -76,7 +76,7 @@ class DebugFragment : Fragment() {
                                     .setEnabled(checked)
                                 if (checked) {
                                     com.winlator.cmod.runtime.system.LogManager
-                                        .startAppLogging(ctx)
+                                        .startAppLogging(ctx, reset = true)
                                 } else {
                                     com.winlator.cmod.runtime.system.LogManager
                                         .stopAppLogging()

--- a/app/src/main/runtime/system/LogManager.kt
+++ b/app/src/main/runtime/system/LogManager.kt
@@ -36,24 +36,11 @@ object LogManager {
     }
 
     @JvmStatic
-    fun rotateLogsOnAppStart(context: Context) {
-        if (!isAnyLoggingEnabled(context)) return
-        val logsDir = getLogsDir(context)
-        logsDir.listFiles()?.filter { it.name.endsWith(".old.log") }?.forEach { it.delete() }
-        // Rename current .log → .old.log
-        logsDir.listFiles()?.filter { it.name.endsWith(".log") && !it.name.endsWith(".old.log") }?.forEach { file ->
-            val oldName = file.name.replace(".log", ".old.log")
-            file.renameTo(File(logsDir, oldName))
-        }
-    }
-
-    @JvmStatic
     fun prepareForNewSession(context: Context) {
         stopAppLogging()
         val logsDir = getLogsDir(context)
-        logsDir.listFiles()?.filter { it.name.endsWith(".old.log") }?.forEach { it.delete() }
         logsDir.listFiles()?.filter { it.name.endsWith(".log") }?.forEach { it.delete() }
-        startAppLogging(context)
+        startAppLogging(context, reset = true)
     }
 
     // ── Wine/Box64 Logcat Capture ────────────────────────────────────
@@ -100,7 +87,8 @@ object LogManager {
     }
 
     @JvmStatic
-    fun startAppLogging(context: Context) {
+    @JvmOverloads
+    fun startAppLogging(context: Context, reset: Boolean = false) {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         if (!prefs.getBoolean("enable_app_debug", false)) return
 
@@ -109,8 +97,10 @@ object LogManager {
 
         try {
             stopAppLogging()
-            logFile.delete()
-            runBlockingLogcatCommand(arrayOf("logcat", "-c"))
+            if (reset) {
+                logFile.delete()
+                runBlockingLogcatCommand(arrayOf("logcat", "-c"))
+            }
             val pid = android.os.Process.myPid()
             appLogProcess =
                 Runtime.getRuntime().exec(
@@ -166,7 +156,7 @@ object LogManager {
         return logsDir
             .listFiles()
             ?.filter {
-                it.isFile && (it.name.endsWith(".log") || it.name.endsWith(".old.log") || it.name.endsWith(".txt") || it.name.endsWith(".csv"))
+                it.isFile && (it.name.endsWith(".log") || it.name.endsWith(".txt") || it.name.endsWith(".csv"))
             }?.toTypedArray() ?: emptyArray()
     }
 


### PR DESCRIPTION
Fixing application logging has exposed 2 new flaw with app logging.
 * cold app starts don't erease app logging anymore.

This issue prevents users from having to make the issue happen twice to get the application.old.log to appear to actually pull the crash.
Since this has been fixed and gated to only Game boots. You may safely pull the log with out the .old.log

 * redundant application.old.log has been removed.