### PR TITLE
Name added games after their folder instead of their executable

### DIFF
--- a/app/src/main/app/shell/UnifiedActivityDrawer.kt
+++ b/app/src/main/app/shell/UnifiedActivityDrawer.kt
@@ -856,14 +856,17 @@ internal fun UnifiedActivity.AddCustomGameDialog(onDismiss: () -> Unit) {
             } else {
                 LibraryShortcutUtils.detectCustomGameFolder(path)
             }
-        // Auto-generate a game name from the EXE name (without extension)
         if (gameName.isBlank()) {
             gameName =
-                java.io
-                    .File(path)
-                    .nameWithoutExtension
-                    .replace("_", " ")
-                    .replace("-", " ")
+                if (detectedRetro != null) {
+                    java.io
+                        .File(path)
+                        .nameWithoutExtension
+                        .replace("_", " ")
+                        .replace("-", " ")
+                } else {
+                    LibraryShortcutUtils.suggestCustomGameName(path)
+                }
         }
     }
 

--- a/app/src/main/feature/shortcuts/LibraryShortcutUtils.kt
+++ b/app/src/main/feature/shortcuts/LibraryShortcutUtils.kt
@@ -43,6 +43,46 @@ object LibraryShortcutUtils {
     fun detectCustomGameFolder(exePath: String): String =
         detectCustomGameFolder(File(exePath)).absolutePath
 
+    private val GENERIC_FOLDER_NAMES =
+        setOf(
+            "drive_c",
+            "program files",
+            "program files (x86)",
+            "programdata",
+            "games",
+            "game",
+            "users",
+            "xuser",
+            "home",
+            "documents",
+            "downloads",
+            "desktop",
+            "emulated",
+            "storage",
+            "0",
+            "",
+        )
+
+    private fun prettifyName(raw: String): String =
+        raw
+            .replace('_', ' ')
+            .replace('-', ' ')
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    @JvmStatic
+    fun suggestCustomGameName(exePath: String): String {
+        val exeFile = File(exePath)
+        val fromExe = prettifyName(exeFile.nameWithoutExtension)
+        val folder = runCatching { detectCustomGameFolder(exeFile) }.getOrNull() ?: return fromExe
+        val rawName = folder.name.lowercase(Locale.US)
+        val folderName = prettifyName(folder.name)
+        if (rawName in GENERIC_FOLDER_NAMES || folderName.lowercase(Locale.US) in GENERIC_FOLDER_NAMES) {
+            return fromExe
+        }
+        return folderName.ifBlank { fromExe }
+    }
+
     @JvmStatic
     fun buildPinnedHomeShortcutId(shortcut: Shortcut): String? {
         val shortcutId = shortcut.getExtra("uuid")


### PR DESCRIPTION
Reported by Aizen: adding a custom game prefills the name from the exe, and shipped executables are rarely named after the game, so almost every entry had to be corrected by hand.

  Batman Arkham Asylum GOTY/Binaries/ShippingPC-BmGame.exe  ->  ShippingPC BmGame
  Vampyr/Binaries/Win64/AVGame-Win64-Shipping.exe           ->  AVGame Win64 Shipping

The dialog already resolves the game's root folder for its Game Folder field — detectCustomGameFolder walks up out of Binaries, Win64, bin and friends, and promotes past a project directory when a shared runtime sits beside it. Only the name was still derived from the file. It now comes from that same folder, so the two fields agree.

Falls back to the executable name when the resolved folder is not a game directory, so an exe sitting loose in drive_c or Program Files does not get named after the drive. ROM shortcuts keep using the file name, since roms live in a folder named after the system rather than the game.

Verified against real directory trees: the Batman and Vampyr paths above resolve to their folder names, Palworld/Pal/Binaries/Win64 promotes to Palworld off its Engine sibling, and a loose drive_c executable still falls back to the exe.