### PR TITLE
Add container-level display refresh rate setting

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -1283,15 +1283,13 @@ private fun GeneralSection(
                     onSelected = { state.selectedScreenSize.intValue = it }
                 )
             }
-            if (!isContainer) {
-                Box(Modifier.weight(1f)) {
-                    SettingDropdown(
-                        label = stringResource(R.string.settings_general_refresh_rate),
-                        entries = state.refreshRateEntries.value,
-                        selectedIndex = state.selectedRefreshRate.intValue,
-                        onSelected = { state.selectedRefreshRate.intValue = it }
-                    )
-                }
+            Box(Modifier.weight(1f)) {
+                SettingDropdown(
+                    label = stringResource(R.string.settings_general_refresh_rate),
+                    entries = state.refreshRateEntries.value,
+                    selectedIndex = state.selectedRefreshRate.intValue,
+                    onSelected = { state.selectedRefreshRate.intValue = it }
+                )
             }
         }
 

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -44,9 +44,11 @@ import com.winlator.cmod.runtime.content.ContentProfile
 import com.winlator.cmod.runtime.content.ContentsManager
 import com.winlator.cmod.feature.settings.DXVKConfigUtils
 import com.winlator.cmod.feature.settings.GraphicsDriverConfigUtils
+import com.winlator.cmod.feature.settings.OtherSettingsFragment
 import com.winlator.cmod.feature.settings.WineD3DConfigUtils
 import com.winlator.cmod.shared.android.AppUtils
 import com.winlator.cmod.shared.android.DirectoryPickerDialog
+import com.winlator.cmod.shared.android.RefreshRateUtils
 import com.winlator.cmod.shared.ui.toast.WinToast
 import com.winlator.cmod.shared.io.AssetPaths
 import com.winlator.cmod.runtime.wine.EnvVars
@@ -507,6 +509,20 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         state.screenSizeEntries.value = screenSizeArr
         selectScreenSize(c?.getScreenSize() ?: Container.DEFAULT_SCREEN_SIZE)
 
+        try {
+            val refreshEntries = OtherSettingsFragment.buildRefreshRateEntries(activity)
+            state.refreshRateEntries.value = refreshEntries
+            val savedRate = c?.getExtra("refreshRate", "0")
+            if (savedRate.isNullOrEmpty() || savedRate == "0") {
+                state.selectedRefreshRate.intValue = 0
+            } else {
+                val idx = refreshEntries.indexOfFirst { it == "$savedRate Hz" }
+                state.selectedRefreshRate.intValue = if (idx >= 0) idx else 0
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading refresh rate entries", e)
+        }
+
         val graphicsDriverArr = context.resources.getStringArray(R.array.graphics_driver_entries).toList()
         state.graphicsDriverEntries.value = graphicsDriverArr
         selectByIdentifier(
@@ -793,6 +809,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             c.setDXWrapper(dxwrapper)
             c.setDXWrapperConfig(dxwrapperConfig)
             c.putExtra("swapRB", if (state.selectedSurfaceEffect.intValue == 1) "1" else "0")
+            c.putExtra("refreshRate", getRefreshRateFromState())
             c.setAudioDriver(audioDriver)
             c.setEmulator(emulator)
             c.setEmulator64(emulator64)
@@ -860,6 +877,11 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
 
                 ContainerCreation.createContainerAsync(manager, contentsManager, data) { newContainer ->
                     if (newContainer != null) {
+                        // Container.loadData() ignores unknown top-level keys, so extras must be set post-creation.
+                        getRefreshRateFromState()?.let {
+                            newContainer.putExtra("refreshRate", it)
+                            newContainer.saveData()
+                        }
                         saveMouseWarpOverride(newContainer)
                     } else {
                         WinToast.show(context, R.string.setup_wizard_unable_to_install_system_files)
@@ -1389,6 +1411,15 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 state.customHeight.value = parts[1]
             }
         }
+    }
+
+    /** Selected rate, or null for "Default" — stored as key absence so it falls through to the phone's auto rate. */
+    private fun getRefreshRateFromState(): String? {
+        val entries = state.refreshRateEntries.value
+        val idx = state.selectedRefreshRate.intValue
+        if (idx !in entries.indices) return null
+        val rate = RefreshRateUtils.parseRefreshRateLabel(entries[idx])
+        return if (rate > 0) rate.toString() else null
     }
 
     private fun getScreenSizeFromState(): String {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -627,12 +627,19 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     private int getRefreshRateOverride() {
         int perGameRate = getPerGameRefreshRateOverride();
-        return perGameRate > 0 ? perGameRate : getGlobalRefreshRateOverride();
+        if (perGameRate > 0) return perGameRate;
+        int containerRate = getContainerRefreshRateOverride();
+        return containerRate > 0 ? containerRate : getGlobalRefreshRateOverride();
     }
 
     private int getPerGameRefreshRateOverride() {
         if (shortcut == null) return 0;
         return parsePositiveInt(shortcut.getExtra("refreshRate", ""));
+    }
+
+    private int getContainerRefreshRateOverride() {
+        if (container == null) return 0;
+        return parsePositiveInt(container.getExtra("refreshRate", ""));
     }
 
     private int getGlobalRefreshRateOverride() {

--- a/app/src/main/shared/android/RefreshRateUtils.java
+++ b/app/src/main/shared/android/RefreshRateUtils.java
@@ -138,6 +138,7 @@ public final class RefreshRateUtils {
 
     Display.Mode bestMode = null;
     float bestModeRate = 0f;
+    boolean bestIsExact = false;
     float closestDelta = Float.MAX_VALUE;
 
     for (Display.Mode mode : modes) {
@@ -155,15 +156,18 @@ public final class RefreshRateUtils {
       }
 
       if (Math.round(refreshRate) == requestedHz) {
-        if (bestMode == null || refreshRate > bestModeRate) {
+        // Any exact match beats a non-exact one; among exact matches keep the highest rate.
+        if (!bestIsExact || refreshRate > bestModeRate) {
           bestMode = mode;
           bestModeRate = refreshRate;
+          bestIsExact = true;
           closestDelta = 0f;
         }
         continue;
       }
 
-      if (bestMode != null && closestDelta == 0f) continue;
+      // Never let a non-exact mode override an exact match found elsewhere in the list.
+      if (bestIsExact) continue;
 
       float delta = Math.abs(refreshRate - requestedHz);
       if (bestMode == null
@@ -296,6 +300,11 @@ public final class RefreshRateUtils {
 
   public static void applyPreferredRefreshRate(Activity activity, int requestedHz, int fpsLimit) {
     if (activity.isFinishing() || activity.isDestroyed()) return;
+
+    // The window has no display until it is attached; applying here resolves to a
+    // bogus fallback (mode 0 / default rate) that briefly overrides the real choice.
+    // Skip and let the next apply (resume / focus / display-change) set it once ready.
+    if (getDisplay(activity) == null) return;
 
     int effectiveRequestedHz = resolveFramePacedRefreshRate(activity, requestedHz, fpsLimit);
     WindowManager.LayoutParams params = activity.getWindow().getAttributes();


### PR DESCRIPTION
Container settings now exposes the same refresh rate dropdown as shortcut settings, in the same spot. The container rate applies to every shortcut using that container; a rate explicitly set on a shortcut takes precedence over it. Default on both leaves the rate uncapped so the display picks it, unchanged from the previous behavior.