### PR TITLE
Force the controls editor to landscape

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,7 +126,7 @@
         <activity
             android:name="com.winlator.cmod.runtime.input.ControlsEditorActivity"
             android:theme="@style/AppThemeFullscreen.Dark"
-            android:screenOrientation="fullUser"
+            android:screenOrientation="sensorLandscape"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|density|navigation"
             android:exported="false" />
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -141,6 +141,7 @@ import com.winlator.cmod.runtime.display.ui.MagnifierView;
 import com.winlator.cmod.runtime.display.ui.MangoHudView;
 import com.winlator.cmod.runtime.display.ui.XServerSurfaceView;
 import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity;
+import com.winlator.cmod.shared.android.SelfManagedOrientationActivity;
 import com.winlator.cmod.runtime.input.ui.InputControlsView;
 import com.winlator.cmod.runtime.input.ui.TouchpadView;
 import com.winlator.cmod.runtime.display.winhandler.MouseEventFlags;
@@ -197,7 +198,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import cn.sherlock.com.sun.media.sound.SF2Soundbank;
 import static com.winlator.cmod.runtime.display.XServerDisplayUtils.*;
 
-public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity {
+public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
+        implements SelfManagedOrientationActivity {
     private static final long STEAM_TERMINATION_GRACE_MS = 10000L;
     private static final long STEAM_TERMINATION_POLL_MS = 1000L;
     private static final long STEAM_PROCESS_RESPONSE_TIMEOUT_MS = 2000L;

--- a/app/src/main/runtime/input/ControlsEditorActivity.java
+++ b/app/src/main/runtime/input/ControlsEditorActivity.java
@@ -38,6 +38,7 @@ import com.winlator.cmod.runtime.input.ui.InputControlsView;
 import com.winlator.cmod.shared.android.AppUtils;
 import com.winlator.cmod.shared.ui.toast.WinToast;
 import com.winlator.cmod.shared.android.FixedFontScaleAppCompatActivity;
+import com.winlator.cmod.shared.android.LandscapeOnlyActivity;
 import com.winlator.cmod.shared.io.FileUtils;
 import com.winlator.cmod.shared.math.Mathf;
 import com.winlator.cmod.shared.ui.widget.NumberPicker;
@@ -46,7 +47,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-public class ControlsEditorActivity extends FixedFontScaleAppCompatActivity implements View.OnClickListener {
+public class ControlsEditorActivity extends FixedFontScaleAppCompatActivity
+    implements View.OnClickListener, LandscapeOnlyActivity {
   private InputControlsView inputControlsView;
   private ControlsProfile profile;
   private boolean blockingUpdate = false;

--- a/app/src/main/shared/android/OrientationLock.kt
+++ b/app/src/main/shared/android/OrientationLock.kt
@@ -4,6 +4,10 @@ import android.app.Activity
 import android.content.pm.ActivityInfo
 import com.winlator.cmod.feature.stores.steam.utils.PrefManager
 
+interface LandscapeOnlyActivity
+
+interface SelfManagedOrientationActivity
+
 object OrientationLock {
     private val listeners = mutableListOf<() -> Unit>()
 
@@ -25,8 +29,9 @@ object OrientationLock {
 }
 
 fun Activity.applyOrientationLock() {
+    if (this is SelfManagedOrientationActivity) return
     val requested =
-        if (OrientationLock.forceLandscape) {
+        if (this is LandscapeOnlyActivity || OrientationLock.forceLandscape) {
             ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         } else {
             ActivityInfo.SCREEN_ORIENTATION_FULL_USER


### PR DESCRIPTION
The PC controls editor was unlocked to fullUser along with the rest of the UI in #687, but its layout was never adapted for portrait. The toolbar is a wrap_content row of six tool buttons that overflows a narrow screen, and element positions are laid out on a grid derived from view width, so a portrait viewport scatters the overlay into unusable vertical gaps. Editing a profile in portrait was not possible.

Pin the activity back to sensorLandscape so the overlay is authored in the orientation the game runs in.

The manifest alone is not enough to keep it that way. Every activity deriving from the FixedFontScale bases calls applyOrientationLock in onCreate, which sets FULL_USER whenever the force-landscape preference is off, overriding the manifest at runtime. Add a LandscapeOnlyActivity marker that the shared helper honours ahead of the preference, so the editor stays landscape even if its manifest entry is loosened again.

XServerDisplayActivity picks its own orientation from the container screen size, and the same helper could stomp a portrait game when the preference is toggled while that session is alive. Mark it SelfManagedOrientationActivity so the shared lock leaves it alone.