### PR TITLE
Add Freeze Log debug toggle

### DIFF
--- a/app/src/main/feature/settings/debug/DebugFragment.kt
+++ b/app/src/main/feature/settings/debug/DebugFragment.kt
@@ -147,6 +147,10 @@ class DebugFragment : Fragment() {
                                 preferences.edit { putBoolean("hud_record_to_file", checked) }
                                 refresh()
                             },
+                            onFreezeLogChanged = { checked ->
+                                preferences.edit { putBoolean("enable_freeze_log", checked) }
+                                refresh()
+                            },
                             onVulkanValidationLayersChanged = { checked ->
                                 preferences.edit { putBoolean("enable_vulkan_validation_layers", checked) }
                                 refresh()
@@ -214,6 +218,7 @@ class DebugFragment : Fragment() {
                 inputLogs = preferences.getBoolean("enable_input_logs", false),
                 downloadLogs = preferences.getBoolean("enable_download_logs", false),
                 recordPerformanceToFile = preferences.getBoolean("hud_record_to_file", false),
+                freezeLog = preferences.getBoolean("enable_freeze_log", false),
                 vulkanValidationLayers = preferences.getBoolean("enable_vulkan_validation_layers", false),
                 wnHybridMode = com.winlator.cmod.feature.stores.steam.utils.PrefManager.wnHybridMode,
                 logsSize =

--- a/app/src/main/feature/settings/debug/DebugScreen.kt
+++ b/app/src/main/feature/settings/debug/DebugScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.AcUnit
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.CloudDownload
@@ -156,6 +157,7 @@ data class DebugState(
     val inputLogs: Boolean = false,
     val downloadLogs: Boolean = false,
     val recordPerformanceToFile: Boolean = false,
+    val freezeLog: Boolean = false,
     val vulkanValidationLayers: Boolean = false,
     val wnHybridMode: Boolean = false,
     val logsSize: String = "0 B",
@@ -186,6 +188,7 @@ fun DebugScreen(
     onInputLogsChanged: (Boolean) -> Unit,
     onDownloadLogsChanged: (Boolean) -> Unit,
     onRecordPerformanceToFileChanged: (Boolean) -> Unit,
+    onFreezeLogChanged: (Boolean) -> Unit,
     onVulkanValidationLayersChanged: (Boolean) -> Unit,
     onWnHybridModeChanged: (Boolean) -> Unit,
     onShareLogs: () -> Unit,
@@ -338,6 +341,15 @@ fun DebugScreen(
                 icon = Icons.Outlined.CloudDownload,
                 checked = state.downloadLogs,
                 onCheckedChange = onDownloadLogsChanged,
+            )
+
+            SettingsToggleCard(
+                title = stringResource(R.string.settings_debug_freeze_log),
+                subtitle = stringResource(R.string.settings_debug_freeze_log_description),
+                icon = Icons.Outlined.AcUnit,
+                checked = state.freezeLog,
+                onCheckedChange = onFreezeLogChanged,
+                accentColor = Color(0xFF7FC7FF),
             )
 
             SettingsToggleCard(

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -1118,6 +1118,8 @@ Por ejemplo, <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_debug_input_logs_description">Registra los eventos de entrada de gamepad, toque y teclado</string>
     <string name="settings_debug_download_logs">Registros de descarga</string>
     <string name="settings_debug_download_logs_description">Registra los eventos del resolutor de descargas y del respaldo de WinNative</string>
+    <string name="settings_debug_freeze_log">Registro de bloqueos</string>
+    <string name="settings_debug_freeze_log_description">Cuando el juego deja de dibujar, registra qué está haciendo cada hilo invitado</string>
     <string name="settings_debug_vulkan_validation_layers_title">Capas de validación de Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Reinicia la pantalla para aplicar.</string>
     <string name="settings_debug_share_logs">Compartir registros</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -830,6 +830,8 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_debug_input_logs_description">Log gamepad-, touch- og tastaturinputhændelser</string>
     <string name="settings_debug_download_logs">Download-logfiler</string>
     <string name="settings_debug_download_logs_description">Log download-resolver og WinNative-fallback-hændelser</string>
+    <string name="settings_debug_freeze_log">Fryselog</string>
+    <string name="settings_debug_freeze_log_description">Når spillet holder op med at tegne, registrér hvad hver gæstetråd laver</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan-valideringslag</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Genstart skærmen for at anvende.</string>
     <string name="settings_debug_share_logs">Del logfiler</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -830,6 +830,8 @@ Z. B. <b>META</b> für <i>Meta-Taste</i>, \n
     <string name="settings_debug_input_logs_description">Gamepad-, Touch- und Tastatur-Eingabeereignisse protokollieren</string>
     <string name="settings_debug_download_logs">Download-Protokolle</string>
     <string name="settings_debug_download_logs_description">Download-Resolver- und WinNative-Fallback-Ereignisse protokollieren</string>
+    <string name="settings_debug_freeze_log">Freeze-Protokoll</string>
+    <string name="settings_debug_freeze_log_description">Wenn das Spiel nicht mehr zeichnet, aufzeichnen, was jeder Gast-Thread tut</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan-Validierungsebenen</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Display neu starten, um die Änderung anzuwenden.</string>
     <string name="settings_debug_share_logs">Protokolle teilen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -830,6 +830,8 @@ Ej. <b>META</b> para la <i>tecla META</i>, \n
     <string name="settings_debug_input_logs_description">Registrar eventos de entrada de mando, táctil y teclado</string>
     <string name="settings_debug_download_logs">Registros de descarga</string>
     <string name="settings_debug_download_logs_description">Registrar eventos del resolvedor de descargas y respaldo de WinNative</string>
+    <string name="settings_debug_freeze_log">Registro de bloqueos</string>
+    <string name="settings_debug_freeze_log_description">Cuando el juego deja de dibujar, registra qué está haciendo cada hilo invitado</string>
     <string name="settings_debug_vulkan_validation_layers_title">Capas de validación de Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Reinicia la pantalla para aplicar.</string>
     <string name="settings_debug_share_logs">Compartir registros</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1118,6 +1118,8 @@ E.g. <b>META</b> for <i>META-näppäin</i>, \n
     <string name="settings_debug_input_logs_description">Kirjaa peliohjaimen, kosketuksen ja näppäimistön syötetapahtumat</string>
     <string name="settings_debug_download_logs">Latauslokit</string>
     <string name="settings_debug_download_logs_description">Kirjaa latausten selvitys- ja WinNative-varajärjestelmätapahtumat</string>
+    <string name="settings_debug_freeze_log">Jumiutumisloki</string>
+    <string name="settings_debug_freeze_log_description">Kun peli lakkaa piirtämästä, tallenna mitä kukin vierassäie tekee</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan-validointikerrokset</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Käynnistä näyttö uudelleen ottaaksesi käyttöön.</string>
     <string name="settings_debug_share_logs">Jaa lokit</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -830,6 +830,8 @@ Par ex. <b>META</b> pour la <i>touche META</i>, \n
     <string name="settings_debug_input_logs_description">Journaliser les événements de saisie manette, tactile et clavier</string>
     <string name="settings_debug_download_logs">Journaux de téléchargement</string>
     <string name="settings_debug_download_logs_description">Journaliser les événements du résolveur de téléchargement et du repli WinNative</string>
+    <string name="settings_debug_freeze_log">Journal de blocage</string>
+    <string name="settings_debug_freeze_log_description">Quand le jeu cesse de dessiner, enregistrer ce que fait chaque thread invité</string>
     <string name="settings_debug_vulkan_validation_layers_title">Couches de validation Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Redémarrez l\'affichage pour appliquer.</string>
     <string name="settings_debug_share_logs">Partager les journaux</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -940,6 +940,8 @@
     <string name="settings_debug_input_logs_description">गेमपैड, टच और कीबोर्ड इनपुट इवेंट लॉग करें</string>
     <string name="settings_debug_download_logs">डाउनलोड लॉग</string>
     <string name="settings_debug_download_logs_description">डाउनलोड रिज़ॉल्वर और WinNative फ़ॉलबैक ईवेंट लॉग करें</string>
+    <string name="settings_debug_freeze_log">फ़्रीज़ लॉग</string>
+    <string name="settings_debug_freeze_log_description">जब गेम ड्रॉ करना बंद कर दे, तो रिकॉर्ड करें कि हर गेस्ट थ्रेड क्या कर रहा है</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan सत्यापन परतें</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">लागू करने के लिए प्रदर्शन पुनः प्रारंभ करें.</string>
     <string name="settings_debug_share_logs">लॉग शेयर करें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -830,6 +830,8 @@ Ad es. <b>META</b> per il <i>tasto META</i>, \n
     <string name="settings_debug_input_logs_description">Registra gli eventi di input gamepad, touch e tastiera</string>
     <string name="settings_debug_download_logs">Log download</string>
     <string name="settings_debug_download_logs_description">Registra gli eventi del risolutore download e fallback WinNative</string>
+    <string name="settings_debug_freeze_log">Registro blocchi</string>
+    <string name="settings_debug_freeze_log_description">Quando il gioco smette di disegnare, registra cosa sta facendo ogni thread guest</string>
     <string name="settings_debug_vulkan_validation_layers_title">Livelli di validazione Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Riavvia il display per applicare.</string>
     <string name="settings_debug_share_logs">Condividi log</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1118,6 +1118,8 @@
     <string name="settings_debug_input_logs_description">ゲームパッド、タッチ、キーボードの入力イベントを記録します</string>
     <string name="settings_debug_download_logs">ダウンロードログ</string>
     <string name="settings_debug_download_logs_description">ダウンロードリゾルバーと WinNative フォールバックのイベントを記録します</string>
+    <string name="settings_debug_freeze_log">フリーズログ</string>
+    <string name="settings_debug_freeze_log_description">ゲームの描画が停止したとき、各ゲストスレッドの状態を記録します</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan 検証レイヤー</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">適用するにはディスプレイを再起動してください。</string>
     <string name="settings_debug_share_logs">ログを共有</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -830,6 +830,8 @@
     <string name="settings_debug_input_logs_description">게임패드, 터치 및 키보드 입력 이벤트를 기록</string>
     <string name="settings_debug_download_logs">다운로드 로그</string>
     <string name="settings_debug_download_logs_description">다운로드 리졸버 및 WinNative 폴백 이벤트를 기록</string>
+    <string name="settings_debug_freeze_log">멈춤 로그</string>
+    <string name="settings_debug_freeze_log_description">게임이 그리기를 멈추면 각 게스트 스레드의 상태를 기록합니다</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan 검증 레이어</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">적용하려면 디스플레이를 다시 시작하세요.</string>
     <string name="settings_debug_share_logs">로그 공유</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1118,6 +1118,8 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="settings_debug_input_logs_description">Logg inndatahendelser fra spillkontroller, berøring og tastatur</string>
     <string name="settings_debug_download_logs">Nedlastingslogger</string>
     <string name="settings_debug_download_logs_description">Logg nedlastingsresolver- og WinNative-reservehendelser</string>
+    <string name="settings_debug_freeze_log">Frysingslogg</string>
+    <string name="settings_debug_freeze_log_description">Når spillet slutter å tegne, registrer hva hver gjestetråd gjør</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan-valideringslag</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Start skjermen på nytt for å ta i bruk.</string>
     <string name="settings_debug_share_logs">Del logger</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -836,6 +836,8 @@ Np. <b>META</b> dla <i>klawisza META</i>, \n
     <string name="settings_debug_input_logs_description">Loguj zdarzenia gamepada, dotyku i klawiatury</string>
     <string name="settings_debug_download_logs">Logi pobierania</string>
     <string name="settings_debug_download_logs_description">Loguj zdarzenia resolvera pobierania i fallbacku WinNative</string>
+    <string name="settings_debug_freeze_log">Dziennik zawieszeń</string>
+    <string name="settings_debug_freeze_log_description">Gdy gra przestaje rysować, zapisz co robi każdy wątek gościa</string>
     <string name="settings_debug_vulkan_validation_layers_title">Warstwy walidacji Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Uruchom ponownie wyświetlanie, aby zastosować.</string>
     <string name="settings_debug_share_logs">Udostępnij logi</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -830,6 +830,8 @@ Ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_debug_input_logs_description">Registrar eventos de entrada do gamepad, toque e teclado</string>
     <string name="settings_debug_download_logs">Logs de Download</string>
     <string name="settings_debug_download_logs_description">Registrar eventos do resolvedor de download e fallback do WinNative</string>
+    <string name="settings_debug_freeze_log">Registro de travamentos</string>
+    <string name="settings_debug_freeze_log_description">Quando o jogo para de desenhar, registrar o que cada thread convidada está fazendo</string>
     <string name="settings_debug_vulkan_validation_layers_title">Camadas de Validação Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Reinicie a exibição para aplicar.</string>
     <string name="settings_debug_share_logs">Compartilhar Logs</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1118,6 +1118,8 @@ Por ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="settings_debug_input_logs_description">Registar eventos de entrada de comando, toque e teclado</string>
     <string name="settings_debug_download_logs">Registos de Transferências</string>
     <string name="settings_debug_download_logs_description">Registar eventos do resolvedor de transferências e de recurso do WinNative</string>
+    <string name="settings_debug_freeze_log">Registo de bloqueios</string>
+    <string name="settings_debug_freeze_log_description">Quando o jogo deixa de desenhar, registar o que cada thread convidada está a fazer</string>
     <string name="settings_debug_vulkan_validation_layers_title">Camadas de Validação do Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Reinicie o ecrã para aplicar.</string>
     <string name="settings_debug_share_logs">Partilhar Registos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -830,6 +830,8 @@ De ex. <b>META</b> pentru <i>tasta META</i>, \n
     <string name="settings_debug_input_logs_description">Inregistreaza evenimentele de intrare gamepad, tactile si tastatura</string>
     <string name="settings_debug_download_logs">Jurnale descarcari</string>
     <string name="settings_debug_download_logs_description">Inregistreaza evenimentele de rezolvare descarcari si alternativa WinNative</string>
+    <string name="settings_debug_freeze_log">Jurnal de blocare</string>
+    <string name="settings_debug_freeze_log_description">Când jocul nu mai desenează, înregistrează ce face fiecare fir invitat</string>
     <string name="settings_debug_vulkan_validation_layers_title">Straturi de validare Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Repornește afișajul pentru aplicare.</string>
     <string name="settings_debug_share_logs">Partajeaza jurnalele</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -901,6 +901,8 @@
     <string name="settings_debug_input_logs_description">Записывать события ввода с геймпада, сенсорного экрана и клавиатуры.</string>
     <string name="settings_debug_download_logs">Журналы загрузок</string>
     <string name="settings_debug_download_logs_description">Записывать события загрузок и резервного копирования WinNative</string>
+    <string name="settings_debug_freeze_log">Журнал зависаний</string>
+    <string name="settings_debug_freeze_log_description">Когда игра перестаёт отрисовывать, записывать, чем занят каждый гостевой поток</string>
     <string name="settings_debug_vulkan_validation_layers_title">Слои валидации Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Перезапустите дисплей, чтобы применить.</string>
     <string name="settings_debug_share_logs">Поделиться журналами</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1118,6 +1118,8 @@ T.ex. <b>META</b> för <i>META-tangent</i>, \n
     <string name="settings_debug_input_logs_description">Logga inmatningshändelser från gamepad, pekskärm och tangentbord</string>
     <string name="settings_debug_download_logs">Nedladdningsloggar</string>
     <string name="settings_debug_download_logs_description">Logga händelser för nedladdningsupplösare och WinNative-reserv</string>
+    <string name="settings_debug_freeze_log">Frysningslogg</string>
+    <string name="settings_debug_freeze_log_description">När spelet slutar rita, registrera vad varje gästtråd gör</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan-valideringslager</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Starta om skärmen för att tillämpa.</string>
     <string name="settings_debug_share_logs">Dela loggar</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1118,6 +1118,8 @@
     <string name="settings_debug_input_logs_description">บันทึกเหตุการณ์อินพุตของเกมแพด สัมผัส และคีย์บอร์ด</string>
     <string name="settings_debug_download_logs">บันทึกการดาวน์โหลด</string>
     <string name="settings_debug_download_logs_description">บันทึกเหตุการณ์ตัวแก้ไขการดาวน์โหลดและ WinNative fallback</string>
+    <string name="settings_debug_freeze_log">บันทึกการค้าง</string>
+    <string name="settings_debug_freeze_log_description">เมื่อเกมหยุดวาดภาพ ให้บันทึกว่าแต่ละเธรดของเกสต์กำลังทำอะไร</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan Validation Layers</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">รีสตาร์ทการแสดงผลเพื่อนำไปใช้</string>
     <string name="settings_debug_share_logs">แชร์บันทึก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1118,6 +1118,8 @@ E.g. <b>META</b> için <i>META tuşu</i>, \n
     <string name="settings_debug_input_logs_description">Oyun kumandası, dokunma ve klavye giriş olaylarını kaydet</string>
     <string name="settings_debug_download_logs">İndirme Günlükleri</string>
     <string name="settings_debug_download_logs_description">İndirme çözümleyici ve WinNative geri dönüş olaylarını kaydet</string>
+    <string name="settings_debug_freeze_log">Donma Günlüğü</string>
+    <string name="settings_debug_freeze_log_description">Oyun çizmeyi bıraktığında her konuk iş parçacığının ne yaptığını kaydet</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan Doğrulama Katmanları</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Uygulamak için ekranı yeniden başlatın.</string>
     <string name="settings_debug_share_logs">Günlükleri Paylaş</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -836,6 +836,8 @@
     <string name="settings_debug_input_logs_description">Журналювати події геймпада, дотиків та клавіатури</string>
     <string name="settings_debug_download_logs">Журнали завантажень</string>
     <string name="settings_debug_download_logs_description">Журналювати події засобу розв\'язування завантажень та резервного механізму WinNative</string>
+    <string name="settings_debug_freeze_log">Журнал зависань</string>
+    <string name="settings_debug_freeze_log_description">Коли гра припиняє малювати, записувати, що робить кожен гостьовий потік</string>
     <string name="settings_debug_vulkan_validation_layers_title">Рівні перевірки Vulkan</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Перезапустіть дисплей, щоб застосувати.</string>
     <string name="settings_debug_share_logs">Поділитися журналами</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -830,6 +830,8 @@
     <string name="settings_debug_input_logs_description">记录手柄、触摸和键盘输入事件</string>
     <string name="settings_debug_download_logs">下载日志</string>
     <string name="settings_debug_download_logs_description">记录下载解析器和 WinNative 回退事件</string>
+    <string name="settings_debug_freeze_log">卡死日志</string>
+    <string name="settings_debug_freeze_log_description">当游戏停止绘制时，记录每个客户机线程正在做什么</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan 验证层</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">重启显示以应用。</string>
     <string name="settings_debug_share_logs">分享日志</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -830,6 +830,8 @@
     <string name="settings_debug_input_logs_description">記錄手把、觸控和鍵盤輸入事件</string>
     <string name="settings_debug_download_logs">下載日誌</string>
     <string name="settings_debug_download_logs_description">記錄下載解析器和 WinNative 備援事件</string>
+    <string name="settings_debug_freeze_log">當機記錄</string>
+    <string name="settings_debug_freeze_log_description">當遊戲停止繪製時，記錄每個客體執行緒正在做什麼</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan 驗證層</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">重新啟動顯示以套用。</string>
     <string name="settings_debug_share_logs">分享日誌</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1157,6 +1157,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="settings_debug_input_logs_description">Log gamepad, touch, and keyboard input events</string>
     <string name="settings_debug_download_logs">Download Logs</string>
     <string name="settings_debug_download_logs_description">Log download resolver and WinNative fallback events</string>
+    <string name="settings_debug_freeze_log">Freeze Log</string>
+    <string name="settings_debug_freeze_log_description">When the game stops drawing, record what every guest thread is doing</string>
     <string name="settings_debug_vulkan_validation_layers_title">Vulkan Validation Layers</string>
     <string name="settings_debug_vulkan_validation_layers_subtitle">Restart display to apply.</string>
     <string name="settings_debug_share_logs">Share Logs</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -335,6 +335,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private int taskAffinityMaskWoW64 = 0;
     private final HashSet<Integer> guestAffinityCheckedPids = new HashSet<>();
     private volatile boolean serviceAffinityStarted = false;
+    private volatile boolean freezeWatchdogStarted = false;
     private static final String[] SERVICE_AFFINITY_PROCESSES = {
         "services.exe", "rpcss.exe", "svchost.exe", "winedevice.exe",
         "plugplay.exe", "conhost.exe", "start.exe"
@@ -1820,6 +1821,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             public void onMapWindow(Window window) {
                 assignTaskAffinity(window);
                 pinServiceAffinity();
+                startFreezeWatchdog();
                 if ((effectiveShowFPS || controllerHudMode) && frameRating != null) {
                     syncFrameRatingWithExistingWindows();
                 }
@@ -8080,6 +8082,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             gamenativeMarker.delete();
         }
 
+        logWrapperIdentity(rootDir);
+
         // libgallium_wgl.dll is present only while Windows Zink is installed — use as marker.
         if (wineInfo != null && wineInfo.isArm64EC()
                 && !GPUInformation.getRenderer(null, null).contains("Mali")) {
@@ -11353,6 +11357,96 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     // policy without ever re-sending — manual task manager changes stick.
     // Services go to the efficiency cores (lower half), shell/UI to the 64-bit
     // list, winhandler to all cores.
+    // Says which libvulkan_wrapper.so the container will actually load, so a stale
+    // or hand-copied .so can't be mistaken for the shipped one.
+    private void logWrapperIdentity(File rootDir) {
+        try {
+            File so = new File(rootDir, "usr/lib/libvulkan_wrapper.so");
+            if (!so.isFile()) {
+                Log.w("WrapperIdentity", "MISSING " + so.getAbsolutePath());
+                return;
+            }
+            int traces = 0;
+            byte[] needle = "WNTRACE".getBytes("UTF-8");
+            try (java.io.FileInputStream in = new java.io.FileInputStream(so)) {
+                byte[] buf = new byte[1 << 20];
+                int n, carry = 0;
+                byte[] prev = new byte[needle.length];
+                while ((n = in.read(buf)) > 0) {
+                    for (int i = 0; i <= n - needle.length; i++) {
+                        boolean hit = true;
+                        for (int j = 0; j < needle.length; j++)
+                            if (buf[i + j] != needle[j]) { hit = false; break; }
+                        if (hit) traces++;
+                    }
+                }
+            }
+            Log.w("WrapperIdentity", "path=" + so.getAbsolutePath()
+                    + " size=" + so.length()
+                    + " mtime=" + so.lastModified()
+                    + " WNTRACE=" + traces
+                    + (traces >= 16 ? " (round3 instrumented)"
+                       : traces >= 10 ? " (round2 instrumented)"
+                       : traces > 0 ? " (older instrumented)" : " (STOCK - no tracing)"));
+        } catch (Exception e) {
+            Log.w("WrapperIdentity", "check failed: " + e);
+        }
+    }
+
+    // Presents stop when the guest stalls; dump the kernel's view of every guest
+    // thread so we can see what it is actually blocked on.
+    private void startFreezeWatchdog() {
+        if (freezeWatchdogStarted) return;
+        if (!PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean("enable_freeze_log", false)) return;
+        freezeWatchdogStarted = true;
+        final String freezeLogName = "freeze_"
+                + new java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.US)
+                        .format(new java.util.Date()) + ".log";
+        new Thread(() -> {
+            try { if (imageFs != null) logWrapperIdentity(imageFs.getRootDir()); } catch (Exception ignored) {}
+            final long stallNs = 5_000_000_000L;
+            final long repeatNs = 15_000_000_000L;
+            long lastDumpNs = 0;
+            int dumps = 0;
+            String kgslBase = ProcessHelper.readKgslCounters();
+            Log.w("FreezeWatchdog", "kgsl baseline: " + kgslBase);
+            while (dumps < 6) {
+                try { Thread.sleep(1000); } catch (InterruptedException e) { return; }
+                long last = com.winlator.cmod.runtime.display.xserver.extensions.PresentExtension.lastPresentNanos;
+                if (last == 0) continue;
+                long now = System.nanoTime();
+                long idleNs = now - last;
+                if (idleNs < stallNs) continue;
+                if (lastDumpNs != 0 && now - lastDumpNs < repeatNs) continue;
+                lastDumpNs = now;
+                dumps++;
+                String hdr = "No present for " + (idleNs / 1000000) + " ms (dump " + dumps + "/6)";
+                Log.w("FreezeWatchdog", hdr + " — full dump in logs/" + freezeLogName);
+                StringBuilder rep = new StringBuilder();
+                rep.append("\n========== ").append(hdr).append(" ==========\n")
+                   .append("kgsl baseline: ").append(kgslBase).append('\n')
+                   .append("kgsl now     : ").append(ProcessHelper.readKgslCounters()).append('\n')
+                   .append(ProcessHelper.dumpGuestThreadStates())
+                   .append(ProcessHelper.dumpGuestMaps());
+                // logcat rate-limits and silently drops the game's several-hundred map
+                // lines, so the full dump goes to a file the log export already collects
+                try {
+                    File ld = new File(getExternalFilesDir(null), "logs");
+                    if (ld.isDirectory() || ld.mkdirs()) {
+                        try (java.io.FileWriter fw = new java.io.FileWriter(new File(ld, freezeLogName), true)) {
+                            fw.write(rep.toString());
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.w("FreezeWatchdog", "file dump failed: " + e);
+                }
+                for (String line : ProcessHelper.dumpGuestThreadStates().split("\n"))
+                    Log.w("FreezeWatchdog", line);
+            }
+        }, "FreezeWatchdog").start();
+    }
+
     private void pinServiceAffinity() {
         if (serviceAffinityStarted || winHandler == null) return;
         serviceAffinityStarted = true;

--- a/app/src/main/runtime/display/xserver/extensions/PresentExtension.java
+++ b/app/src/main/runtime/display/xserver/extensions/PresentExtension.java
@@ -36,6 +36,7 @@ public class PresentExtension
         XResourceManager.OnResourceLifecycleListener,
         WindowManager.OnWindowModificationListener {
   public static final byte MAJOR_OPCODE = -103;
+  public static volatile long lastPresentNanos = 0;
   private static final int FAKE_INTERVAL = 1000000 / 60;
   private byte firstEventId = 0;
   private byte firstErrorId = 0;
@@ -479,6 +480,7 @@ public class PresentExtension
         // necessary, import the sync_file as a Vulkan semaphore and chain it into the
         // submit instead of blocking here.
         PresentPixmapParams p = parsePresentPixmap(client, inputStream);
+        lastPresentNanos = System.nanoTime();
 
         try (XLock lock =
             client.xServer.lock(XServer.Lockable.WINDOW_MANAGER, XServer.Lockable.PIXMAP_MANAGER)) {

--- a/app/src/main/runtime/system/ProcessHelper.java
+++ b/app/src/main/runtime/system/ProcessHelper.java
@@ -605,6 +605,100 @@ public abstract class ProcessHelper {
     return filteredPids;
   }
 
+  private static String readProcFile(String path) {
+    try (FileInputStream in = new FileInputStream(path)) {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      byte[] buf = new byte[4096];
+      int n;
+      while ((n = in.read(buf)) > 0) out.write(buf, 0, n);
+      return out.toString("UTF-8").trim();
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  // GPU fault/reset bookkeeping from the kgsl driver. A reset counter that moves
+  // across a freeze means the GPU hung and the kernel recovered it.
+  // Probe fixed filenames: the kgsl dir is usually not listable by an app even though
+  // individual attributes inside it open fine.
+  private static final String[] KGSL_ATTRS = {
+    "reset_count", "gpu_reset_stat", "gpu_reset_count", "fault_count", "gpu_fault",
+    "hang_count", "recovery_count", "snapshot_crashdumper", "gpubusy", "temp",
+    "gpuclk", "gpu_busy_percentage", "gpu_model", "deviceid",
+  };
+
+  public static String readKgslCounters() {
+    StringBuilder sb = new StringBuilder();
+    StringBuilder missing = new StringBuilder();
+    for (String base : new String[] {"/sys/class/kgsl/kgsl-3d0", "/sys/devices/platform/soc/3d00000.qcom,kgsl-3d0/kgsl/kgsl-3d0"}) {
+      for (String n : KGSL_ATTRS) {
+        File f = new File(base, n);
+        if (!f.isFile()) continue;
+        String v = readProcFile(f.getAbsolutePath());
+        if (v.isEmpty()) { if (missing.length() < 200) missing.append(n).append("? "); continue; }
+        if (v.length() > 120) v = v.substring(0, 120);
+        if (sb.length() > 0) sb.append("  ");
+        sb.append(n).append('=').append(v.replace('\n', '/'));
+      }
+      if (sb.length() > 0) break;
+    }
+    if (sb.length() == 0)
+      return "kgsl: no attributes readable (unreadable: " + missing + ")";
+    return sb.toString();
+  }
+
+  // File-backed mappings for the biggest guest process, so faulting addresses seen
+  // in the wine log can be resolved to a library.
+  public static String dumpGuestMaps() {
+    StringBuilder sb = new StringBuilder("=== guest library maps ===\n");
+    for (String pid : listRunningWineProcesses()) {
+      String maps = readProcFile("/proc/" + pid + "/maps");
+      if (maps.isEmpty()) continue;
+      StringBuilder one = new StringBuilder();
+      for (String line : maps.split("\n")) {
+        // every executable mapping, file-backed or anonymous (anon exec = JIT code)
+        String[] f = line.trim().split("\\s+", 6);
+        if (f.length < 2 || f[1].length() < 3 || f[1].charAt(2) != 'x') continue;
+        String path = f.length >= 6 ? f[5].trim() : "";
+        one.append("   ").append(f[0]).append(' ').append(f[1]).append("  ")
+           .append(path.isEmpty() ? "[anon-exec]" : path).append('\n');
+      }
+      if (one.length() > 0) sb.append("pid ").append(pid).append('\n').append(one);
+    }
+    return sb.toString();
+  }
+
+  // Kernel's own record of where each guest thread is parked. Readable because the
+  // guest runs under our uid. R=running S=sleeping D=uninterruptible.
+  public static String dumpGuestThreadStates() {
+    StringBuilder sb = new StringBuilder("=== guest thread states ===\n");
+    for (String pid : listRunningWineProcesses()) {
+      String cmdline = readProcFile("/proc/" + pid + "/cmdline").replace('\0', ' ').trim();
+      sb.append("pid ").append(pid).append("  ").append(cmdline).append('\n');
+      File taskDir = new File("/proc/" + pid + "/task");
+      String[] tids = taskDir.list();
+      if (tids == null) continue;
+      Arrays.sort(tids);
+      for (String tid : tids) {
+        String base = "/proc/" + pid + "/task/" + tid + "/";
+        String comm = readProcFile(base + "comm");
+        String syscall = readProcFile(base + "syscall");
+        String wchan = readProcFile(base + "wchan");
+        String stat = readProcFile(base + "stat");
+        String state = "?";
+        int close = stat.lastIndexOf(')');
+        if (close > 0 && close + 2 < stat.length()) state = stat.substring(close + 2, close + 3);
+        sb.append("   tid ").append(tid)
+          .append(" [").append(state).append("] ")
+          .append(comm.isEmpty() ? "-" : comm)
+          .append("  wchan=").append(wchan.isEmpty() ? "-" : wchan)
+          .append("  syscall=").append(syscall.isEmpty() ? "-" : syscall)
+          .append('\n');
+      }
+    }
+    return sb.toString();
+  }
+
   public static ArrayList<String> listRunningWineProcessDetails() {
     File proc = new File("/proc");
     String[] allPids =


### PR DESCRIPTION
When the game stops presenting for 5 s, record what every guest thread is doing so a freeze can be diagnosed after the fact.

Each dump captures per-thread state from /proc (name, run state, wchan, current syscall), every executable mapping including anonymous JIT regions, and the kgsl GPU counters. Dumps repeat every 15 s while stalled, capped at six, and are written to logs/freeze_<timestamp>.log so the existing log export picks them up.

Writing to a file rather than logcat is deliberate: a guest process has several hundred mappings and logcat rate-limits and silently drops them.

Off by default; toggle lives in Settings > Debug.