### PR TITLE
Fix library crash from duplicate item keys

### DIFF
--- a/app/src/main/app/shell/UnifiedActivityHub.kt
+++ b/app/src/main/app/shell/UnifiedActivityHub.kt
@@ -1913,11 +1913,13 @@ internal fun UnifiedActivity.LibraryCarousel(
                                         .ifBlank { shortcut.name }
 
                                 val uuid = shortcut.getExtra("uuid")
-                                val customId = if (uuid.isNotEmpty()) {
-                                    -(uuid.hashCode().and(0x7FFFFFFF) + 1)
-                                } else {
-                                    -(displayName.hashCode().and(0x7FFFFFFF) + 1)
-                                }
+                                val identity =
+                                    if (uuid.isNotEmpty()) {
+                                        uuid
+                                    } else {
+                                        shortcut.file?.absolutePath ?: displayName
+                                    }
+                                val customId = -(identity.hashCode().and(0x7FFFFFFF) + 1)
 
                                 com.winlator.cmod.feature.retro.RetroSystems
                                     .fromId(
@@ -2010,7 +2012,7 @@ internal fun UnifiedActivity.LibraryCarousel(
                         gameDir = gog.installPath,
                     )
                 }
-            val merged = steamInstalled + customApps + mappedEpic + mappedGog
+            val merged = (steamInstalled + customApps + mappedEpic + mappedGog).distinctBy { it.id }
             val sorted =
                 merged.sortedByDescending { app ->
                     val searchKey =


### PR DESCRIPTION
    java.lang.IllegalArgumentException: Key "-503186657" was already used.
      at LazyLayoutKeyIndexMapKt.NearestRangeKeyIndexMap
      at LazyGridKt$LazyGrid$1$1.invoke

Not device specific. The library grid keys items by SteamApp.id, and the merged list could contain the same id twice, which Compose rejects outright.

That key decodes to a custom shortcut: only custom entries produce negative ids, and -503186657 is exactly -(hash & 0x7FFFFFFF + 1) for hash & 0x7FFFFFFF =
503186656. Shortcuts without a uuid fell back to hashing their display name, so two custom shortcuts sharing a name got the same id. A uuid is only generated lazily — opening shortcut settings is what assigns one — so any pair of same-named shortcuts that had never been opened collided.

The fallback now hashes the shortcut's own file path, which is unique on disk, so both entries survive with distinct ids instead of one shadowing the other. Shortcuts that already have a uuid keep the id they had, so nothing keyed to those ids moves.

The merge also dedupes by id. Uniqueness is a hard requirement of the grid and the list is assembled from four independent sources, so it is enforced where the list is built rather than relying on every id scheme staying collision free. Steam, Epic and GOG ids can still overlap: gogPseudoId spans 1500000000 to 2036870911 while Epic ids start at 2000000000, so the ranges genuinely intersect and that overlap is worth closing separately.