### PR TITLE
Fix CPU affinity for 32-bit games

### DIFF
--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -323,6 +323,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private com.winlator.cmod.runtime.system.SessionLogWriter sessionLogWriter;
     private int taskAffinityMask = 0;
     private int taskAffinityMaskWoW64 = 0;
+    private final HashSet<Integer> guestAffinityCheckedPids = new HashSet<>();
     private int frameRatingWindowId = -1;
     private android.net.wifi.WifiManager.MulticastLock multicastLock;
     private final float[] xform = XForm.getInstance();
@@ -10936,16 +10937,66 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         if (taskAffinityMask == 0 && taskAffinityMaskWoW64 == 0) return;
         int processId = window.getProcessId();
         String className = window.getClassName();
-        int processAffinity = window.isWoW64() ? taskAffinityMaskWoW64 : taskAffinityMask;
-
-        if (processAffinity == 0) return;
 
         if (processId > 0) {
-            winHandler.setProcessAffinity(processId, processAffinity);
+            if (taskAffinityMask == taskAffinityMaskWoW64) {
+                winHandler.setProcessAffinity(processId, taskAffinityMask);
+            } else {
+                applyGuestResolvedAffinity(processId, window.isWoW64());
+            }
         }
         else if (!className.isEmpty()) {
-            winHandler.setProcessAffinity(window.getClassName(), processAffinity);
+            int processAffinity = window.isWoW64() ? taskAffinityMaskWoW64 : taskAffinityMask;
+            if (processAffinity != 0) winHandler.setProcessAffinity(className, processAffinity);
         }
+    }
+
+    // _NET_WM_WOW64 can be absent on 32-bit guest windows, so when the two masks
+    // differ, resolve the wow64 flag from the guest process list and apply once.
+    // The window property is only the fallback if the guest doesn't answer.
+    private void applyGuestResolvedAffinity(final int pid, final boolean windowSaysWoW64) {
+        synchronized (guestAffinityCheckedPids) {
+            if (!guestAffinityCheckedPids.add(pid)) return;
+        }
+        new Thread(() -> {
+            final WinHandler handler = winHandler;
+            if (handler == null) return;
+            final CountDownLatch latch = new CountDownLatch(1);
+            final boolean[] resolved = new boolean[1];
+            final OnGetProcessInfoListener previous = handler.getOnGetProcessInfoListener();
+            final OnGetProcessInfoListener resolver = (index, numProcesses, processInfo) -> {
+                if (previous != null) previous.onGetProcessInfo(index, numProcesses, processInfo);
+                if (processInfo != null && processInfo.pid == pid) {
+                    int desired = processInfo.wow64Process ? taskAffinityMaskWoW64 : taskAffinityMask;
+                    Log.d("XServerDisplayActivity", "Guest affinity resolve pid=" + pid
+                            + " wow64=" + processInfo.wow64Process
+                            + " mask=0x" + Integer.toHexString(desired));
+                    if (desired != 0) handler.setProcessAffinity(pid, desired);
+                    resolved[0] = true;
+                    latch.countDown();
+                } else if (processInfo == null || index == numProcesses - 1) {
+                    latch.countDown();
+                }
+            };
+            handler.setOnGetProcessInfoListener(resolver);
+            try {
+                handler.listProcesses();
+                latch.await(3000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                if (handler.getOnGetProcessInfoListener() == resolver) {
+                    handler.setOnGetProcessInfoListener(previous);
+                }
+            }
+            if (!resolved[0]) {
+                int fallback = windowSaysWoW64 ? taskAffinityMaskWoW64 : taskAffinityMask;
+                if (fallback != 0) handler.setProcessAffinity(pid, fallback);
+                synchronized (guestAffinityCheckedPids) {
+                    guestAffinityCheckedPids.remove(pid);
+                }
+            }
+        }, "GuestAffinityResolve").start();
     }
 
     private void changeFrameRatingVisibility(Window window, Property property) {


### PR DESCRIPTION
The 32-bit affinity list was applied only when the game window carried the WoW64 window property, which is often missing, so 32-bit games silently got the 64-bit (all cores) mask. When the two lists differ, resolve the process wow64 flag from the guest process list and apply the matching mask once; the window property is now only a timeout fallback.