### PR TITLE
Restore container drive mappings and stop emitting unresolvable Z: paths

### DIFF
--- a/app/src/main/app/shell/UnifiedActivity.kt
+++ b/app/src/main/app/shell/UnifiedActivity.kt
@@ -1314,13 +1314,12 @@ class UnifiedActivity :
         val windowsPath =
             container?.let {
                 com.winlator.cmod.runtime.wine.WineUtils
-                    .getDriveCGameWindowsPath(
+                    .resolveGameExeWindowsPath(
                         it,
                         "CUSTOM",
                         gameInstallPath,
                         exeFile.absolutePath,
-                    ) ?: com.winlator.cmod.runtime.wine.WineUtils
-                    .getWindowsPath(it, exeFile.absolutePath)
+                    )
             } ?: run {
                 com.winlator.cmod.runtime.wine.WineUtils.getDosPath(exeFile.absolutePath)
             }

--- a/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
+++ b/app/src/main/feature/settings/containers/ContainerSettingsComposeDialog.kt
@@ -464,8 +464,7 @@ class ContainerSettingsComposeDialog @JvmOverloads constructor(
 
         drivesWorking.clear()
         val drivesStr = c?.let {
-            com.winlator.cmod.runtime.wine.WineUtils.readDrivesFromPrefix(it)
-                .ifEmpty { it.getDrives() }
+            com.winlator.cmod.runtime.wine.WineUtils.resolveEffectiveDrives(it)
         } ?: Container.DEFAULT_DRIVES
         for (drive in Container.drivesIterator(drivesStr)) {
             drivesWorking.add(

--- a/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
+++ b/app/src/main/feature/shortcuts/ShortcutSettingsComposeDialog.kt
@@ -1605,7 +1605,7 @@ class ShortcutSettingsComposeDialog private constructor(
         exeFile: File,
     ) {
         val mappedPath =
-            WineUtils.getDriveCGameWindowsPath(
+            WineUtils.resolveGameExeWindowsPath(
                 targetContainer,
                 "CUSTOM",
                 gameFolder.absolutePath,

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -2215,7 +2215,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
     private String mapCustomExecutableWinPath(String customGameFolder, @NonNull File exeFile) {
         if (container != null && customGameFolder != null && !customGameFolder.isEmpty()) {
             String mappedPath =
-                    WineUtils.getDriveCGameWindowsPath(
+                    WineUtils.resolveGameExeWindowsPath(
                             container, "CUSTOM", customGameFolder, exeFile.getAbsolutePath());
             if (mappedPath != null && !mappedPath.isEmpty()) {
                 return mappedPath;
@@ -6815,8 +6815,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
             normalizeSyncEnvVars(envVars);
 
             ArrayList<String> bindingPaths = new ArrayList<>();
-            String drives = WineUtils.readDrivesFromPrefix(container);
-            if (drives.isEmpty()) drives = container.getDrives();
+            String drives = WineUtils.resolveEffectiveDrives(container);
             for (String[] drive : Container.drivesIterator(drives)) {
                 bindingPaths.add(drive[1]);
             }

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -36,6 +36,19 @@ public abstract class WineUtils {
       @Nullable Container container, @Nullable String hostPath) {
     if (hostPath == null || hostPath.isEmpty()) return "";
 
+    String mapped = tryHostPathToMappedWinePath(container, hostPath);
+    if (mapped != null) return mapped;
+
+    String windowsPath = normalizeHostPath(hostPath).replace("/", "\\");
+    if (!windowsPath.startsWith("\\")) windowsPath = "\\" + windowsPath;
+    return "Z:" + windowsPath;
+  }
+
+  @Nullable
+  public static String tryHostPathToMappedWinePath(
+      @Nullable Container container, @Nullable String hostPath) {
+    if (hostPath == null || hostPath.isEmpty()) return null;
+
     String normalizedHostPath = normalizeHostPath(hostPath);
 
     if (container != null) {
@@ -61,13 +74,7 @@ public abstract class WineUtils {
     String bestDriveLetter = null;
     String bestDriveRoot = null;
 
-    String drives = readDrivesFromPrefix(container);
-    if (drives.isEmpty()) {
-      drives =
-          container != null && container.getDrives() != null
-              ? container.getDrives()
-              : Container.DEFAULT_DRIVES;
-    }
+    String drives = resolveEffectiveDrives(container);
 
     for (String[] drive : Container.drivesIterator(drives)) {
       if (drive.length < 2) continue;
@@ -89,9 +96,7 @@ public abstract class WineUtils {
       return bestDriveLetter + ":\\" + relativePath;
     }
 
-    String windowsPath = normalizedHostPath.replace("/", "\\");
-    if (!windowsPath.startsWith("\\")) windowsPath = "\\" + windowsPath;
-    return "Z:" + windowsPath;
+    return null;
   }
 
   private static boolean pathStartsWith(String path, String basePath) {
@@ -253,8 +258,13 @@ public abstract class WineUtils {
 
   public static File ensureDriveCGameSymlink(
       Container container, String source, String gameInstallPath) {
+    return ensureDriveCGameSymlink(container, source, gameInstallPath, false);
+  }
+
+  public static File ensureDriveCGameSymlink(
+      Container container, String source, String gameInstallPath, boolean allowCustom) {
     if (container == null || gameInstallPath == null || gameInstallPath.isEmpty()) return null;
-    if ("CUSTOM".equalsIgnoreCase(source)) return null;
+    if (!allowCustom && "CUSTOM".equalsIgnoreCase(source)) return null;
 
     File gameDir = new File(gameInstallPath);
     if (!gameDir.exists()) return null;
@@ -298,8 +308,37 @@ public abstract class WineUtils {
     return link;
   }
 
+  public static String resolveGameExeWindowsPath(
+      Container container, String source, String gameInstallPath, String nativePath) {
+    String mapped = getDriveCGameWindowsPath(container, source, gameInstallPath, nativePath);
+    if (mapped != null && !mapped.isEmpty()) return mapped;
+
+    mapped = tryHostPathToMappedWinePath(container, nativePath);
+    if (mapped != null && !mapped.isEmpty()) return mapped;
+
+    mapped = getDriveCGameWindowsPath(container, source, gameInstallPath, nativePath, true);
+    if (mapped != null && !mapped.isEmpty()) {
+      Log.i(
+          "WineUtils",
+          "resolveGameExeWindowsPath: no drive letter covers " + nativePath
+              + "; mapped through the container's C: game link instead");
+      return mapped;
+    }
+
+    return hostPathToMappedWinePath(container, nativePath);
+  }
+
   public static String getDriveCGameWindowsPath(
       Container container, String source, String gameInstallPath, String nativePath) {
+    return getDriveCGameWindowsPath(container, source, gameInstallPath, nativePath, false);
+  }
+
+  public static String getDriveCGameWindowsPath(
+      Container container,
+      String source,
+      String gameInstallPath,
+      String nativePath,
+      boolean allowCustom) {
     if (container == null || gameInstallPath == null || nativePath == null) return null;
     try {
       String safeSource = sanitizeDriveCGamePathSegment(source);
@@ -311,7 +350,7 @@ public abstract class WineUtils {
       if (!targetPath.equals(gameDirPath) && !targetPath.startsWith(gameDirPath + File.separator))
         return null;
 
-      File symlink = ensureDriveCGameSymlink(container, source, gameInstallPath);
+      File symlink = ensureDriveCGameSymlink(container, source, gameInstallPath, allowCustom);
       if (symlink == null) return null;
 
       String relative =
@@ -411,6 +450,36 @@ public abstract class WineUtils {
     return drives.toString();
   }
 
+  public static String mergeDrives(@Nullable String primary, @Nullable String secondary) {
+    LinkedHashSet<String> usedLetters = new LinkedHashSet<>();
+    LinkedHashSet<String> usedPaths = new LinkedHashSet<>();
+    StringBuilder merged = new StringBuilder();
+
+    for (String source : new String[] {primary, secondary}) {
+      if (source == null || source.isEmpty()) continue;
+      for (String[] drive : Container.drivesIterator(source)) {
+        if (drive.length < 2 || drive[1] == null || drive[1].isEmpty()) continue;
+        String letter = normalizeDriveLetter(drive[0]);
+        if (!isSupportedDriveLetter(letter) || "A".equals(letter)) continue;
+        String normalizedPath = normalizeHostPath(drive[1]);
+        if (normalizedPath.isEmpty()
+            || usedLetters.contains(letter)
+            || usedPaths.contains(normalizedPath)) continue;
+        usedLetters.add(letter);
+        usedPaths.add(normalizedPath);
+        merged.append(letter).append(':').append(drive[1]);
+      }
+    }
+    return merged.toString();
+  }
+
+  public static String resolveEffectiveDrives(@Nullable Container container) {
+    if (container == null) return Container.DEFAULT_DRIVES;
+    String configDrives = container.getDrives() != null ? container.getDrives() : "";
+    String merged = mergeDrives(configDrives, readDrivesFromPrefix(container));
+    return merged.isEmpty() ? Container.DEFAULT_DRIVES : merged;
+  }
+
   public static void applyDrivesToPrefix(@Nullable Container container, @Nullable String drives) {
     if (container == null) return;
     File dosdevicesDir = new File(container.getRootDir(), ".wine/dosdevices");
@@ -462,21 +531,32 @@ public abstract class WineUtils {
     FileUtils.symlink("../drive_c", dosdevicesPath + "/c:");
     FileUtils.symlink(container.getRootDir().getPath() + "/../..", dosdevicesPath + "/z:");
 
-    // the container config only seeds a prefix that has no drives yet
-    String drives = readDrivesFromPrefix(container);
-    Log.d("ContainerLaunch", "createDosdevicesSymlinks: entries=" + Arrays.toString(dosdevicesDir.list()) + " read=" + drives);
-    if (drives.isEmpty()) {
-      drives = container.getDrives();
-      Context context =
-          container.getManager() != null ? container.getManager().getContext() : null;
-      if (context != null) {
-        String normalizedDrives = normalizePersistentDrives(context, drives, false);
-        if (normalizedDrives != null && !normalizedDrives.isEmpty()) drives = normalizedDrives;
-      }
-      Log.d("ContainerLaunch", "createDosdevicesSymlinks: seeding fresh prefix with " + drives);
+    String configDrives = container.getDrives() != null ? container.getDrives() : "";
+    String prefixDrives = readDrivesFromPrefix(container);
+    String drives = mergeDrives(configDrives, prefixDrives);
+    Context context = container.getManager() != null ? container.getManager().getContext() : null;
+
+    boolean restoreDefaults =
+        context != null && !"t".equals(container.getExtra("driveDefaultsRestored"));
+    if (context != null) {
+      String normalizedDrives = normalizePersistentDrives(context, drives, restoreDefaults);
+      if (normalizedDrives != null && !normalizedDrives.isEmpty()) drives = normalizedDrives;
     }
+    if (restoreDefaults) container.putExtra("driveDefaultsRestored", "t");
+
+    Log.d(
+        "ContainerLaunch",
+        "createDosdevicesSymlinks: entries=" + Arrays.toString(dosdevicesDir.list())
+            + " config=" + configDrives + " prefix=" + prefixDrives + " effective=" + drives);
 
     applyDrivesToPrefix(container, drives);
+
+    boolean drivesChanged = !drives.isEmpty() && !drives.equals(container.getDrives());
+    if (drivesChanged) container.setDrives(drives);
+    if (drivesChanged || restoreDefaults) {
+      container.saveData();
+      Log.d("ContainerLaunch", "createDosdevicesSymlinks: persisted drives=" + drives);
+    }
 
     // Only expose Steam's steamapps/common symlink for actual Steam launches.
     if (gameDirectoryPath != null && !gameDirectoryPath.isEmpty()) {


### PR DESCRIPTION
Since #674 dosdevices was the only source of truth for drive letters: createDosdevicesSymlinks read the prefix, applied exactly that set and deleted every other letter, and only consulted the container config when the prefix had no drives at all. A container whose prefix had lost f: -- the internal-storage mapping -- could therefore never get F: back even though .container still listed it, so the drive stayed missing on every later boot.

Boot now applies the union of the container config and the prefix, so a configured drive is always recreated while a drive added inside winecfg is kept and persisted back into the config. A drive removed in container settings is written out of both, so it still stays removed. Containers whose config itself lost the platform defaults get them re-added once, guarded by driveDefaultsRestored so the repair cannot fight later edits.

The missing F: also broke custom game shortcuts. Since #544 custom games launch from their real install path, which needs a drive letter covering it; with none, hostPathToMappedWinePath fell through to "Z:" plus the absolute android path. z: points at the imagefs root, not /, so that path cannot resolve and wine reported "Path not found". Path mapping now reports when nothing covers a path, and custom game launch falls back to the container's C:\WinNative\Games link, which always resolves.