### PR TITLE
Gyro mouse: allow mouse and keyboard bindings as the hold/toggle acti…

### DIFF
--- a/app/src/main/feature/settings/input/InputControlsFragment.kt
+++ b/app/src/main/feature/settings/input/InputControlsFragment.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import com.winlator.cmod.app.shell.UnifiedActivity
 import com.winlator.cmod.R
+import com.winlator.cmod.runtime.display.winhandler.WinHandler
 import com.winlator.cmod.runtime.input.ControllerHelper
 import com.winlator.cmod.runtime.input.ControlsEditorActivity
 import com.winlator.cmod.runtime.input.controls.Binding
@@ -926,6 +927,9 @@ class InputControlsFragment : Fragment() {
     }
 
     private fun currentGyroActivatorLabel(): String {
+        if (preferences.getBoolean("mouse_gyro_enabled", false)) {
+            return WinHandler.getGyroMouseActivator(preferences).toString()
+        }
         val names = resources.getStringArray(R.array.button_options)
         val keycodes = resources.getIntArray(R.array.button_keycodes)
         val currentKeycode = preferences.getInt("gyro_trigger_button", KeyEvent.KEYCODE_BUTTON_L1)
@@ -934,6 +938,10 @@ class InputControlsFragment : Fragment() {
     }
 
     private fun showActivatorPicker() {
+        if (preferences.getBoolean("mouse_gyro_enabled", false)) {
+            showMouseGyroActivatorPicker()
+            return
+        }
         val names = resources.getStringArray(R.array.button_options)
         val keycodes = resources.getIntArray(R.array.button_keycodes)
         val currentKeycode = preferences.getInt("gyro_trigger_button", KeyEvent.KEYCODE_BUTTON_L1)
@@ -944,6 +952,19 @@ class InputControlsFragment : Fragment() {
             checkedIndex = checkedIndex,
         ) { which ->
             preferences.edit().putInt("gyro_trigger_button", keycodes[which]).apply()
+            publishUiState()
+        }
+    }
+
+    private fun showMouseGyroActivatorPicker() {
+        val bindings = Binding.activatorBindingValues()
+        val current = WinHandler.getGyroMouseActivator(preferences)
+        showSingleChoiceDialog(
+            title = getString(R.string.session_gyroscope_activator_button),
+            items = bindings.map { it.toString() }.toTypedArray(),
+            checkedIndex = bindings.indexOf(current).coerceAtLeast(0),
+        ) { which ->
+            preferences.edit().putString("gyro_mouse_trigger_binding", bindings[which].name).apply()
             publishUiState()
         }
     }

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -546,6 +546,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private static final long EXIT_CLOUD_UPLOAD_RETRY_DELAY_MS = 1000L;
 
     private Handler  timeoutHandler = new Handler(Looper.getMainLooper());
+    private static final long POINTER_ACTIVITY_REARM_MS = 1000L;
+    private long lastPointerActivityAt = 0L;
     private Runnable hideControlsRunnable;
 
     private volatile boolean startFullscreenStretched;
@@ -6143,6 +6145,20 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private void cancelMousePointerTimeout() {
         if (timeoutHandler != null && hideControlsRunnable != null) {
             timeoutHandler.removeCallbacks(hideControlsRunnable);
+        }
+    }
+
+    // Pointer movement that bypasses touch/mouse events (gyro) still counts as activity.
+    public void notifyPointerActivity() {
+        if (isMouseDisabled || xServer == null || xServer.getRenderer() == null) return;
+        boolean hidden = !xServer.getRenderer().isCursorVisible();
+        long now = SystemClock.uptimeMillis();
+        if (!hidden && now - lastPointerActivityAt < POINTER_ACTIVITY_REARM_MS) return;
+        lastPointerActivityAt = now;
+        if (hidden) xServer.getRenderer().setCursorVisible(true);
+        if (timeoutHandler != null && hideControlsRunnable != null) {
+            timeoutHandler.removeCallbacks(hideControlsRunnable);
+            timeoutHandler.postDelayed(hideControlsRunnable, 5000);
         }
     }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -4112,6 +4112,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     }
 
     private String currentGyroActivatorLabel() {
+        if (preferences.getBoolean("mouse_gyro_enabled", false)) {
+            return WinHandler.getGyroMouseActivator(preferences).toString();
+        }
         String[] names = getResources().getStringArray(R.array.button_options);
         int[] keycodes = getResources().getIntArray(R.array.button_keycodes);
         int currentKeycode = preferences.getInt("gyro_trigger_button", KeyEvent.KEYCODE_BUTTON_L1);
@@ -4460,6 +4463,12 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
                     @Override
                     public void onGyroscopeActivatorSelected(int keycode) {
                         preferences.edit().putInt("gyro_trigger_button", keycode).apply();
+                        renderDrawerMenu();
+                    }
+
+                    @Override
+                    public void onGyroscopeActivatorBindingSelected(String bindingName) {
+                        preferences.edit().putString("gyro_mouse_trigger_binding", bindingName).apply();
                         renderDrawerMenu();
                     }
 

--- a/app/src/main/runtime/display/XServerDrawerInputPanes.kt
+++ b/app/src/main/runtime/display/XServerDrawerInputPanes.kt
@@ -167,6 +167,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import com.winlator.cmod.R
+import com.winlator.cmod.runtime.input.controls.Binding
 import com.winlator.cmod.shared.theme.WinNativeBackground
 import com.winlator.cmod.shared.theme.WinNativeOutline
 import com.winlator.cmod.shared.theme.WinNativePanel
@@ -337,10 +338,22 @@ internal fun GyroscopePaneContent(
 
                 Column(verticalArrangement = Arrangement.spacedBy((8f * paneScale).dp)) {
                     PaneSectionLabel(stringResource(R.string.session_gyroscope_activator_button))
-                    GyroscopeActivatorDropdown(
-                        currentLabel = state.gyroscopeActivatorLabel,
-                        onSelected = listener::onGyroscopeActivatorSelected,
-                    )
+                    if (state.gyroMouseEnabled) {
+                        val bindings = remember { Binding.activatorBindingValues() }
+                        GyroscopeActivatorDropdown(
+                            currentLabel = state.gyroscopeActivatorLabel,
+                            options = remember(bindings) { bindings.map { it.toString() } },
+                            onSelectedIndex = { listener.onGyroscopeActivatorBindingSelected(bindings[it].name) },
+                        )
+                    } else {
+                        val names = stringArrayResource(R.array.button_options)
+                        val keycodes = integerArrayResource(R.array.button_keycodes)
+                        GyroscopeActivatorDropdown(
+                            currentLabel = state.gyroscopeActivatorLabel,
+                            options = remember(names) { names.toList() },
+                            onSelectedIndex = { listener.onGyroscopeActivatorSelected(keycodes[it]) },
+                        )
+                    }
                 }
 
                 NavBooleanRow(
@@ -449,11 +462,10 @@ internal fun GyroscopePaneContent(
 @Composable
 internal fun GyroscopeActivatorDropdown(
     currentLabel: String,
-    onSelected: (Int) -> Unit,
+    options: List<String>,
+    onSelectedIndex: (Int) -> Unit,
 ) {
     val paneScale = LocalPaneScale.current
-    val names = stringArrayResource(R.array.button_options)
-    val keycodes = integerArrayResource(R.array.button_keycodes)
     var expanded by remember { mutableStateOf(false) }
     val parentNav = LocalPaneNav.current
     val optionRegistry = remember { PaneNavRegistry() }
@@ -512,9 +524,9 @@ internal fun GyroscopeActivatorDropdown(
 
         InputControlsOptionsPopup(
             expanded = expanded,
-            options = names.toList(),
-            selectedIndex = names.indexOfFirst { it == currentLabel }.coerceAtLeast(0),
-            onSelected = { index -> onSelected(keycodes[index]) },
+            options = options,
+            selectedIndex = options.indexOfFirst { it == currentLabel }.coerceAtLeast(0),
+            onSelected = { index -> onSelectedIndex(index) },
             onDismiss = { expanded = false },
             optionRegistry = optionRegistry,
         )

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -1000,6 +1000,8 @@ interface XServerDrawerActionListener {
 
     fun onGyroscopeActivatorSelected(keycode: Int)
 
+    fun onGyroscopeActivatorBindingSelected(bindingName: String)
+
     fun onRightStickGyroChanged(enabled: Boolean)
 
     fun onGyroMouseEnabledChanged(enabled: Boolean)

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -15,6 +15,8 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import androidx.preference.PreferenceManager;
 import com.winlator.cmod.runtime.display.XServerDisplayActivity;
+import com.winlator.cmod.runtime.display.xserver.Pointer;
+import com.winlator.cmod.runtime.display.xserver.XKeycode;
 import com.winlator.cmod.runtime.display.xserver.XServer;
 import com.winlator.cmod.runtime.input.controls.ControllerManager;
 import com.winlator.cmod.runtime.input.controls.Binding;
@@ -122,6 +124,7 @@ public class WinHandler {
   private float accumulatedGyroY = 0.0f;
   private boolean gyroToggleEnabled = false;
   private boolean gyroActivatorPressed = false;
+  private boolean gyroMouseActivatorPressed = false;
   private int lastGyroTargetSource = 0;
   private ExternalController lastGyroTargetController;
   // Cached activation; read by shouldApplyGyroToTarget so the query stays side-effect free.
@@ -409,6 +412,7 @@ public class WinHandler {
   }
 
   public void mouseEvent(final int flags, final int dx, final int dy, final int wheelDelta) {
+    checkGyroActivatorMouseFlags(flags);
     if (!this.initReceived) {
       return;
     }
@@ -1570,6 +1574,7 @@ public class WinHandler {
     this.currentGyroStickY = 0.0f;
     this.gyroToggleEnabled = false;
     this.gyroActivatorPressed = false;
+    this.gyroMouseActivatorPressed = false;
     this.accumulatedGyroX = 0.0f;
     this.accumulatedGyroY = 0.0f;
     this.lastGyroActive = false;
@@ -1667,9 +1672,16 @@ public class WinHandler {
     this.currentGyroStickX = 0.0f;
     this.currentGyroStickY = 0.0f;
 
-    // Gate on the activator; stay always-on when no controller target exists (controllerless use).
-    GyroTarget target = resolveActiveGyroTarget(gyroSettings);
-    boolean active = target == null || target.active;
+    Binding activator = getGyroMouseActivator();
+    boolean active;
+    if (activator.isMouse() || activator.isKeyboard()) {
+      active = gyroSettings.mode == 1 ? this.gyroToggleEnabled : this.gyroMouseActivatorPressed;
+      this.lastGyroActive = active;
+    } else {
+      // Gate on the activator; stay always-on when no controller target exists (controllerless use).
+      GyroTarget target = resolveActiveGyroTarget(gyroSettings);
+      active = target == null || target.active;
+    }
     if (!active) {
       this.accumulatedGyroX = 0.0f;
       this.accumulatedGyroY = 0.0f;
@@ -1703,6 +1715,10 @@ public class WinHandler {
     settings.mode = this.preferences.getInt("gyro_mode", 0);
     settings.activatorKeyCode =
         this.preferences.getInt("gyro_trigger_button", KeyEvent.KEYCODE_BUTTON_L1);
+    if (this.preferences.getBoolean("mouse_gyro_enabled", false)) {
+      Binding activator = getGyroMouseActivator();
+      settings.activatorBinding = activator.isGamepad() ? activator : null;
+    }
     settings.applyToRightStick =
         this.preferences.getBoolean("process_gyro_with_left_trigger", false);
     float sensitivityOffset =
@@ -1847,9 +1863,13 @@ public class WinHandler {
 
   private boolean updateGyroActivation(GamepadState targetState, GamepadState rawState, GyroSettings gyroSettings) {
     // Check both remapped and raw state for the activator
-    boolean activatorPressed = isActivatorPressed(targetState, gyroSettings.activatorKeyCode) ||
-                               isActivatorPressed(rawState, gyroSettings.activatorKeyCode);
-    
+    boolean activatorPressed =
+        gyroSettings.activatorBinding != null
+            ? isActivatorPressed(targetState, gyroSettings.activatorBinding)
+                || isActivatorPressed(rawState, gyroSettings.activatorBinding)
+            : isActivatorPressed(targetState, gyroSettings.activatorKeyCode)
+                || isActivatorPressed(rawState, gyroSettings.activatorKeyCode);
+
     if (gyroSettings.mode == 1 && activatorPressed && !this.gyroActivatorPressed) {
       this.gyroToggleEnabled = !this.gyroToggleEnabled;
     }
@@ -1871,6 +1891,103 @@ public class WinHandler {
           || state.isButtonPressed(GamepadState.BUTTON_R2);
     }
     return buttonIdx != -1 && state.isButtonPressed(buttonIdx);
+  }
+
+  private boolean isActivatorPressed(GamepadState state, Binding binding) {
+    if (state == null || !binding.isGamepad()) {
+      return false;
+    }
+    int buttonIdx = gamepadButtonIdxOf(binding);
+    if (buttonIdx == GamepadState.BUTTON_L2) {
+      return state.triggerL > GYRO_TRIGGER_PRESS_THRESHOLD
+          || state.isButtonPressed(GamepadState.BUTTON_L2);
+    }
+    if (buttonIdx == GamepadState.BUTTON_R2) {
+      return state.triggerR > GYRO_TRIGGER_PRESS_THRESHOLD
+          || state.isButtonPressed(GamepadState.BUTTON_R2);
+    }
+    return state.isButtonPressed(buttonIdx);
+  }
+
+  // Binding gamepad ordinals line up with GamepadState button indices, except the d-pad.
+  private static int gamepadButtonIdxOf(Binding binding) {
+    switch (binding) {
+      case GAMEPAD_DPAD_UP:
+        return GamepadState.BUTTON_DPAD_UP;
+      case GAMEPAD_DPAD_DOWN:
+        return GamepadState.BUTTON_DPAD_DOWN;
+      case GAMEPAD_DPAD_LEFT:
+        return GamepadState.BUTTON_DPAD_LEFT;
+      case GAMEPAD_DPAD_RIGHT:
+        return GamepadState.BUTTON_DPAD_RIGHT;
+      default:
+        return binding.ordinal() - Binding.GAMEPAD_BUTTON_A.ordinal();
+    }
+  }
+
+  public static Binding getGyroMouseActivator(SharedPreferences preferences) {
+    try {
+      return Binding.valueOf(
+          preferences.getString("gyro_mouse_trigger_binding", Binding.MOUSE_RIGHT_BUTTON.name()));
+    } catch (Exception e) {
+      return Binding.MOUSE_RIGHT_BUTTON;
+    }
+  }
+
+  private Binding getGyroMouseActivator() {
+    return getGyroMouseActivator(this.preferences);
+  }
+
+  // Called for every pointer button heading to the guest, from any source.
+  public void onPointerButtonInjected(Pointer.Button button, boolean pressed) {
+    if (button == null || !isGyroMouseGated()) {
+      return;
+    }
+    if (getGyroMouseActivator().getPointerButton() == button) {
+      updateGyroMouseActivation(pressed);
+    }
+  }
+
+  // Called for every key heading to the guest, from any source.
+  public void onKeyInjected(XKeycode keycode, boolean pressed) {
+    if (keycode == null || !isGyroMouseGated()) {
+      return;
+    }
+    Binding activator = getGyroMouseActivator();
+    if (activator.isKeyboard() && activator.keycode == keycode) {
+      updateGyroMouseActivation(pressed);
+    }
+  }
+
+  private boolean isGyroMouseGated() {
+    return this.preferences.getBoolean("gyro_enabled", false)
+        && this.preferences.getBoolean("mouse_gyro_enabled", false);
+  }
+
+  // Rising-edge guarded, so the same press arriving on more than one path stays idempotent.
+  private void updateGyroMouseActivation(boolean pressed) {
+    if (pressed
+        && !this.gyroMouseActivatorPressed
+        && this.preferences.getInt("gyro_mode", 0) == 1) {
+      this.gyroToggleEnabled = !this.gyroToggleEnabled;
+    }
+    this.gyroMouseActivatorPressed = pressed;
+  }
+
+  private void checkGyroActivatorMouseFlags(int flags) {
+    if ((flags & MouseEventFlags.LEFTDOWN) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_LEFT, true);
+    } else if ((flags & MouseEventFlags.LEFTUP) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_LEFT, false);
+    } else if ((flags & MouseEventFlags.RIGHTDOWN) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_RIGHT, true);
+    } else if ((flags & MouseEventFlags.RIGHTUP) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_RIGHT, false);
+    } else if ((flags & MouseEventFlags.MIDDLEDOWN) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_MIDDLE, true);
+    } else if ((flags & MouseEventFlags.MIDDLEUP) != 0) {
+      onPointerButtonInjected(Pointer.Button.BUTTON_MIDDLE, false);
+    }
   }
 
   private GamepadState getOutputGamepadState(GamepadState baseState, boolean applyGyroOverlay) {
@@ -1937,6 +2054,7 @@ public class WinHandler {
     boolean enabled;
     int mode;
     int activatorKeyCode;
+    Binding activatorBinding;
     boolean applyToRightStick;
     float sensitivityX;
     float sensitivityY;

--- a/app/src/main/runtime/display/winhandler/WinHandler.java
+++ b/app/src/main/runtime/display/winhandler/WinHandler.java
@@ -1704,6 +1704,7 @@ public class WinHandler {
     int dy = (int) this.accumulatedGyroY;
     if (dx != 0 || dy != 0) {
       mouseMoveDelta(dx, dy);
+      this.activity.notifyPointerActivity();
       this.accumulatedGyroX -= dx;
       this.accumulatedGyroY -= dy;
     }

--- a/app/src/main/runtime/display/xserver/XServer.java
+++ b/app/src/main/runtime/display/xserver/XServer.java
@@ -291,6 +291,7 @@ public class XServer {
   }
 
   public void injectPointerButtonPress(Pointer.Button buttonCode) {
+    if (winHandler != null) winHandler.onPointerButtonInjected(buttonCode, true);
     try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
       pointer.setButton(buttonCode, true);
 
@@ -300,6 +301,7 @@ public class XServer {
   }
 
   public void injectPointerButtonRelease(Pointer.Button buttonCode) {
+    if (winHandler != null) winHandler.onPointerButtonInjected(buttonCode, false);
     try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
       pointer.setButton(buttonCode, false);
 
@@ -313,12 +315,14 @@ public class XServer {
   }
 
   public void injectKeyPress(XKeycode xKeycode, int keysym) {
+    if (winHandler != null) winHandler.onKeyInjected(xKeycode, true);
     try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
       keyboard.setKeyPress(xKeycode.id, keysym);
     }
   }
 
   public void injectKeyRelease(XKeycode xKeycode) {
+    if (winHandler != null) winHandler.onKeyInjected(xKeycode, false);
     try (XLock lock = lock(Lockable.WINDOW_MANAGER, Lockable.INPUT_DEVICE)) {
       keyboard.setKeyRelease(xKeycode.id);
     }

--- a/app/src/main/runtime/input/controls/Binding.java
+++ b/app/src/main/runtime/input/controls/Binding.java
@@ -290,4 +290,24 @@ public enum Binding {
     for (Binding binding : Binding.values()) if (binding.isGamepad()) labels.add(binding);
     return labels.toArray(new Binding[0]);
   }
+
+  // Inputs usable as a hold/toggle activator: discrete presses only, no analog directions.
+  public static Binding[] activatorBindingValues() {
+    ArrayList<Binding> values = new ArrayList<>();
+    values.add(NONE);
+    values.add(MOUSE_LEFT_BUTTON);
+    values.add(MOUSE_MIDDLE_BUTTON);
+    values.add(MOUSE_RIGHT_BUTTON);
+    for (Binding binding : Binding.values()) if (binding.isKeyboard()) values.add(binding);
+    for (Binding binding : Binding.values())
+      if (binding.isGamepad() && !binding.name().contains("_THUMB_")) values.add(binding);
+    return values.toArray(new Binding[0]);
+  }
+
+  public static String[] activatorBindingLabels() {
+    Binding[] bindings = activatorBindingValues();
+    String[] labels = new String[bindings.length];
+    for (int i = 0; i < bindings.length; i++) labels[i] = bindings[i].toString();
+    return labels;
+  }
 }

--- a/app/src/main/shared/ui/nav/PaneNav.kt
+++ b/app/src/main/shared/ui/nav/PaneNav.kt
@@ -53,6 +53,12 @@ private class PaneNavEntry(
 @Stable
 internal class PaneNavRegistry(initialSignal: Int = -1) {
     private val items = mutableStateMapOf<Int, PaneNavEntry>()
+    // Row layout is derived from every item's geometry, so it is cached per change instead of
+    // being re-sorted on each isActive() call.
+    private var layoutVersion by mutableStateOf(0)
+    private var cachedRows: List<List<Int>> = emptyList()
+    private var cachedRowsVersion = -1
+    private var cachedRowsSingleRow = false
     private var slotCounter = 0
     private var lastSignal = initialSignal
     var controllerActive by mutableStateOf(false)
@@ -91,6 +97,7 @@ internal class PaneNavRegistry(initialSignal: Int = -1) {
         val e = items[slot]
         if (e == null) {
             items[slot] = PaneNavEntry(0f, 0f, 0f, onActivate, onAdjust, onSecondary)
+            layoutVersion++
         } else {
             e.onActivate = onActivate
             e.onAdjust = onAdjust
@@ -101,7 +108,10 @@ internal class PaneNavRegistry(initialSignal: Int = -1) {
     fun reportPosition(slot: Int, x: Float, y: Float, h: Float) {
         val e = items[slot] ?: return
         if (e.x != x || e.y != y || e.h != h) {
-            items[slot] = PaneNavEntry(x, y, h, e.onActivate, e.onAdjust, e.onSecondary, e.gx, e.gy)
+            e.x = x
+            e.y = y
+            e.h = h
+            layoutVersion++
             if (pendingEntry) entrySlot?.let { selectSlot(it) }
         }
     }
@@ -111,8 +121,11 @@ internal class PaneNavRegistry(initialSignal: Int = -1) {
         val e = items[slot]
         if (e == null) {
             items[slot] = PaneNavEntry(0f, 0f, 0f, {}, null, {}, gx, gy)
+            layoutVersion++
         } else if (e.gx != gx || e.gy != gy) {
-            items[slot] = PaneNavEntry(e.x, e.y, e.h, e.onActivate, e.onAdjust, e.onSecondary, gx, gy)
+            e.gx = gx
+            e.gy = gy
+            layoutVersion++
         }
         if (pendingEntry) entrySlot?.let { selectSlot(it) }
     }
@@ -132,28 +145,39 @@ internal class PaneNavRegistry(initialSignal: Int = -1) {
         return e.y to (e.y + e.h)
     }
 
-    fun unregister(slot: Int) { items.remove(slot) }
+    fun unregister(slot: Int) {
+        if (items.remove(slot) != null) layoutVersion++
+    }
 
     val rows: List<List<Int>>
         get() {
-            if (singleRow) {
-                if (items.isEmpty()) return emptyList()
-                return listOf(items.entries.sortedBy { it.value.x }.map { it.key })
-            }
-            val sorted = items.entries.sortedWith(compareBy({ it.value.y + it.value.h / 2f }, { it.value.x }))
-            val result = mutableListOf<MutableList<Int>>()
-            var prevCenterY = Float.NaN
-            for (entry in sorted) {
-                val centerY = entry.value.y + entry.value.h / 2f
-                if (result.isEmpty() || kotlin.math.abs(centerY - prevCenterY) > PANE_ROW_Y_THRESHOLD) {
-                    result.add(mutableListOf(entry.key))
-                } else {
-                    result.last().add(entry.key)
-                }
-                prevCenterY = centerY
-            }
-            return result
+            val version = layoutVersion
+            if (cachedRowsVersion == version && cachedRowsSingleRow == singleRow) return cachedRows
+            cachedRows = computeRows()
+            cachedRowsVersion = version
+            cachedRowsSingleRow = singleRow
+            return cachedRows
         }
+
+    private fun computeRows(): List<List<Int>> {
+        if (singleRow) {
+            if (items.isEmpty()) return emptyList()
+            return listOf(items.entries.sortedBy { it.value.x }.map { it.key })
+        }
+        val sorted = items.entries.sortedWith(compareBy({ it.value.y + it.value.h / 2f }, { it.value.x }))
+        val result = mutableListOf<MutableList<Int>>()
+        var prevCenterY = Float.NaN
+        for (entry in sorted) {
+            val centerY = entry.value.y + entry.value.h / 2f
+            if (result.isEmpty() || kotlin.math.abs(centerY - prevCenterY) > PANE_ROW_Y_THRESHOLD) {
+                result.add(mutableListOf(entry.key))
+            } else {
+                result.last().add(entry.key)
+            }
+            prevCenterY = centerY
+        }
+        return result
+    }
 
     fun isActive(slot: Int): Boolean {
         if (!controllerActive) return false


### PR DESCRIPTION
When experimental mouse movement is enabled the activator dropdown now lists mouse and keyboard bindings alongside gamepad buttons, stored in gyro_mouse_trigger_binding (default right mouse button). Activation is detected at the pointer/key injection points and the relative-mouse path, so presses from a physical mouse or keyboard, on-screen controls or the touchpad all drive hold and toggle. A rising-edge guard keeps the toggle correct when one press arrives on both paths in relative mouse mode.