### PR TITLE
Add a manual Release workflow that publishes to the Releases tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,315 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. v0.4.0-beta (becomes the tag, the APK versionName and the asset names)'
+        required: true
+        type: string
+      notes_file:
+        description: 'Release notes markdown committed in the repo. Blank: use Release_Notes_<version>.md if present, otherwise generate from commits.'
+        required: false
+        type: string
+        default: ''
+      draft:
+        description: 'Create as a draft so it can be reviewed before it goes public'
+        type: boolean
+        default: true
+      prerelease:
+        description: 'Mark as a pre-release'
+        type: boolean
+        default: true
+      latest:
+        description: 'Mark as the latest release (ignored for drafts)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_CERT_SHA256: 94de8fe193e378604f4415d87c63dece030605460b8e9ee6d447e1fc90840980
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Validate inputs and preconditions
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "::error::version must look like v1.2.3 or v1.2.3-beta (got '$VERSION')"
+            exit 1
+          fi
+
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::KEYSTORE_BASE64 is not set; refusing to cut a release that would be signed with a throwaway key"
+            exit 1
+          fi
+
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release $VERSION already exists"
+            exit 1
+          fi
+
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag $VERSION already exists"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION from ${GITHUB_SHA}"
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        flavor:
+          - name: Standard
+            gradleTask: assembleStandardDebug
+            apkPath: app/build/outputs/apk/standard/debug/standard.apk
+            artifactName: release-apk-standard
+          - name: Ludashi
+            gradleTask: assembleLudashiDebug
+            apkPath: app/build/outputs/apk/ludashi/debug/ludashi.apk
+            artifactName: release-apk-ludashi
+          - name: Pubg
+            gradleTask: assemblePubgDebug
+            apkPath: app/build/outputs/apk/pubg/debug/pubg.apk
+            artifactName: release-apk-pubg
+          - name: Antutu
+            gradleTask: assembleAntutuDebug
+            apkPath: app/build/outputs/apk/antutu/debug/antutu.apk
+            artifactName: release-apk-antutu
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Cache LFS
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('**/*.txz', '**/*.tzst') }}
+          restore-keys: lfs-
+
+      - name: Pull LFS files
+        run: git lfs pull
+
+      - name: Cache NDK build outputs
+        uses: actions/cache@v5
+        with:
+          path: |
+            app/.cxx
+            app/build/intermediates/cxx
+          key: tag-ndk-${{ hashFiles('app/src/main/cpp/**', 'app/build.gradle', 'app/src/main/cpp/CMakeLists.txt') }}
+          restore-keys: |
+            tag-ndk-
+            ndk-
+
+      - name: Cache Rust Steam client
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            app/src/main/cpp/wn-steam-client/rust/target
+          key: cargo-${{ hashFiles('app/src/main/cpp/wn-steam-client/rust/Cargo.lock') }}
+          restore-keys: cargo-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Install Rust Android target
+        run: rustup target add aarch64-linux-android
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: true
+          cache-cleanup: 'on-success'
+
+      - name: Decode keystore and build release APK
+        timeout-minutes: 20
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          GRADLE_OPTS: -Xmx4g -XX:+UseG1GC
+          VERSION_NAME: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          export KEYSTORE_FILE="${{ github.workspace }}/release.jks"
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_FILE"
+          ./gradlew :app:${{ matrix.flavor.gradleTask }} --build-cache --parallel -x lint
+
+      - name: Verify signature and version
+        env:
+          APK_PATH: ${{ matrix.flavor.apkPath }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          EXPECTED_CERT_SHA256: ${{ secrets.RELEASE_CERT_SHA256 || env.DEFAULT_CERT_SHA256 }}
+        run: |
+          set -euo pipefail
+          build_tools=$(find "$ANDROID_SDK_ROOT/build-tools" -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1)
+
+          digest=$("$build_tools/apksigner" verify --print-certs "$APK_PATH" |
+            grep -m1 -oE 'SHA-256 digest: [a-f0-9]{64}' | awk '{print $3}')
+          if [ "$digest" != "$EXPECTED_CERT_SHA256" ]; then
+            echo "::error::APK signed by $digest, expected $EXPECTED_CERT_SHA256"
+            exit 1
+          fi
+
+          version_name=$("$build_tools/aapt2" dump badging "$APK_PATH" |
+            head -1 | grep -oE "versionName='[^']*'" | cut -d"'" -f2)
+          if [ "$version_name" != "$VERSION" ]; then
+            echo "::error::APK versionName is '$version_name', expected '$VERSION'"
+            exit 1
+          fi
+
+          echo "Signed by $digest, versionName $version_name"
+
+      - name: Prepare APK for upload
+        env:
+          APK_PATH: ${{ matrix.flavor.apkPath }}
+          VARIANT_NAME: ${{ matrix.flavor.name }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cp "$APK_PATH" "artifacts/WinNative-${VERSION}-${VARIANT_NAME}-signed.apk"
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.flavor.artifactName }}
+          path: artifacts/*.apk
+          retention-days: 7
+          if-no-files-found: error
+          compression-level: 0
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download built APKs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          for flavor in standard ludashi pubg antutu; do
+            gh run download "$GITHUB_RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "release-apk-$flavor" \
+              --dir assets
+          done
+          ls -l assets
+          test "$(find assets -name '*.apk' | wc -l)" -eq 4
+
+      - name: Assemble release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          NOTES_FILE: ${{ inputs.notes_file }}
+        run: |
+          set -euo pipefail
+
+          resolved="$NOTES_FILE"
+          if [ -n "$resolved" ] && [ ! -f "$resolved" ]; then
+            echo "::error::notes_file '$resolved' not found in the repository at $GITHUB_SHA"
+            exit 1
+          fi
+          if [ -z "$resolved" ]; then
+            for candidate in "Release_Notes_${VERSION}.md" "Release_Notes_${VERSION#v}.md"; do
+              if [ -f "$candidate" ]; then
+                resolved="$candidate"
+                break
+              fi
+            done
+          fi
+
+          prev_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 \
+            --exclude-drafts --json tagName --jq '.[0].tagName // ""')
+
+          if [ -n "$resolved" ]; then
+            echo "Using notes from $resolved"
+            cp "$resolved" notes.md
+          else
+            echo "No notes file; generating a changelog from commits"
+            {
+              printf '## Changes\n\n'
+              if [ -n "$prev_tag" ] && git rev-parse -q --verify "refs/tags/$prev_tag" >/dev/null; then
+                git log --pretty='- %s' "refs/tags/$prev_tag..HEAD"
+              else
+                git log --pretty='- %s' -50
+              fi
+            } > notes.md
+          fi
+
+          if [ -n "$prev_tag" ] && ! grep -q 'Full Changelog' notes.md; then
+            printf '\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "$GITHUB_REPOSITORY" "$prev_tag" "$VERSION" >> notes.md
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          flags=()
+          if [ "${{ inputs.draft }}" = "true" ]; then flags+=(--draft); fi
+          if [ "${{ inputs.prerelease }}" = "true" ]; then flags+=(--prerelease); fi
+          if [ "${{ inputs.latest }}" = "true" ] && [ "${{ inputs.draft }}" != "true" ]; then
+            flags+=(--latest)
+          fi
+
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$VERSION" \
+            --notes-file notes.md \
+            "${flags[@]}" \
+            assets/*.apk
+
+          url=$(gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" --json url --jq '.url')
+          echo "Released $VERSION -> $url"
+          {
+            printf '### Release %s\n\n' "$VERSION"
+            printf '%s\n\n' "$url"
+            printf 'Draft: %s | Pre-release: %s\n' "${{ inputs.draft }}" "${{ inputs.prerelease }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Release_Notes_0.4.0-beta.md
+++ b/Release_Notes_0.4.0-beta.md
@@ -1,0 +1,81 @@
+# WinNative v0.4.0-beta — DRAFT
+
+### Main Changes:
+
+**Retro console emulation**
+ - WinNative now plays retro console games alongside your Wine/PC titles. Retro games live in the same Library and launch the same way, but run on a libretro backend — or, for PS2 and GameCube/Wii, on a full emulator in its own process.
+ - Supported systems: NES (FCEUmm), SNES (Snes9x), Game Boy / Color (Gambatte), Game Boy Advance (mGBA, with gpSP for link-cable multiplayer), Genesis / Master System / Game Gear (Genesis Plus GX), Nintendo 64 (Mupen64Plus-Next), PlayStation (Beetle PSX), PlayStation 2 (ARMSX2), and GameCube / Wii (Dolphin, standalone Vulkan).
+ - **No emulator core ships inside the APK.** Cores are downloaded on demand from **Settings › Retro** as a single verified bundle, extracted atomically so an interrupted install can never leave a half-installed core set behind. Updates are an exact checksum comparison — the screen tells you the installed build date and only downloads when you tap.
+ - **RetroAchievements** support (softcore) with login, achievement lists and in-game unlock toasts.
+ - **347 core options** generated from each core's own source, grouped into Display / Sound / Performance / Controls / System, as per-console defaults and per-game overrides.
+ - Editable touch layouts with per-game profiles, netplay for the libretro cores and Dolphin, save states, cloud save sync, and a draggable performance HUD — fully translated into all 22 locales.
+ - The guide button now opens the retro menu in the 3D engine too, and the Stadium ROM row imports through the system file picker instead of only printing a path.
+
+**ReShade — drop-in effects, in-app catalog and live in-game control**
+ - ReShade `.fx` effects now work on Vulkan-backed (DXVK/VKD3D) games, with a per-game and per-container **loadout**: add effects, reorder them, and pick **Solo** (one at a time, live A/B switch) or **Stack** (layer any subset in chain order).
+ - A built-in **catalog** lets you search, download and delete effects without leaving the app, and each effect's own parameters are exposed for tuning.
+ - A ReShade pane in the in-game drawer gives you a master toggle, the Solo/Stack selector and per-effect control — no relaunch needed.
+ - Built on vkBasalt, brought into the Winlator/Cmod lineage by Pipetto-crypto.
+
+**Graphics drivers & wrappers**
+ - **Vulkan 1.4** has been added to the graphics driver version list and is now the default; the exported version is clamped to what the driver actually reports, so picking 1.4 on a 1.3 driver no longer advertises an unsupported version.
+ - Updated the graphics wrapper to Pipetto-crypto's latest, with a patched BCn view-format list.
+ - Updated the Wrapper-Gamenative driver binary — external memory sharing now uses dmabuf heaps with a `/dev/ion` fallback.
+ - New **Zink Mode** toggle (Unix/Windows) for arm64ec containers, saved per container and overridable per shortcut.
+ - Fixed OpenGL on arm64 and corrected the HUD reporting Vulkan when a game had actually requested Zink.
+
+**Frame pacing & performance**
+ - Rewritten FPS limiter: lower latency, and selecting a refresh rate no longer secretly turns the cap on — choosing 60Hz used to lock you to a fighting ~55 FPS.
+ - Fixed the FPS HUD showing the panel refresh rate instead of true game FPS; uncapped games are no longer paced down to the panel, and a game's own vsync choice now survives.
+ - Added a **container-level display refresh rate** setting, matching the one in shortcut settings; a rate set on a shortcut still wins.
+ - Background services are pinned to small cores, aggressive service startup has been fixed, and a 32-bit fix has been folded in.
+ - More FEX presets, and `pan_nave` in the Advanced tab has been fixed.
+
+**MangoHud-style overlay**
+ - A new Mango-style HUD overlay joins the existing HUD, with grouped settings, controller navigation, brighter accents and a battery temperature row.
+ - The main HUD has been taken off the present path with matched 500ms sampling windows, and the Mango panel now uses a narrower layout so it takes less of the screen.
+
+**Input & touch controls**
+ - **Combo button swipes**: sliding off a touch button no longer leaves your finger dead — buttons press on entry and release on exit, the d-pad hands off steering, and radial menus swipe open and close.
+ - The control editor's snapping grid is gone — drags are free pixel motion and no longer land short of your finger.
+ - Gyro mouse activation can now be bound to mouse and keyboard buttons, not just gamepad buttons, and works from a physical mouse, on-screen controls or the touchpad.
+ - All control binding slots are dispatched, with a new reverse-order toggle.
+ - New default touch draw (slate) plus 8 selectable draws and 10 themes; custom colors still override themes.
+ - Fixed tap-to-click leaving buttons latched down when the setting was disabled, Lumina D-pad chevrons pointing inward, and the Lumina range button drawing as a giant circle instead of a pill.
+
+**Library, Steam & file manager**
+ - New **artwork scraper for custom games**, pulling art from SteamGridDB and Steam, with SteamGridDB now searching by game name by default.
+ - Steam records a durable install path, so games stay recognized instead of showing up as missing or re-downloading.
+ - The file manager gained **multi-select** for batch copy, cut and delete, with a single byte-weighted progress bar for the whole paste.
+ - `.msi`, `.bat` and `.cmd` can now be picked *and* launched from the exe pickers and the file manager — they run through msiexec or cmd instead of failing at CreateProcess.
+ - Fixed tapping the Add Custom Game name field not opening the keyboard.
+
+**Containers**
+ - Fixed duplicated containers failing to boot, and duplicates now keep the full source config (prefix architecture and emulator versions included) with their shortcuts pointing at the copy rather than the original.
+ - Fixed the surface effect setting being lost when set during container creation and ignored at launch.
+ - Added the missing virtual channel to the Wine debug channel list.
+
+**Audio**
+ - Adopted Bruno's new XAudio stack.
+
+### Minor Changes:
+ - New 32-bit and 64-bit input tests, available from both the hero boot popup and the Start Menu, translated into all 22 locales.
+ - Application logging fixes: cold app starts no longer erase the log, so a crash can be pulled on the first occurrence, and the redundant `application.old.log` is gone.
+ - Fixed graphics driver selection on Polish and Hindi locales, where stale translated arrays silently saved the wrong driver and the wrapper was never extracted at launch.
+ - Removed the hairline of surface left on screen by the closed drawer sheet.
+ - Fixed custom mapping drive containers.
+ - App source files have been reorganized for readability, and the Antutu flavor has been added and fixed.
+ - Build plumbing: LibretroDroid moved out of the main repo and is fetched during configuration, so a fresh clone resolves in the IDE without a manual build.
+
+### Contributors
+Huge thanks to everyone who contributed, this release wouldn't exist without you:
+ - @Xnick417x — 39 commits (ReShade groundwork, frame pacing and FPS limiter, Mango HUD, touch/control input, file manager, drivers and wrappers, container fixes, many more)
+ - @MaxsTechReview — 4 commits (retro console emulation, core bundle delivery, 3D engine guide button + Stadium ROM import, build plumbing)
+ - @SadMoment — 2 commits (custom game artwork scraper, SteamGridDB name search)
+ - @The412Banner — 1 commit (ReShade: drop-in effects, catalog, loadouts and live in-game control)
+
+## New Contributors
+* @SadMoment made their first contribution in https://github.com/WinNative-Emu/WinNative/pull/634
+* @The412Banner made their first contribution in https://github.com/WinNative-Emu/WinNative/pull/631
+
+**Full Changelog**: https://github.com/WinNative-Emu/WinNative/compare/v0.3.1-beta...v0.4.0-beta


### PR DESCRIPTION
Releases have been cut by hand: built locally and uploaded as WinNative-<tag>-<Variant>-signed.apk. Tag APK Artifacts only ever produced workflow artifacts, which expire, so nothing published the release itself.

Release builds every flavor the same way the tag and PR workflows do (debug build type, release signing config), then creates the tag and the GitHub release with the four APKs attached. It reuses the tag workflow's cache keys, and names assets to match every release since v0.3.0-beta.

Guards, since a bad release is public and hard to walk back:

- prepare validates the version shape and refuses a tag or release that already exists, before spending a build on it.
- prepare also refuses to run when KEYSTORE_BASE64 is unset. The PR and tag workflows fall back to a generated throwaway key when that secret is missing, which for a release would ship an APK no existing user can update over.
- Each APK is checked after the build: the signer must match the published certificate and versionName must equal the requested version.

The tag is created by the release API call under GITHUB_TOKEN, and events raised by GITHUB_TOKEN do not start further workflow runs, so this does not kick off a duplicate Tag APK Artifacts build.

Notes come from notes_file, else Release_Notes_<version>.md with or without the leading v, else a changelog generated from the previous tag. The v0.4.0-beta notes are included so the workflow has one to pick up.