### PR TITLE
Remove snapping grid from control editor.  Free drag motion. 

### DIFF
--- a/app/src/main/runtime/input/controls/ControlsProfile.java
+++ b/app/src/main/runtime/input/controls/ControlsProfile.java
@@ -289,8 +289,10 @@ public class ControlsProfile implements Comparable<ControlsProfile> {
         element.setShape(ControlElement.Shape.valueOf(elementJSONObject.getString("shape")));
         element.setToggleSwitch(elementJSONObject.getBoolean("toggleSwitch"));
         element.setSwipeable(elementJSONObject.optBoolean("swipeable", true));
-        element.setX((int) (elementJSONObject.getDouble("x") * inputControlsView.getMaxWidth()));
-        element.setY((int) (elementJSONObject.getDouble("y") * inputControlsView.getMaxHeight()));
+        element.setX(
+            (int) Math.round(elementJSONObject.getDouble("x") * inputControlsView.getMaxWidth()));
+        element.setY(
+            (int) Math.round(elementJSONObject.getDouble("y") * inputControlsView.getMaxHeight()));
         element.setScale((float) elementJSONObject.getDouble("scale"));
         element.setText(elementJSONObject.getString("text"));
         element.setIconId(elementJSONObject.getInt("iconId"));

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -751,8 +751,8 @@ public class InputControlsView extends View {
         case MotionEvent.ACTION_MOVE:
           {
             if (selectedElement != null) {
-              selectedElement.setX((int) Mathf.roundTo(event.getX() - offsetX, snappingSize));
-              selectedElement.setY((int) Mathf.roundTo(event.getY() - offsetY, snappingSize));
+              selectedElement.setX(Math.round(event.getX() - offsetX));
+              selectedElement.setY(Math.round(event.getY() - offsetY));
               invalidate();
             }
             break;
@@ -761,9 +761,7 @@ public class InputControlsView extends View {
           {
             if (selectedElement != null && profile != null) profile.save();
             if (moveCursor)
-              cursor.set(
-                  (int) Mathf.roundTo(event.getX(), snappingSize),
-                  (int) Mathf.roundTo(event.getY(), snappingSize));
+              cursor.set(Math.round(event.getX()), Math.round(event.getY()));
             invalidate();
             break;
           }

--- a/app/src/main/runtime/input/ui/InputControlsView.java
+++ b/app/src/main/runtime/input/ui/InputControlsView.java
@@ -745,6 +745,7 @@ public class InputControlsView extends View {
               moveCursor = false;
             }
 
+            if (moveCursor) cursor.set(Math.round(x), Math.round(y));
             selectElement(element);
             break;
           }
@@ -753,6 +754,9 @@ public class InputControlsView extends View {
             if (selectedElement != null) {
               selectedElement.setX(Math.round(event.getX() - offsetX));
               selectedElement.setY(Math.round(event.getY() - offsetY));
+              invalidate();
+            } else if (moveCursor) {
+              cursor.set(Math.round(event.getX()), Math.round(event.getY()));
               invalidate();
             }
             break;


### PR DESCRIPTION
Drags were quantized to a width/100 grid via a floor, so positions between grid lines were unreachable and every move landed short of the finger. Dragging and the add-element cursor now use exact pixel coordinates. Profile loading rounds instead of truncating, so a save/reopen cycle no longer loses a pixel.