### PR TITLE
Fix FPS HUD showing the panel rate instead of true game FPS

### DIFF
--- a/app/src/main/feature/settings/drivers/DXVKConfigUtils.java
+++ b/app/src/main/feature/settings/drivers/DXVKConfigUtils.java
@@ -19,9 +19,6 @@ public final class DXVKConfigUtils {
     }
 
     public static void setEnvVars(Context context, KeyValueSet config, EnvVars envVars) {
-        // Read once at guest start, so the gate comes off unconditionally or the pacer can never rise above the panel rate mid-session.
-        String content = "dxgi.syncInterval = 0; d3d9.presentInterval = 0";
-
         String async = config.get("async");
         if (!async.isEmpty() && !async.equals("0")) {
             envVars.put("DXVK_ASYNC", "1");
@@ -30,10 +27,6 @@ public final class DXVKConfigUtils {
         String asyncCache = config.get("asyncCache");
         if (!asyncCache.isEmpty() && !asyncCache.equals("0")) {
             envVars.put("DXVK_GPLASYNCCACHE", "1");
-        }
-
-        if (!content.isEmpty()) {
-            envVars.put("DXVK_CONFIG", content);
         }
 
         envVars.put("VKD3D_FEATURE_LEVEL", config.get("vkd3dLevel"));

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -684,8 +684,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             if (isFinishing() || isDestroyed()) return;
 
             RefreshRateUtils.applyPreferredRefreshRate(this, getRefreshRateOverride(), runtimeFpsLimit);
-            // Read the live mode back rather than the requested rate; the mode change lands asynchronously and can be refused.
-            if (xServer != null) xServer.setDisplayRefreshHz(RefreshRateUtils.getActiveRefreshRate(this));
         };
 
         if (Looper.myLooper() == Looper.getMainLooper()) {
@@ -732,11 +730,6 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
 
     private void handleDisplayCapabilitiesChanged() {
         if (isFinishing() || isDestroyed()) return;
-
-        // Keep the pacer's refresh rate current across seamless mode switches that don't cross the limit.
-        if (xServer != null) {
-            xServer.setDisplayRefreshHz(RefreshRateUtils.getActiveRefreshRate(this));
-        }
 
         int maxRate = RefreshRateUtils.getMaxSupportedRefreshRate(this);
         boolean maxChanged = maxRate != lastKnownMaxRefreshRate;

--- a/app/src/main/runtime/display/xserver/XClient.java
+++ b/app/src/main/runtime/display/xserver/XClient.java
@@ -160,9 +160,7 @@ public class XClient implements XResourceManager.OnResourceLifecycleListener {
     com.winlator.cmod.runtime.display.renderer.VulkanRenderer renderer = xServer.getRenderer();
     if (renderer == null) return;
 
-    // Presentation is unlocked, so with no user cap hold the panel rate instead of letting the guest free-run.
     int targetFps = renderer.getFpsLimit();
-    if (targetFps <= 0) targetFps = Math.round(xServer.getDisplayRefreshHz());
     if (targetFps <= 0) {
       nextFrameTimeNanos = 0;
       return;

--- a/app/src/main/runtime/display/xserver/XServer.java
+++ b/app/src/main/runtime/display/xserver/XServer.java
@@ -50,7 +50,6 @@ public class XServer {
   public final CursorLocker cursorLocker;
   private SHMSegmentManager shmSegmentManager;
   private VulkanRenderer renderer;
-  private volatile float displayRefreshHz = 0f;
   private WinHandler winHandler;
   private final EnumMap<Lockable, ReentrantLock> locks = new EnumMap<>(Lockable.class);
   private boolean relativeMouseMovement = false;
@@ -115,15 +114,6 @@ public class XServer {
 
   public VulkanRenderer getRenderer() {
     return renderer;
-  }
-
-  /** Live panel rate in Hz; the frame pacer's fallback cap when no user limit is set. */
-  public float getDisplayRefreshHz() {
-    return displayRefreshHz;
-  }
-
-  public void setDisplayRefreshHz(float hz) {
-    displayRefreshHz = hz > 0f ? hz : 0f;
   }
 
   public GrabManager getGrabManager() {


### PR DESCRIPTION
The frame pacer treated "no FPS cap" as "cap at the panel rate", parking the guest's present call until the next panel-rate heartbeat. The HUD counts real guest presents, so an uncapped game able to outrun the panel was genuinely throttled to it and the HUD honestly reported the panel rate. Uncapped now does no pacing at all; an explicit cap still goes through the pacer unchanged.

Drop the displayRefreshHz field and its accessors, unread once the fallback is gone.

Stop forcing dxgi.syncInterval and d3d9.presentInterval to 0. Overriding the guest's own present interval left a vsync'd game free-running and tearing once the pacer no longer held the panel rate; the game's vsync choice now survives.