### PR TITLE
Fix duplicated containers failing to boot

### DIFF
--- a/app/src/main/feature/settings/containers/ContainersFragment.kt
+++ b/app/src/main/feature/settings/containers/ContainersFragment.kt
@@ -164,12 +164,19 @@ class ContainersFragment : Fragment() {
         duplicatingPopup.show()
         manager.duplicateContainerAsync(container, { progress ->
             duplicatingPopup.setProgress(progress)
-        }) {
-            duplicatingPopup.setProgress(100)
-            duplicatingPopup.closeWithDelay(600)
-            Handler(Looper.getMainLooper()).postDelayed({
-                loadContainersList()
-            }, 600)
+        }) { success ->
+            if (success) {
+                duplicatingPopup.setProgress(100)
+                duplicatingPopup.closeWithDelay(600)
+                Handler(Looper.getMainLooper()).postDelayed({
+                    loadContainersList()
+                }, 600)
+            } else {
+                duplicatingPopup.close()
+                context?.let {
+                    WinToast.show(it, R.string.containers_list_duplicate_failed, Toast.LENGTH_LONG)
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Duplicar contenedor</string>
     <string name="containers_list_confirm_remove">¿Eliminar este contenedor? Las partidas guardadas dentro de él se eliminarán de forma permanente. Las partidas sincronizadas en la nube permanecen en la nube, pero los cambios locales que aún no se hayan sincronizado se perderán — sincroniza primero las partidas en la nube de este juego si quieres conservarlas.</string>
     <string name="containers_list_confirm_duplicate">¿Quieres duplicar este contenedor?</string>
+    <string name="containers_list_duplicate_failed">No se pudo duplicar el contenedor</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">¿Quieres eliminar este acceso directo?</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Dupliker container</string>
     <string name="containers_list_confirm_remove">Vil du fjerne denne container?</string>
     <string name="containers_list_confirm_duplicate">Vil du duplikere denne container?</string>
+    <string name="containers_list_duplicate_failed">Kunne ikke duplikere containeren</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Vil du fjerne denne genvej?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Container duplizieren</string>
     <string name="containers_list_confirm_remove">Möchtest du diesen Container entfernen?</string>
     <string name="containers_list_confirm_duplicate">Möchtest du diesen Container duplizieren?</string>
+    <string name="containers_list_duplicate_failed">Container konnte nicht dupliziert werden</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Möchtest du diese Verknüpfung entfernen?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Duplicar contenedor</string>
     <string name="containers_list_confirm_remove">¿Deseas eliminar este contenedor?</string>
     <string name="containers_list_confirm_duplicate">¿Deseas duplicar este contenedor?</string>
+    <string name="containers_list_duplicate_failed">No se pudo duplicar el contenedor</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">¿Deseas eliminar este acceso directo?</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Kopioi säiliö</string>
     <string name="containers_list_confirm_remove">Poistetaanko tämä säiliö? Kaikki sen sisältämät pelitallennukset poistetaan pysyvästi. Pilveen synkronoidut tallennukset säilyvät pilvessä, mutta paikalliset muutokset, joita ei ole vielä synkronoitu, menetetään – synkronoi tämän pelin pilvitallennukset ensin, jos haluat säilyttää ne.</string>
     <string name="containers_list_confirm_duplicate">Haluatko kopioida tämän säiliön?</string>
+    <string name="containers_list_duplicate_failed">Säiliön kopiointi epäonnistui</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Haluatko poistaa tämän pikakuvakkeen?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Dupliquer le conteneur</string>
     <string name="containers_list_confirm_remove">Voulez-vous supprimer ce conteneur ?</string>
     <string name="containers_list_confirm_duplicate">Voulez-vous dupliquer ce conteneur ?</string>
+    <string name="containers_list_duplicate_failed">Échec de la duplication du conteneur</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Voulez-vous supprimer ce raccourci ?</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -278,6 +278,7 @@
     <string name="containers_list_duplicate_title">कंटेनर की नकल बनाएं</string>
     <string name="containers_list_confirm_remove">क्या आप इस कंटेनर को हटाना चाहते हैं?</string>
     <string name="containers_list_confirm_duplicate">क्या आप इस कंटेनर की नकल बनाना चाहते हैं?</string>
+    <string name="containers_list_duplicate_failed">कंटेनर डुप्लिकेट करने में विफल</string>
     <string name="shortcuts_list_confirm_remove">क्या आप इस शॉर्टकट को हटाना चाहते हैं?</string>
     <string name="shortcuts_list_add_to_home_screen">होम स्क्रीन में जोड़ें</string>
     <string name="shortcuts_library_artwork_title">लाइब्रेरी आर्टवर्क</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Duplica contenitore</string>
     <string name="containers_list_confirm_remove">Vuoi rimuovere questo contenitore?</string>
     <string name="containers_list_confirm_duplicate">Vuoi duplicare questo contenitore?</string>
+    <string name="containers_list_duplicate_failed">Impossibile duplicare il contenitore</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Vuoi rimuovere questa scorciatoia?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">コンテナを複製</string>
     <string name="containers_list_confirm_remove">このコンテナを削除しますか? 内部に保存されたゲームのセーブデータはすべて完全に削除されます。クラウドに同期済みのセーブデータはクラウドに残りますが、未同期のローカルの変更は失われます — 残しておきたい場合は、先にこのゲームのクラウドセーブを同期してください。</string>
     <string name="containers_list_confirm_duplicate">このコンテナを複製しますか?</string>
+    <string name="containers_list_duplicate_failed">コンテナの複製に失敗しました</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">このショートカットを削除しますか?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">컨테이너 복제</string>
     <string name="containers_list_confirm_remove">이 컨테이너를 제거하시겠습니까?</string>
     <string name="containers_list_confirm_duplicate">이 컨테이너를 복제하시겠습니까?</string>
+    <string name="containers_list_duplicate_failed">컨테이너 복제에 실패했습니다</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">이 바로가기를 제거하시겠습니까?</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Dupliser beholder</string>
     <string name="containers_list_confirm_remove">Fjerne denne beholderen? Eventuelle spilllagringer som er lagret i den, vil bli slettet permanent. Skylagrede lagringer forblir i skyen, men lokale endringer som ennå ikke er synkronisert, vil gå tapt – synkroniser dette spillets skylagringer først hvis du vil beholde dem.</string>
     <string name="containers_list_confirm_duplicate">Vil du duplisere denne beholderen?</string>
+    <string name="containers_list_duplicate_failed">Kunne ikke duplisere beholderen</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Vil du fjerne denne snarveien?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -274,6 +274,7 @@
     <string name="containers_list_duplicate_title">Zduplikuj kontener</string>
     <string name="containers_list_confirm_remove">Czy chcesz usunąć ten kontener?</string>
     <string name="containers_list_confirm_duplicate">Czy chcesz zduplikować ten kontener?</string>
+    <string name="containers_list_duplicate_failed">Nie udało się zduplikować kontenera</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Czy chcesz usunąć ten skrót?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Duplicar container</string>
     <string name="containers_list_confirm_remove">Deseja remover este container?</string>
     <string name="containers_list_confirm_duplicate">Deseja duplicar este container?</string>
+    <string name="containers_list_duplicate_failed">Falha ao duplicar o container</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Deseja remover este atalho?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Duplicar contentor</string>
     <string name="containers_list_confirm_remove">Remover este contentor? Quaisquer jogos guardados armazenados no seu interior serão eliminados permanentemente. Os jogos guardados sincronizados na nuvem permanecem na nuvem, mas as alterações locais que ainda não foram sincronizadas serão perdidas — sincronize primeiro os jogos guardados na nuvem deste jogo se os quiser manter.</string>
     <string name="containers_list_confirm_duplicate">Pretende duplicar este contentor?</string>
+    <string name="containers_list_duplicate_failed">Falha ao duplicar o contentor</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Pretende remover este atalho?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">Duplica containerul</string>
     <string name="containers_list_confirm_remove">Doresti sa elimini acest container?</string>
     <string name="containers_list_confirm_duplicate">Doresti sa duplici acest container?</string>
+    <string name="containers_list_duplicate_failed">Duplicarea containerului a esuat</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Doresti sa elimini aceasta comanda rapida?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -287,6 +287,7 @@
     <string name="containers_list_duplicate_title">Дублировать контейнер</string>
     <string name="containers_list_confirm_remove">Вы хотите удалить этот контейнер?</string>
     <string name="containers_list_confirm_duplicate">Вы хотите продублировать этот контейнер?</string>
+    <string name="containers_list_duplicate_failed">Не удалось продублировать контейнер</string>
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Вы хотите удалить этот ярлык?</string>
     <string name="shortcuts_list_add_to_home_screen">Добавить на главный экран</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Duplicera container</string>
     <string name="containers_list_confirm_remove">Ta bort den här containern? Alla spelsparningar som lagras i den raderas permanent. Molnsynkade sparningar finns kvar i molnet, men lokala ändringar som ännu inte synkats går förlorade — synka det här spelets molnsparningar först om du vill behålla dem.</string>
     <string name="containers_list_confirm_duplicate">Vill du duplicera den här containern?</string>
+    <string name="containers_list_duplicate_failed">Det gick inte att duplicera containern</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Vill du ta bort den här genvägen?</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">ทำสำเนาคอนเทนเนอร์</string>
     <string name="containers_list_confirm_remove">ลบคอนเทนเนอร์นี้หรือไม่? ไฟล์บันทึกเกมที่เก็บไว้ข้างในจะถูกลบอย่างถาวร ไฟล์บันทึกที่ซิงค์กับคลาวด์จะยังอยู่บนคลาวด์ แต่การเปลี่ยนแปลงในเครื่องที่ยังไม่ได้ซิงค์จะสูญหาย — ซิงค์ไฟล์บันทึกบนคลาวด์ของเกมนี้ก่อนหากต้องการเก็บไว้</string>
     <string name="containers_list_confirm_duplicate">คุณต้องการทำสำเนาคอนเทนเนอร์นี้หรือไม่?</string>
+    <string name="containers_list_duplicate_failed">ทำสำเนาคอนเทนเนอร์ไม่สำเร็จ</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">คุณต้องการลบทางลัดนี้หรือไม่?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -289,6 +289,7 @@
     <string name="containers_list_duplicate_title">Konteyneri çoğalt</string>
     <string name="containers_list_confirm_remove">Bu konteyner kaldırılsın mı? İçinde saklanan tüm oyun kayıtları kalıcı olarak silinecek. Buluta eşitlenmiş kayıtlar bulutta kalır, ancak henüz eşitlenmemiş yerel değişiklikler kaybolur — korumak istiyorsanız önce bu oyunun bulut kayıtlarını eşitleyin.</string>
     <string name="containers_list_confirm_duplicate">Bu konteyneri çoğaltmak istiyor musunuz?</string>
+    <string name="containers_list_duplicate_failed">Konteyner çoğaltılamadı</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Bu kısayolu kaldırmak istiyor musunuz?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -274,6 +274,7 @@
     <string name="containers_list_duplicate_title">Дублювати контейнер</string>
     <string name="containers_list_confirm_remove">Ви хочете видалити цей контейнер?</string>
     <string name="containers_list_confirm_duplicate">Ви хочете дублювати цей контейнер?</string>
+    <string name="containers_list_duplicate_failed">Не вдалося дублювати контейнер</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Ви хочете видалити цей ярлик?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">复制容器</string>
     <string name="containers_list_confirm_remove">您要移除此容器吗？</string>
     <string name="containers_list_confirm_duplicate">您要复制此容器吗？</string>
+    <string name="containers_list_duplicate_failed">复制容器失败</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">您要移除此快捷方式吗？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -270,6 +270,7 @@
     <string name="containers_list_duplicate_title">複製容器</string>
     <string name="containers_list_confirm_remove">您要移除此容器嗎？</string>
     <string name="containers_list_confirm_duplicate">您要複製此容器嗎？</string>
+    <string name="containers_list_duplicate_failed">複製容器失敗</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">您要移除此捷徑嗎？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="containers_list_duplicate_title">Duplicate container</string>
     <string name="containers_list_confirm_remove">Remove this container? Any game saves stored inside it will be permanently deleted. Cloud-synced saves stay in the cloud, but local changes that haven\'t synced yet will be lost — sync this game\'s cloud saves first if you want to keep them.</string>
     <string name="containers_list_confirm_duplicate">Do you want to duplicate this container?</string>
+    <string name="containers_list_duplicate_failed">Failed to duplicate container</string>
 
     <!-- Shortcuts > List -->
     <string name="shortcuts_list_confirm_remove">Do you want to remove this shortcut?</string>

--- a/app/src/main/runtime/container/ContainerManager.java
+++ b/app/src/main/runtime/container/ContainerManager.java
@@ -184,12 +184,8 @@ public class ContainerManager {
             });
   }
 
-  public void duplicateContainerAsync(Container container, Runnable callback) {
-    duplicateContainerAsync(container, null, callback);
-  }
-
   public void duplicateContainerAsync(
-      Container container, Callback<Integer> progressCallback, Runnable callback) {
+      Container container, Callback<Integer> progressCallback, Callback<Boolean> callback) {
     final Handler handler = new Handler(Looper.getMainLooper());
     Executors.newSingleThreadExecutor()
         .execute(
@@ -198,8 +194,8 @@ public class ContainerManager {
                   progressCallback != null
                       ? progress -> handler.post(() -> progressCallback.call(progress))
                       : null;
-              duplicateContainer(container, uiProgress);
-              handler.post(callback);
+              final boolean success = duplicateContainer(container, uiProgress);
+              handler.post(() -> callback.call(success));
             });
   }
 
@@ -335,15 +331,22 @@ public class ContainerManager {
     return firstDash >= 0 ? entryName.substring(firstDash + 1) : entryName;
   }
 
-  private void duplicateContainer(Container srcContainer) {
-    duplicateContainer(srcContainer, null);
-  }
-
-  private void duplicateContainer(Container srcContainer, Callback<Integer> progressCallback) {
+  private boolean duplicateContainer(Container srcContainer, Callback<Integer> progressCallback) {
     int id = maxContainerId + 1;
-
     File dstDir = new File(homeDir, ImageFs.USER + "-" + id);
-    if (!dstDir.mkdirs()) return;
+
+    // A crashed create/duplicate can leave an unregistered dir behind; skip past it.
+    while (dstDir.exists()) {
+      id++;
+      dstDir = new File(homeDir, ImageFs.USER + "-" + id);
+    }
+
+    if (!dstDir.mkdirs()) {
+      Log.e(
+          "ContainerManager",
+          "duplicateContainer: failed to create dir " + dstDir.getAbsolutePath());
+      return false;
+    }
 
     final int totalFiles = FileUtils.countFiles(srcContainer.getRootDir());
     final int[] copiedFiles = {0};
@@ -359,32 +362,70 @@ public class ContainerManager {
             progressCallback.call(pct);
           }
         })) {
+      Log.e(
+          "ContainerManager",
+          "duplicateContainer: file copy failed for container " + srcContainer.id);
       FileUtils.delete(dstDir);
-      return;
+      return false;
     }
 
+    // Runtime socket dir; the copy's 0771 makes wineserver refuse to start ("accessible by other users").
+    FileUtils.delete(new File(dstDir, ".wine/.wineserver"));
+
+    // Load the source config wholesale; hand-picking fields reset the rest to defaults.
     Container dstContainer = new Container(id, this);
     dstContainer.setRootDir(dstDir);
+    String configStr = FileUtils.readString(srcContainer.getConfigFile());
+    if (configStr == null || configStr.trim().isEmpty()) {
+      Log.e(
+          "ContainerManager",
+          "duplicateContainer: config empty or unreadable for container " + srcContainer.id);
+      FileUtils.delete(dstDir);
+      return false;
+    }
+    try {
+      JSONObject data = new JSONObject(configStr);
+      data.put("id", id);
+      dstContainer.loadData(data);
+    } catch (JSONException e) {
+      Log.e(
+          "ContainerManager",
+          "duplicateContainer: bad config JSON for container " + srcContainer.id, e);
+      FileUtils.delete(dstDir);
+      return false;
+    }
     dstContainer.setName(
         srcContainer.getName() + " (" + context.getString(R.string.common_ui_copy) + ")");
-    dstContainer.setScreenSize(srcContainer.getScreenSize());
-    dstContainer.setEnvVars(srcContainer.getEnvVars());
-    dstContainer.setCPUList(srcContainer.getCPUList());
-    dstContainer.setCPUListWoW64(srcContainer.getCPUListWoW64());
-    dstContainer.setGraphicsDriver(srcContainer.getGraphicsDriver());
-    dstContainer.setDXWrapper(srcContainer.getDXWrapper());
-    dstContainer.setDXWrapperConfig(srcContainer.getDXWrapperConfig());
-    dstContainer.setAudioDriver(srcContainer.getAudioDriver());
-    dstContainer.setWinComponents(srcContainer.getWinComponents());
-    dstContainer.setDrives(srcContainer.getDrives());
-    dstContainer.setStartupSelection(srcContainer.getStartupSelection());
-    dstContainer.setBox64Preset(srcContainer.getBox64Preset());
-    dstContainer.setDesktopTheme(srcContainer.getDesktopTheme());
-    dstContainer.setWineVersion(srcContainer.getWineVersion());
     dstContainer.saveData();
+    rewriteShortcutContainerIds(dstContainer.getDesktopDir(), id);
 
-    maxContainerId++;
+    maxContainerId = id;
     containers.add(dstContainer);
+    return true;
+  }
+
+  // Copied shortcuts keep the source's container_id, which overrides the owning container at launch.
+  static void rewriteShortcutContainerIds(File desktopDir, int newId) {
+    File[] files = desktopDir.listFiles((dir, name) -> name.endsWith(".desktop"));
+    if (files == null) return;
+
+    for (File file : files) {
+      StringBuilder updated = new StringBuilder();
+      boolean changed = false;
+
+      for (String line : FileUtils.readLines(file)) {
+        String trimmed = line.trim();
+        boolean colon = trimmed.startsWith("container_id:");
+        if (colon || trimmed.startsWith("container_id=")) {
+          updated.append("container_id").append(colon ? ':' : '=').append(newId).append("\n");
+          changed = true;
+        } else updated.append(line).append("\n");
+      }
+
+      if (changed && !FileUtils.writeString(file, updated.toString())) {
+        Log.e("ContainerManager", "rewriteShortcutContainerIds: failed to write " + file);
+      }
+    }
   }
 
   private void removeContainer(Container container) {
@@ -460,10 +501,6 @@ public class ContainerManager {
             shortcutUpgradeRunning.set(false);
         }
     }, "ShortcutUpgrade").start();
-  }
-
-  public int getNextContainerId() {
-    return maxContainerId + 1;
   }
 
   public Container getContainerById(int id) {

--- a/app/src/main/runtime/container/Shortcut.java
+++ b/app/src/main/runtime/container/Shortcut.java
@@ -384,9 +384,12 @@ public class Shortcut {
       boolean containerIdFound = false;
 
       for (String line : lines) {
-        if (line.startsWith("container_id:")) {
-          // Update the container_id to the new container
-          updatedContent.append("container_id:").append(newContainer.id).append("\n");
+        String trimmed = line.trim();
+        // MSLink writes the '=' form, which the ':'-only match missed.
+        boolean colon = trimmed.startsWith("container_id:");
+        if (colon || trimmed.startsWith("container_id=")) {
+          updatedContent.append("container_id").append(colon ? ':' : '=')
+              .append(newContainer.id).append("\n");
           containerIdFound = true;
         } else {
           updatedContent.append(line).append("\n");


### PR DESCRIPTION
Delete .wine/.wineserver from the copy. The copy callback chmods every entry to 0771, and wineserver refuses to start unless its directory is 0700, so wine exited immediately and the container closed before the desktop appeared.

Load the source container config wholesale instead of hand-copying 14 fields. The rest were reset to defaults on save, losing wineprefixArch and the emulator versions, which coerced an arm64ec prefix to box64.

Rewrite container_id in copied .desktop files so a duplicate's shortcuts launch the duplicate rather than the source, and match both the ':' and '=' separators when moving a shortcut between containers.

Report duplication failure instead of completing the progress bar, skip stale container dirs when picking the new id, and drop the unused getNextContainerId.