### PR TITLE
Combo button swipes. 

### DIFF
--- a/app/src/main/res/layout/control_element_settings.xml
+++ b/app/src/main/res/layout/control_element_settings.xml
@@ -226,13 +226,29 @@
                 android:spinnerMode="dropdown" />
         </LinearLayout>
 
-        <CheckBox
-            android:id="@+id/CBToggleSwitch"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="12dp"
-            android:textColor="@color/settings_text_primary"
-            android:text="@string/input_controls_editor_toggle_switch" />
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/CBToggleSwitch"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:textColor="@color/settings_text_primary"
+                android:text="@string/input_controls_editor_toggle_switch" />
+
+            <CheckBox
+                android:id="@+id/CBSwipeable"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:textColor="@color/settings_text_primary"
+                android:text="@string/input_controls_editor_swipeable" />
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/LLCustomTextIcon"

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">No hay ninguna instantánea original disponible para este perfil.</string>
     <string name="input_controls_editor_title">Editor de controles</string>
     <string name="input_controls_editor_toggle_switch">Interruptor</string>
+    <string name="input_controls_editor_swipeable">Deslizable</string>
     <string name="input_controls_editor_profile_exported_to">Perfil exportado a</string>
     <string name="input_controls_editor_unable_to_import">No se pudo importar el perfil</string>
     <string name="input_controls_editor_import_profile">Importar perfil</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Vil du duplikere denne profil?</string>
     <string name="input_controls_editor_title">Kontroleditor</string>
     <string name="input_controls_editor_toggle_switch">Skiftekontakt</string>
+    <string name="input_controls_editor_swipeable">Swipebar</string>
     <string name="input_controls_editor_profile_exported_to">Profil eksporteret til</string>
     <string name="input_controls_editor_unable_to_import">Kan ikke importere profil</string>
     <string name="input_controls_editor_import_profile">Importer profil</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Möchtest du dieses Profil duplizieren?</string>
     <string name="input_controls_editor_title">Steuerungs-Editor</string>
     <string name="input_controls_editor_toggle_switch">Umschalter</string>
+    <string name="input_controls_editor_swipeable">Wischbar</string>
     <string name="input_controls_editor_profile_exported_to">Profil exportiert nach</string>
     <string name="input_controls_editor_unable_to_import">Profil kann nicht importiert werden</string>
     <string name="input_controls_editor_import_profile">Profil importieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">¿Deseas duplicar este perfil?</string>
     <string name="input_controls_editor_title">Editor de controles</string>
     <string name="input_controls_editor_toggle_switch">Interruptor</string>
+    <string name="input_controls_editor_swipeable">Deslizable</string>
     <string name="input_controls_editor_profile_exported_to">Perfil exportado a</string>
     <string name="input_controls_editor_unable_to_import">No se pudo importar el perfil</string>
     <string name="input_controls_editor_import_profile">Importar perfil</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">Tälle profiilille ei ole saatavilla alkuperäistä tilannevedosta.</string>
     <string name="input_controls_editor_title">Ohjausten muokkain</string>
     <string name="input_controls_editor_toggle_switch">Vaihtokytkin</string>
+    <string name="input_controls_editor_swipeable">Pyyhkäisyaktivointi</string>
     <string name="input_controls_editor_profile_exported_to">Profiili viety kohteeseen</string>
     <string name="input_controls_editor_unable_to_import">Profiilia ei voitu tuoda</string>
     <string name="input_controls_editor_import_profile">Tuo profiili</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Voulez-vous dupliquer ce profil ?</string>
     <string name="input_controls_editor_title">Éditeur de contrôles</string>
     <string name="input_controls_editor_toggle_switch">Interrupteur à bascule</string>
+    <string name="input_controls_editor_swipeable">Activation par glissement</string>
     <string name="input_controls_editor_profile_exported_to">Profil exporté vers</string>
     <string name="input_controls_editor_unable_to_import">Impossible d\'importer le profil</string>
     <string name="input_controls_editor_import_profile">Importer un profil</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -363,6 +363,7 @@
     <string name="input_controls_editor_reset_unavailable">इस प्रोफ़ाइल के लिए कोई मूल स्नैपशॉट उपलब्ध नहीं है.</string>
     <string name="input_controls_editor_title">नियंत्रण संपादक</string>
     <string name="input_controls_editor_toggle_switch">टॉगल स्विच</string>
+    <string name="input_controls_editor_swipeable">स्वाइप योग्य</string>
     <string name="input_controls_editor_profile_exported_to">प्रोफ़ाइल को निर्यात किया गया</string>
     <string name="input_controls_editor_unable_to_import">प्रोफ़ाइल आयात करने में असमर्थ</string>
     <string name="input_controls_editor_import_profile">प्रोफ़ाइल आयात करें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Vuoi duplicare questo profilo?</string>
     <string name="input_controls_editor_title">Editor controlli</string>
     <string name="input_controls_editor_toggle_switch">Interruttore a levetta</string>
+    <string name="input_controls_editor_swipeable">Attivabile con swipe</string>
     <string name="input_controls_editor_profile_exported_to">Profilo esportato in</string>
     <string name="input_controls_editor_unable_to_import">Impossibile importare il profilo</string>
     <string name="input_controls_editor_import_profile">Importa profilo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">このプロファイルには元のスナップショットがありません。</string>
     <string name="input_controls_editor_title">操作エディター</string>
     <string name="input_controls_editor_toggle_switch">トグルスイッチ</string>
+    <string name="input_controls_editor_swipeable">スワイプ可能</string>
     <string name="input_controls_editor_profile_exported_to">プロファイルのエクスポート先</string>
     <string name="input_controls_editor_unable_to_import">プロファイルをインポートできません</string>
     <string name="input_controls_editor_import_profile">プロファイルをインポート</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">이 프로필을 복제하시겠습니까?</string>
     <string name="input_controls_editor_title">컨트롤 편집기</string>
     <string name="input_controls_editor_toggle_switch">토글 스위치</string>
+    <string name="input_controls_editor_swipeable">스와이프 가능</string>
     <string name="input_controls_editor_profile_exported_to">프로필이 다음으로 내보내졌습니다:</string>
     <string name="input_controls_editor_unable_to_import">프로필을 가져올 수 없습니다</string>
     <string name="input_controls_editor_import_profile">프로필 가져오기</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">Ingen opprinnelig øyeblikksbilde er tilgjengelig for denne profilen.</string>
     <string name="input_controls_editor_title">Kontrollredigering</string>
     <string name="input_controls_editor_toggle_switch">Vippebryter</string>
+    <string name="input_controls_editor_swipeable">Sveipbar</string>
     <string name="input_controls_editor_profile_exported_to">Profil eksportert til</string>
     <string name="input_controls_editor_unable_to_import">Kan ikke importere profil</string>
     <string name="input_controls_editor_import_profile">Importer profil</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -330,6 +330,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Czy chcesz zduplikować ten profil?</string>
     <string name="input_controls_editor_title">Edytor sterowania</string>
     <string name="input_controls_editor_toggle_switch">Przełącznik</string>
+    <string name="input_controls_editor_swipeable">Aktywacja przesunięciem</string>
     <string name="input_controls_editor_profile_exported_to">Profil wyeksportowany do</string>
     <string name="input_controls_editor_unable_to_import">Nie można zaimportować profilu</string>
     <string name="input_controls_editor_import_profile">Importuj profil</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Deseja duplicar este perfil?</string>
     <string name="input_controls_editor_title">Editor de Controles</string>
     <string name="input_controls_editor_toggle_switch">Interruptor</string>
+    <string name="input_controls_editor_swipeable">Deslizável</string>
     <string name="input_controls_editor_profile_exported_to">Perfil exportado para</string>
     <string name="input_controls_editor_unable_to_import">Nao foi possivel importar o perfil</string>
     <string name="input_controls_editor_import_profile">Importar Perfil</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">Não existe nenhum instantâneo original disponível para este perfil.</string>
     <string name="input_controls_editor_title">Editor de controlos</string>
     <string name="input_controls_editor_toggle_switch">Interruptor de alternância</string>
+    <string name="input_controls_editor_swipeable">Deslizável</string>
     <string name="input_controls_editor_profile_exported_to">Perfil exportado para</string>
     <string name="input_controls_editor_unable_to_import">Não foi possível importar o perfil</string>
     <string name="input_controls_editor_import_profile">Importar perfil</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Doresti sa duplici acest profil?</string>
     <string name="input_controls_editor_title">Editor controale</string>
     <string name="input_controls_editor_toggle_switch">Comutator</string>
+    <string name="input_controls_editor_swipeable">Activare prin glisare</string>
     <string name="input_controls_editor_profile_exported_to">Profil exportat in</string>
     <string name="input_controls_editor_unable_to_import">Nu s-a putut importa profilul</string>
     <string name="input_controls_editor_import_profile">Importa profil</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -375,6 +375,7 @@
     <string name="input_controls_editor_reset_unavailable">Для этого профиля нет исходного снимка.</string>
     <string name="input_controls_editor_title">Редактор элементов управления</string>
     <string name="input_controls_editor_toggle_switch">Тумблер</string>
+    <string name="input_controls_editor_swipeable">Активация свайпом</string>
     <string name="input_controls_editor_profile_exported_to">Профиль экспортирован в</string>
     <string name="input_controls_editor_unable_to_import">Невозможно импортировать профиль</string>
     <string name="input_controls_editor_import_profile">Импортировать профиль</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">Ingen ursprunglig ögonblicksbild finns tillgänglig för den här profilen.</string>
     <string name="input_controls_editor_title">Kontrollredigerare</string>
     <string name="input_controls_editor_toggle_switch">Växlingsknapp</string>
+    <string name="input_controls_editor_swipeable">Svepbar</string>
     <string name="input_controls_editor_profile_exported_to">Profil exporterad till</string>
     <string name="input_controls_editor_unable_to_import">Det gick inte att importera profilen</string>
     <string name="input_controls_editor_import_profile">Importera profil</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">ไม่มีสแนปช็อตต้นฉบับสำหรับโปรไฟล์นี้</string>
     <string name="input_controls_editor_title">ตัวแก้ไขการควบคุม</string>
     <string name="input_controls_editor_toggle_switch">สวิตช์เปิด/ปิด</string>
+    <string name="input_controls_editor_swipeable">ปัดได้</string>
     <string name="input_controls_editor_profile_exported_to">ส่งออกโปรไฟล์ไปยัง</string>
     <string name="input_controls_editor_unable_to_import">ไม่สามารถนำเข้าโปรไฟล์</string>
     <string name="input_controls_editor_import_profile">นำเข้าโปรไฟล์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -385,6 +385,7 @@
     <string name="input_controls_editor_reset_unavailable">Bu profil için orijinal anlık görüntü mevcut değil.</string>
     <string name="input_controls_editor_title">Kontrol Düzenleyicisi</string>
     <string name="input_controls_editor_toggle_switch">Açma/Kapama Anahtarı</string>
+    <string name="input_controls_editor_swipeable">Kaydırılabilir</string>
     <string name="input_controls_editor_profile_exported_to">Profil şuraya dışa aktarıldı</string>
     <string name="input_controls_editor_unable_to_import">Profil içe aktarılamıyor</string>
     <string name="input_controls_editor_import_profile">Profili İçe Aktar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -330,6 +330,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">Ви хочете дублювати цей профіль?</string>
     <string name="input_controls_editor_title">Редактор керування</string>
     <string name="input_controls_editor_toggle_switch">Перемикач</string>
+    <string name="input_controls_editor_swipeable">Активація свайпом</string>
     <string name="input_controls_editor_profile_exported_to">Профіль експортовано до</string>
     <string name="input_controls_editor_unable_to_import">Неможливо імпортувати профіль</string>
     <string name="input_controls_editor_import_profile">Імпортувати профіль</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">您要复制此配置文件吗？</string>
     <string name="input_controls_editor_title">控制编辑器</string>
     <string name="input_controls_editor_toggle_switch">切换开关</string>
+    <string name="input_controls_editor_swipeable">可滑动触发</string>
     <string name="input_controls_editor_profile_exported_to">配置文件已导出到</string>
     <string name="input_controls_editor_unable_to_import">无法导入配置文件</string>
     <string name="input_controls_editor_import_profile">导入配置文件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -326,6 +326,7 @@
     <string name="input_controls_editor_confirm_duplicate_profile">您要複製此設定檔嗎？</string>
     <string name="input_controls_editor_title">控制編輯器</string>
     <string name="input_controls_editor_toggle_switch">切換開關</string>
+    <string name="input_controls_editor_swipeable">可滑動觸發</string>
     <string name="input_controls_editor_profile_exported_to">設定檔已匯出至</string>
     <string name="input_controls_editor_unable_to_import">無法匯入設定檔</string>
     <string name="input_controls_editor_import_profile">匯入設定檔</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,6 +386,7 @@
     <string name="input_controls_editor_reset_unavailable">No original snapshot is available for this profile.</string>
     <string name="input_controls_editor_title">Controls Editor</string>
     <string name="input_controls_editor_toggle_switch">Toggle Switch</string>
+    <string name="input_controls_editor_swipeable">Swipeable</string>
     <string name="input_controls_editor_profile_exported_to">Profile exported to</string>
     <string name="input_controls_editor_unable_to_import">Unable to import profile</string>
     <string name="input_controls_editor_import_profile">Import Profile</string>

--- a/app/src/main/runtime/input/ControlsEditorActivity.java
+++ b/app/src/main/runtime/input/ControlsEditorActivity.java
@@ -356,6 +356,7 @@ private void showControlElementSettings(View anchorView) {
           ControlElement.Type type = element.getType();
           view.findViewById(R.id.LLShape).setVisibility(View.GONE);
           view.findViewById(R.id.CBToggleSwitch).setVisibility(View.GONE);
+          view.findViewById(R.id.CBSwipeable).setVisibility(View.GONE);
           view.findViewById(R.id.LLCustomTextIcon).setVisibility(View.GONE);
           view.findViewById(R.id.LLRangeOptions).setVisibility(View.GONE);
           view.findViewById(R.id.LLRadialMenuOptions).setVisibility(View.GONE);
@@ -365,9 +366,12 @@ private void showControlElementSettings(View anchorView) {
             if (type == ControlElement.Type.BUTTON) {
               view.findViewById(R.id.LLShape).setVisibility(View.VISIBLE);
               view.findViewById(R.id.CBToggleSwitch).setVisibility(View.VISIBLE);
+              view.findViewById(R.id.CBSwipeable).setVisibility(View.VISIBLE);
             } else {
               view.findViewById(R.id.LLRadialMenuOptions).setVisibility(View.VISIBLE);
             }
+          } else if (type == ControlElement.Type.D_PAD) {
+            view.findViewById(R.id.CBSwipeable).setVisibility(View.VISIBLE);
           } else if (type == ControlElement.Type.RANGE_BUTTON) {
             view.findViewById(R.id.LLRangeOptions).setVisibility(View.VISIBLE);
           }
@@ -458,6 +462,14 @@ private void showControlElementSettings(View anchorView) {
     cbToggleSwitch.setOnCheckedChangeListener(
         (buttonView, isChecked) -> {
           element.setToggleSwitch(isChecked);
+          profile.save();
+        });
+
+    CheckBox cbSwipeable = view.findViewById(R.id.CBSwipeable);
+    cbSwipeable.setChecked(element.isSwipeable());
+    cbSwipeable.setOnCheckedChangeListener(
+        (buttonView, isChecked) -> {
+          element.setSwipeable(isChecked);
           profile.save();
         });
 

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -3778,6 +3778,14 @@ return boundingBox;
     }
   }
 
+  public boolean isCapturing(int pointerId) {
+    return currentPointerId == pointerId;
+  }
+
+  public boolean isSwipeTarget() {
+    return type == Type.BUTTON || type == Type.D_PAD || type == Type.RADIAL_MENU;
+  }
+
   public boolean handleTouchDown(int pointerId, float x, float y) {
     if (currentPointerId == -1 && containsPoint(x, y)) {
       if (type != Type.RANGE_BUTTON && type != Type.RADIAL_MENU) {

--- a/app/src/main/runtime/input/controls/ControlElement.java
+++ b/app/src/main/runtime/input/controls/ControlElement.java
@@ -96,6 +96,7 @@ public class ControlElement {
   private short y;
   private boolean selected = false;
   private boolean toggleSwitch = false;
+  private boolean swipeable = true;
   private boolean radialMenuExpanded = false;
   private int activeRadialBindingIndex = -1;
   private boolean isRadialBindingCurrentlyHeld = false;
@@ -213,6 +214,14 @@ public class ControlElement {
 
   public void setToggleSwitch(boolean toggleSwitch) {
     this.toggleSwitch = toggleSwitch;
+  }
+
+  public boolean isSwipeable() {
+    return swipeable;
+  }
+
+  public void setSwipeable(boolean swipeable) {
+    this.swipeable = swipeable;
   }
 
   public float getOpacity() {
@@ -3732,6 +3741,7 @@ return boundingBox;
       elementJSONObject.put("x", (float) x / inputControlsView.getMaxWidth());
       elementJSONObject.put("y", (float) y / inputControlsView.getMaxHeight());
       elementJSONObject.put("toggleSwitch", toggleSwitch);
+      elementJSONObject.put("swipeable", swipeable);
       elementJSONObject.put("text", text);
       elementJSONObject.put("iconId", iconId);
 
@@ -3783,7 +3793,8 @@ return boundingBox;
   }
 
   public boolean isSwipeTarget() {
-    return type == Type.BUTTON || type == Type.D_PAD || type == Type.RADIAL_MENU;
+    if (type == Type.RADIAL_MENU) return true;
+    return (type == Type.BUTTON || type == Type.D_PAD) && swipeable;
   }
 
   public boolean handleTouchDown(int pointerId, float x, float y) {

--- a/app/src/main/runtime/input/controls/ControlsProfile.java
+++ b/app/src/main/runtime/input/controls/ControlsProfile.java
@@ -288,6 +288,7 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
         element.setType(ControlElement.Type.valueOf(elementJSONObject.getString("type")));
         element.setShape(ControlElement.Shape.valueOf(elementJSONObject.getString("shape")));
         element.setToggleSwitch(elementJSONObject.getBoolean("toggleSwitch"));
+        element.setSwipeable(elementJSONObject.optBoolean("swipeable", true));
         element.setX((int) (elementJSONObject.getDouble("x") * inputControlsView.getMaxWidth()));
         element.setY((int) (elementJSONObject.getDouble("y") * inputControlsView.getMaxHeight()));
         element.setScale((float) elementJSONObject.getDouble("scale"));

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -799,22 +799,7 @@ public class InputControlsView extends View {
                   eventHandled = true;
                   activeTouchElements.put(pointerId, element);
 
-                  // Trigger haptic feedback for input controls
-                  if (hapticsEnabled) {
-                    Vibrator vibrator;
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-                      VibratorManager vibratorManager =
-                          getContext().getSystemService(VibratorManager.class);
-                      vibrator =
-                          vibratorManager != null ? vibratorManager.getDefaultVibrator() : null;
-                    } else {
-                      vibrator = getContext().getSystemService(Vibrator.class);
-                    }
-                    if (vibrator != null && vibrator.hasVibrator()) {
-                      vibrator.vibrate(
-                          VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE));
-                    }
-                  }
+                  if (hapticsEnabled) triggerTouchHaptic();
                   break;
                 }
               }
@@ -836,8 +821,49 @@ public class InputControlsView extends View {
               float y = event.getY(i);
 
               ControlElement activeElement = activeTouchElements.get(movePointerId);
-              boolean pointerHandled =
-                  activeElement != null && activeElement.handleTouchMove(movePointerId, x, y);
+              boolean swipeAllowed =
+                  touchpadView == null
+                      || touchpadView.getScreenTouchMode() != TouchpadView.MODE_MAP_TO_RIGHT_STICK;
+              boolean pointerHandled = false;
+
+              if (swipeAllowed
+                  && activeElement != null
+                  && activeElement.isCapturing(movePointerId)
+                  && (activeElement.getType() == ControlElement.Type.RADIAL_MENU
+                      || activeElement.getType() == ControlElement.Type.D_PAD)
+                  && !activeElement.containsPoint(x, y)) {
+                for (ControlElement element : profile.getElements()) {
+                  if (element.isSwipeTarget() && element.handleTouchDown(movePointerId, x, y)) {
+                    activeElement.handleTouchUp(movePointerId, x, y);
+                    activeTouchElements.put(movePointerId, element);
+                    activeElement = element;
+                    pointerHandled = true;
+                    capturesChanged = true;
+                    if (hapticsEnabled) triggerTouchHaptic();
+                    break;
+                  }
+                }
+              }
+
+              if (!pointerHandled) {
+                pointerHandled =
+                    activeElement != null && activeElement.handleTouchMove(movePointerId, x, y);
+              }
+
+              if (swipeAllowed
+                  && activeElement != null
+                  && activeElement.isSwipeTarget()
+                  && !activeElement.isCapturing(movePointerId)) {
+                for (ControlElement element : profile.getElements()) {
+                  if (element.isSwipeTarget() && element.handleTouchDown(movePointerId, x, y)) {
+                    activeTouchElements.put(movePointerId, element);
+                    pointerHandled = true;
+                    capturesChanged = true;
+                    if (hapticsEnabled) triggerTouchHaptic();
+                    break;
+                  }
+                }
+              }
 
               if (!pointerHandled && activeElement == null) {
                 if (stickElement != null && stickElement.handleTouchMove(movePointerId, x, y)) {
@@ -910,6 +936,19 @@ public class InputControlsView extends View {
       releaseStaleCaptures(event);
     }
     return true;
+  }
+
+  private void triggerTouchHaptic() {
+    Vibrator vibrator;
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+      VibratorManager vibratorManager = getContext().getSystemService(VibratorManager.class);
+      vibrator = vibratorManager != null ? vibratorManager.getDefaultVibrator() : null;
+    } else {
+      vibrator = getContext().getSystemService(Vibrator.class);
+    }
+    if (vibrator != null && vibrator.hasVibrator()) {
+      vibrator.vibrate(VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE));
+    }
   }
 
   private void syncCapturedPointers() {

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -852,7 +852,7 @@ public class InputControlsView extends View {
 
               if (swipeAllowed
                   && activeElement != null
-                  && activeElement.isSwipeTarget()
+                  && activeElement.getType() == ControlElement.Type.BUTTON
                   && !activeElement.isCapturing(movePointerId)) {
                 for (ControlElement element : profile.getElements()) {
                   if (element.isSwipeTarget() && element.handleTouchDown(movePointerId, x, y)) {


### PR DESCRIPTION
Sliding off a touch button no longer leaves the finger dead: buttons press on entry and release on exit, d-pad engages steering on entry and hands off when exited onto another control, radial menus swipe-open and close when pulled out to another control. Range buttons unchanged; disabled in map-to-right-stick mode. Multi-touch capture stays per-pointer.