### PR TITLE
Add Unix/Windows Zink mode toggle for arm64ec (container + shortcut)

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -400,6 +400,9 @@ class GameSettingsStateHolder {
     // Display
     val graphicsDriverEntries = mutableStateOf<List<String>>(emptyList())
     val selectedGraphicsDriver = mutableIntStateOf(0)
+    val isArm64EC = mutableStateOf(false)
+    val zinkModeEntries = mutableStateOf<List<String>>(emptyList())
+    val selectedZinkMode = mutableIntStateOf(0)
     val graphicsDriverVersion = mutableStateOf("")
     val dxWrapperEntries = mutableStateOf<List<String>>(emptyList())
     val selectedDxWrapper = mutableIntStateOf(0)
@@ -658,13 +661,13 @@ private fun buildSections(isSteam: Boolean, isContainer: Boolean): List<Pair<Int
     list += SEC_DISPLAY to SidebarSection(Icons.Outlined.Monitor, R.string.common_ui_graphics)
     list += SEC_ADVANCED to SidebarSection(Icons.Outlined.Settings, R.string.common_ui_advanced)
     list += SEC_RESHADE to SidebarSection(Icons.Outlined.AutoAwesome, R.string.reshade_section_title)
+    list += SEC_VARIABLES to SidebarSection(Icons.Outlined.Code, R.string.container_config_variables)
     list += SEC_INPUT to SidebarSection(Icons.Outlined.SportsEsports, R.string.common_ui_input_controls)
+    list += SEC_COMPONENTS to SidebarSection(Icons.Outlined.Extension, R.string.settings_content_components)
     if (isContainer) {
         list += SEC_DRIVES to SidebarSection(Icons.Outlined.Storage, R.string.container_config_drives)
     }
-    list += SEC_VARIABLES to SidebarSection(Icons.Outlined.Code, R.string.container_config_variables)
     list += SEC_WINE to SidebarSection(Icons.Outlined.Science, R.string.container_wine_title)
-    list += SEC_COMPONENTS to SidebarSection(Icons.Outlined.Extension, R.string.settings_content_components)
     if (isContainer) {
         list += SEC_SAVES to SidebarSection(Icons.Outlined.Inventory, R.string.saves_import_export_title)
     }
@@ -3500,23 +3503,35 @@ private fun ComponentsSection(
         Spacer(Modifier.height(8.dp))
         SettingGroup {
             val items = state.generalComponents.value
-            items.chunked(2).forEachIndexed { rowIndex, pair ->
+            val showZink = state.isArm64EC.value
+            val totalCells = items.size + if (showZink) 1 else 0
+            val rowCount = (totalCells + 1) / 2
+            for (rowIndex in 0 until rowCount) {
                 if (rowIndex > 0) Spacer(Modifier.height(SettingItemGap))
                 Row(horizontalArrangement = Arrangement.spacedBy(SettingItemGap)) {
-                    pair.forEachIndexed { colIndex, component ->
-                        val index = rowIndex * 2 + colIndex
+                    for (colIndex in 0..1) {
+                        val cell = rowIndex * 2 + colIndex
                         Box(Modifier.weight(1f)) {
-                            SettingDropdown(
-                                label = component.label,
-                                entries = state.winComponentEntries.value,
-                                selectedIndex = component.selectedIndex,
-                                onSelected = { newVal ->
-                                    callbacks.onUpdateWinComponent(false, index, newVal)
-                                }
-                            )
+                            if (cell < items.size) {
+                                val component = items[cell]
+                                SettingDropdown(
+                                    label = component.label,
+                                    entries = state.winComponentEntries.value,
+                                    selectedIndex = component.selectedIndex,
+                                    onSelected = { newVal ->
+                                        callbacks.onUpdateWinComponent(false, cell, newVal)
+                                    }
+                                )
+                            } else if (cell == items.size && showZink) {
+                                SettingDropdown(
+                                    label = stringResource(R.string.container_zink_mode),
+                                    entries = state.zinkModeEntries.value,
+                                    selectedIndex = state.selectedZinkMode.intValue,
+                                    onSelected = { state.selectedZinkMode.intValue = it }
+                                )
+                            }
                         }
                     }
-                    if (pair.size == 1) Box(Modifier.weight(1f))
                 }
             }
         }

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -248,6 +248,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                 val identifier = wineVersionIdentifiers.getOrNull(versionIndex) ?: return
                 val wineInfo = WineInfo.fromIdentifier(context, contentsManager, identifier)
                 isArm64EC = wineInfo.isArm64EC()
+                state.isArm64EC.value = isArm64EC
                 state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
                 applyDefaultContainerName(wineInfo, identifier)
                 // Box64 list depends on arch (box64 vs wowbox64 entries).
@@ -531,6 +532,10 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             state.selectedGraphicsDriver
         )
 
+        state.zinkModeEntries.value = context.resources.getStringArray(R.array.zink_mode_entries).toList()
+        state.selectedZinkMode.intValue =
+            if ((c?.getZinkMode() ?: Container.DEFAULT_ZINK_MODE) == "windows") 1 else 0
+
         val dxWrapperArr = context.resources.getStringArray(R.array.dxwrapper_entries).toList()
         state.dxWrapperEntries.value = dxWrapperArr
         selectByIdentifier(
@@ -575,6 +580,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         if (c != null) {
             val wineInfo = WineInfo.fromIdentifier(context, contentsManager, c.getWineVersion())
             isArm64EC = wineInfo.isArm64EC()
+            state.isArm64EC.value = isArm64EC
             state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
 
             rebuildEmulatorLists()
@@ -706,6 +712,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
         val wineInfo = WineInfo.fromIdentifier(context, contentsManager, selectedIdentifier)
         val archChanged = isArm64EC != wineInfo.isArm64EC()
         isArm64EC = wineInfo.isArm64EC()
+        state.isArm64EC.value = isArm64EC
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
         applyDefaultContainerName(wineInfo, selectedIdentifier)
 
@@ -816,6 +823,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
             c.setCPUList(cpuList)
             c.setCPUListWoW64(cpuListWoW64)
             c.setGraphicsDriver(graphicsDriver)
+            c.setZinkMode(if (state.selectedZinkMode.intValue == 1) "windows" else "unix")
             c.setGraphicsDriverConfig(graphicsDriverConfig)
             c.setDXWrapper(dxwrapper)
             c.setDXWrapperConfig(dxwrapperConfig)
@@ -907,6 +915,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
                             if (state.selectedSurfaceEffect.intValue == 1) "1" else "0"
                         )
                         getRefreshRateFromState()?.let { newContainer.putExtra("refreshRate", it) }
+                        newContainer.setZinkMode(if (state.selectedZinkMode.intValue == 1) "windows" else "unix")
                         newContainer.saveData()
                         saveMouseWarpOverride(newContainer)
                     } else {

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -541,6 +541,10 @@ class ShortcutSettingsComposeDialog private constructor(
             state.selectedGraphicsDriver
         )
 
+        state.zinkModeEntries.value = context.resources.getStringArray(R.array.zink_mode_entries).toList()
+        state.selectedZinkMode.intValue =
+            if (getShortcutSetting("zinkMode", container.getZinkMode()) == "windows") 1 else 0
+
         // DX Wrapper
         val dxWrapperArr =
             context.resources.getStringArray(R.array.dxwrapper_entries).toList()
@@ -580,6 +584,7 @@ class ShortcutSettingsComposeDialog private constructor(
         else shortcut.getExtra("wineVersion", container.getWineVersion())
         val wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersionStr)
         isArm64EC = wineInfo.isArm64EC
+        state.isArm64EC.value = isArm64EC
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
 
         rebuildEmulatorLists()
@@ -683,6 +688,7 @@ class ShortcutSettingsComposeDialog private constructor(
         val wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersionStr)
         val archChanged = isArm64EC != wineInfo.isArm64EC
         isArm64EC = wineInfo.isArm64EC
+        state.isArm64EC.value = isArm64EC
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
 
         rebuildEmulatorLists()
@@ -1039,6 +1045,10 @@ class ShortcutSettingsComposeDialog private constructor(
             )
             hasContainerOverride =
                 hasContainerOverride or saveOverride("graphicsDriver", graphicsDriver, container.getGraphicsDriver())
+
+            val zinkMode = if (state.selectedZinkMode.intValue == 1) "windows" else "unix"
+            hasContainerOverride =
+                hasContainerOverride or saveOverride("zinkMode", zinkMode, container.getZinkMode())
 
             val graphicsDriverConfig = buildGraphicsDriverConfigFromState()
             hasContainerOverride = hasContainerOverride or saveOverride(
@@ -2194,6 +2204,7 @@ class ShortcutSettingsComposeDialog private constructor(
         val wineVersionStr = newContainer.getWineVersion()
         val wineInfo = WineInfo.fromIdentifier(context, contentsManager, wineVersionStr)
         isArm64EC = wineInfo.isArm64EC
+        state.isArm64EC.value = isArm64EC
         state.wineVersionDisplay.value = formatWineVersionDisplay(wineInfo)
         rebuildEmulatorLists()
 

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Controlador de gráficos</string>
+    <string name="container_zink_mode">Modo Zink</string>
     <string name="container_graphics_configuration">Configuración del controlador de gráficos</string>
     <string name="container_graphics_version">Versión del controlador de gráficos</string>
     <string name="container_graphics_available_extensions">Extensiones disponibles</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafikdriver</string>
+    <string name="container_zink_mode">Zink-tilstand</string>
     <string name="container_graphics_transcoder">BCn-transkoder</string>
     <string name="container_graphics_quality">BCn-kvalitet</string>
     <string name="container_graphics_configuration">Grafikdriver-konfiguration</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafiktreiber</string>
+    <string name="container_zink_mode">Zink-Modus</string>
     <string name="container_graphics_transcoder">BCn-Transcoder</string>
     <string name="container_graphics_quality">BCn-Qualität</string>
     <string name="container_graphics_configuration">Grafiktreiber-Konfiguration</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Controlador gráfico</string>
+    <string name="container_zink_mode">Modo Zink</string>
     <string name="container_graphics_transcoder">Transcodificador BCn</string>
     <string name="container_graphics_quality">Calidad BCn</string>
     <string name="container_graphics_configuration">Configuración del controlador gráfico</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafiikka-ajuri</string>
+    <string name="container_zink_mode">Zink-tila</string>
     <string name="container_graphics_configuration">Grafiikka-ajurin asetukset</string>
     <string name="container_graphics_version">Grafiikka-ajurin versio</string>
     <string name="container_graphics_available_extensions">Saatavilla olevat laajennukset</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Pilote graphique</string>
+    <string name="container_zink_mode">Mode Zink</string>
     <string name="container_graphics_transcoder">Transcodeur BCn</string>
     <string name="container_graphics_quality">Qualité BCn</string>
     <string name="container_graphics_configuration">Configuration du pilote graphique</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -567,6 +567,7 @@
     <string name="container_fexcore_version">FEXCore संस्करण</string>
     <string name="use_unix_libs">UnixLibs का उपयोग करें</string>
     <string name="container_graphics_driver">ग्राफ़िक्स ड्राइवर</string>
+    <string name="container_zink_mode">Zink मोड</string>
     <string name="container_graphics_transcoder">BCn ट्रांसकोडर</string>
     <string name="container_graphics_quality">BCn गुणवत्ता</string>
     <string name="container_graphics_configuration">ग्राफ़िक्स ड्राइवर कॉन्फ़िगरेशन</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Driver grafico</string>
+    <string name="container_zink_mode">Modalità Zink</string>
     <string name="container_graphics_transcoder">Transcodificatore BCn</string>
     <string name="container_graphics_quality">Qualità BCn</string>
     <string name="container_graphics_configuration">Configurazione driver grafico</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">グラフィックスドライバー</string>
+    <string name="container_zink_mode">Zink モード</string>
     <string name="container_graphics_configuration">グラフィックスドライバー設定</string>
     <string name="container_graphics_version">グラフィックスドライバーバージョン</string>
     <string name="container_graphics_available_extensions">利用可能な拡張機能</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">그래픽 드라이버</string>
+    <string name="container_zink_mode">Zink 모드</string>
     <string name="container_graphics_transcoder">BCn 트랜스코더</string>
     <string name="container_graphics_quality">BCn 품질</string>
     <string name="container_graphics_configuration">그래픽 드라이버 구성</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafikkdriver</string>
+    <string name="container_zink_mode">Zink-modus</string>
     <string name="container_graphics_configuration">Konfigurasjon av grafikkdriver</string>
     <string name="container_graphics_version">Versjon av grafikkdriver</string>
     <string name="container_graphics_available_extensions">Tilgjengelige utvidelser</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -516,6 +516,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Sterownik grafiki</string>
+    <string name="container_zink_mode">Tryb Zink</string>
     <string name="container_graphics_transcoder">Transkoder BCn</string>
     <string name="container_graphics_quality">Jakość BCn</string>
     <string name="container_graphics_configuration">Konfiguracja sterownika grafiki</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Driver Grafico</string>
+    <string name="container_zink_mode">Modo Zink</string>
     <string name="container_graphics_transcoder">Transcodificador BCn</string>
     <string name="container_graphics_quality">Qualidade BCn</string>
     <string name="container_graphics_configuration">Configuracao do Driver Grafico</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Controlador Gráfico</string>
+    <string name="container_zink_mode">Modo Zink</string>
     <string name="container_graphics_configuration">Configuração do Controlador Gráfico</string>
     <string name="container_graphics_version">Versão do Controlador Gráfico</string>
     <string name="container_graphics_available_extensions">Extensões Disponíveis</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Driver grafic</string>
+    <string name="container_zink_mode">Mod Zink</string>
     <string name="container_graphics_transcoder">Transcodor BCn</string>
     <string name="container_graphics_quality">Calitate BCn</string>
     <string name="container_graphics_configuration">Configurare driver grafic</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -522,6 +522,7 @@
     <string name="use_unix_libs">Использовать UnixLibs</string>
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Графический драйвер</string>
+    <string name="container_zink_mode">Режим Zink</string>
     <string name="container_graphics_transcoder">Транскодер BCn</string>
     <string name="container_graphics_quality">Качество BCn</string>
     <string name="container_graphics_configuration">Конфигурация графического драйвера</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafikdrivrutin</string>
+    <string name="container_zink_mode">Zink-läge</string>
     <string name="container_graphics_configuration">Grafikdrivrutinskonfiguration</string>
     <string name="container_graphics_version">Grafikdrivrutinsversion</string>
     <string name="container_graphics_available_extensions">Tillgängliga tillägg</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">ไดรเวอร์กราฟิก</string>
+    <string name="container_zink_mode">โหมด Zink</string>
     <string name="container_graphics_configuration">การกำหนดค่าไดรเวอร์กราฟิก</string>
     <string name="container_graphics_version">เวอร์ชันไดรเวอร์กราฟิก</string>
     <string name="container_graphics_available_extensions">ส่วนขยายที่ใช้ได้</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -594,6 +594,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Grafik Sürücüsü</string>
+    <string name="container_zink_mode">Zink Modu</string>
     <string name="container_graphics_configuration">Grafik Sürücüsü Yapılandırması</string>
     <string name="container_graphics_version">Grafik Sürücüsü Sürümü</string>
     <string name="container_graphics_available_extensions">Kullanılabilir Uzantılar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -516,6 +516,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Графічний драйвер</string>
+    <string name="container_zink_mode">Режим Zink</string>
     <string name="container_graphics_transcoder">Транскодер BCn</string>
     <string name="container_graphics_quality">Якість BCn</string>
     <string name="container_graphics_configuration">Конфігурація графічного драйвера</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">图形驱动</string>
+    <string name="container_zink_mode">Zink 模式</string>
     <string name="container_graphics_transcoder">BCn 转码器</string>
     <string name="container_graphics_quality">BCn 质量</string>
     <string name="container_graphics_configuration">图形驱动配置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -512,6 +512,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">圖形驅動程式</string>
+    <string name="container_zink_mode">Zink 模式</string>
     <string name="container_graphics_transcoder">BCn 轉碼器</string>
     <string name="container_graphics_quality">BCn 品質</string>
     <string name="container_graphics_configuration">圖形驅動程式設定</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -23,6 +23,10 @@
         <item>Wrapper-Leegao</item>
         <item>Wrapper-Gamenative</item>
     </string-array>
+    <string-array name="zink_mode_entries">
+        <item>Unix Zink</item>
+        <item>Windows Zink</item>
+    </string-array>
     <string-array name="wrapper_graphics_driver_version_entries">
         <item>System</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -633,6 +633,7 @@
 
     <!-- Container > Graphics Driver -->
     <string name="container_graphics_driver">Graphics Driver</string>
+    <string name="container_zink_mode">Zink Mode</string>
     <string name="container_graphics_configuration">Graphics Driver Configuration</string>
     <string name="container_graphics_version">Graphics Driver Version</string>
     <string name="container_graphics_available_extensions">Available Extensions</string>

--- a/app/src/main/runtime/container/Container.java
+++ b/app/src/main/runtime/container/Container.java
@@ -23,6 +23,7 @@ public class Container {
     public static final String DEFAULT_ENV_VARS = "WRAPPER_MAX_IMAGE_COUNT=0 VKD3D_SHADER_MODEL=6_6 ZINK_DESCRIPTORS=lazy ZINK_DEBUG=compact MESA_SHADER_CACHE_DISABLE=false MESA_SHADER_CACHE_MAX_SIZE=512MB mesa_glthread=true TU_DEBUG=noconform,sysmem";
     public static final String DEFAULT_SCREEN_SIZE = "1280x720";
     public static final String DEFAULT_GRAPHICS_DRIVER = "wrapper";
+    public static final String DEFAULT_ZINK_MODE = "unix";
     public static final String DEFAULT_AUDIO_DRIVER = "alsa";
     public static final String DEFAULT_EMULATOR = "Box64";
     public static final String DEFAULT_EMULATOR64 = "Box64";
@@ -150,6 +151,14 @@ public class Container {
 
     public void setGraphicsDriver(String graphicsDriver) {
         this.graphicsDriver = graphicsDriver;
+    }
+
+    public String getZinkMode() {
+        return getExtra("zinkMode", DEFAULT_ZINK_MODE);
+    }
+
+    public void setZinkMode(String zinkMode) {
+        putExtra("zinkMode", zinkMode);
     }
 
     public String getGraphicsDriverConfig() { return this.graphicsDriverConfig; }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -292,6 +292,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private Shortcut shortcut;
     private boolean launchedFromPinnedShortcut = false;
     private String graphicsDriver = Container.DEFAULT_GRAPHICS_DRIVER;
+    private String zinkMode = Container.DEFAULT_ZINK_MODE;
     private HashMap<String, String> graphicsDriverConfig;
     private String audioDriver = Container.DEFAULT_AUDIO_DRIVER;
     private String emulator = Container.DEFAULT_EMULATOR;
@@ -1526,6 +1527,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
         }
 
         graphicsDriver = container.getGraphicsDriver();
+        zinkMode = container.getZinkMode();
         String graphicsDriverConfig = container.getGraphicsDriverConfig();
         audioDriver = container.getAudioDriver();
         emulator = container.getEmulator();
@@ -1672,6 +1674,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             String rawShortcutDxwrapper = shortcutUsesDefaults ? "" : shortcut.getExtra("dxwrapper");
 
             graphicsDriver = getShortcutSetting("graphicsDriver", container.getGraphicsDriver());
+            zinkMode = getShortcutSetting("zinkMode", container.getZinkMode());
             graphicsDriverConfig = getShortcutSetting("graphicsDriverConfig", container.getGraphicsDriverConfig());
             audioDriver = getShortcutSetting("audioDriver", container.getAudioDriver());
             emulator = getShortcutSetting("emulator", container.getEmulator());
@@ -8075,6 +8078,24 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this, "layers" + ".tzst", rootDir);
             leegaoMarker.delete();
             gamenativeMarker.delete();
+        }
+
+        // libgallium_wgl.dll is present only while Windows Zink is installed — use as marker.
+        if (wineInfo != null && wineInfo.isArm64EC()
+                && !GPUInformation.getRenderer(null, null).contains("Mali")) {
+            File winWindowsDir = new File(rootDir, ImageFs.WINEPREFIX + "/drive_c/windows");
+            File zinkMarker = new File(winWindowsDir, "system32/libgallium_wgl.dll");
+            if ("windows".equals(zinkMode)) {
+                if (!zinkMarker.exists()) {
+                    try {
+                        TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this, "graphics_driver/zink_dlls.tzst", winWindowsDir);
+                    } catch (Exception e) {
+                        Log.w("XServerDisplayActivity", "zink_dlls.tzst extraction failed", e);
+                    }
+                }
+            } else if (zinkMarker.exists()) {
+                WinComponentSetup.restoreWineBuiltinDllFiles(imageFs, wineInfo, "opengl32.dll", "libgallium_wgl.dll");
+            }
         }
 
         if (adrenoToolsDriverId != null && !adrenoToolsDriverId.isEmpty()


### PR DESCRIPTION
Dropdown in Components (General group), gated to arm64ec, saved per-container and overridable per-shortcut. At boot the resolved mode extracts the Windows Mesa opengl32 DLLs (Windows Zink) or restores wine's builtin (Unix Zink), keyed off the libgallium_wgl marker so a container and its shortcuts self-correct. Reorder settings sidebar to Variables, Input, Components; add localized Zink Mode label to all locales.